### PR TITLE
chore(app): reduce test warning baseline

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
@@ -5957,7 +5958,54 @@ CHAT_HTML = """<!doctype html>
 
 
 def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool | None = None) -> FastAPI:
-    app = FastAPI(title="Potato Web", version="0.2")
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI):
+        app.state.startup_monotonic = get_monotonic_time()
+        ensure_models_state(app.state.runtime)
+        prime_system_metrics_counters()
+        app.state.system_metrics_snapshot = collect_system_metrics_snapshot()
+        app.state.system_metrics_task = asyncio.create_task(
+            system_metrics_loop(app),
+            name="potato-system-metrics",
+        )
+        if app.state.runtime.enable_orchestrator:
+            app.state.orchestrator_task = asyncio.create_task(
+                orchestrator_loop(app, app.state.runtime),
+                name="potato-orchestrator",
+            )
+        try:
+            yield
+        finally:
+            task = app.state.orchestrator_task
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+            proc = app.state.llama_process
+            if proc is not None and proc.returncode is None:
+                proc.terminate()
+                await proc.wait()
+
+            download_task = app.state.model_download_task
+            if is_download_task_active(download_task):
+                download_task.cancel()
+                try:
+                    await download_task
+                except asyncio.CancelledError:
+                    pass
+
+            system_task = app.state.system_metrics_task
+            if system_task is not None:
+                system_task.cancel()
+                try:
+                    await system_task
+                except asyncio.CancelledError:
+                    pass
+
+    app = FastAPI(title="Potato Web", version="0.2", lifespan=_lifespan)
     app.mount("/assets", StaticFiles(directory=str(WEB_ASSETS_DIR)), name="assets")
     app.state.runtime = runtime or RuntimeConfig.from_env()
     app.state.llama_process = None
@@ -5980,53 +6028,6 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
 
     if enable_orchestrator is not None:
         app.state.runtime.enable_orchestrator = enable_orchestrator
-
-    @app.on_event("startup")
-    async def _startup() -> None:
-        app.state.startup_monotonic = get_monotonic_time()
-        ensure_models_state(app.state.runtime)
-        prime_system_metrics_counters()
-        app.state.system_metrics_snapshot = collect_system_metrics_snapshot()
-        app.state.system_metrics_task = asyncio.create_task(
-            system_metrics_loop(app),
-            name="potato-system-metrics",
-        )
-        if app.state.runtime.enable_orchestrator:
-            app.state.orchestrator_task = asyncio.create_task(
-                orchestrator_loop(app, app.state.runtime),
-                name="potato-orchestrator",
-            )
-
-    @app.on_event("shutdown")
-    async def _shutdown() -> None:
-        task = app.state.orchestrator_task
-        if task is not None:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-
-        proc = app.state.llama_process
-        if proc is not None and proc.returncode is None:
-            proc.terminate()
-            await proc.wait()
-
-        download_task = app.state.model_download_task
-        if is_download_task_active(download_task):
-            download_task.cancel()
-            try:
-                await download_task
-            except asyncio.CancelledError:
-                pass
-
-        system_task = app.state.system_metrics_task
-        if system_task is not None:
-            system_task.cancel()
-            try:
-                await system_task
-            except asyncio.CancelledError:
-                pass
 
     @app.get("/", response_class=HTMLResponse)
     async def root() -> HTMLResponse:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 norecursedirs = references old_reference_design .git .venv .pytest_cache
+addopts = -p no:asyncio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 pytest>=8.0.0,<9.0.0
-pytest-asyncio>=0.23.0,<1.0.0
 respx>=0.21.0,<1.0.0

--- a/tests/unit/test_app_lifecycle.py
+++ b/tests/unit/test_app_lifecycle.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app import main
+
+
+class _FakeTask:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.cancel_called = False
+        self.awaited = False
+        self._done = False
+
+    def cancel(self) -> None:
+        self.cancel_called = True
+        self._done = True
+
+    def done(self) -> bool:
+        return self._done
+
+    def __await__(self):
+        async def _wait() -> None:
+            self.awaited = True
+
+        return _wait().__await__()
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.returncode = None
+        self.terminated = False
+        self.waited = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        self.returncode = 0
+        return 0
+
+
+def test_create_app_does_not_emit_fastapi_on_event_deprecation_warning(runtime: main.RuntimeConfig) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        app = main.create_app(runtime=runtime, enable_orchestrator=False)
+        with TestClient(app):
+            pass
+
+    messages = [
+        str(warning.message)
+        for warning in caught
+        if issubclass(warning.category, DeprecationWarning)
+    ]
+    assert not any("on_event is deprecated" in message for message in messages)
+
+
+def test_app_lifespan_runs_startup_and_shutdown_hooks(
+    runtime: main.RuntimeConfig,
+    monkeypatch,
+) -> None:
+    startup_events: list[str] = []
+    created_tasks: list[_FakeTask] = []
+    download_task = _FakeTask("download")
+    llama_process = _FakeProcess()
+
+    def _ensure_models_state(_runtime: main.RuntimeConfig) -> dict[str, Any]:
+        startup_events.append("ensure_models_state")
+        return {}
+
+    def _prime_system_metrics_counters() -> None:
+        startup_events.append("prime_system_metrics_counters")
+
+    def _collect_system_metrics_snapshot() -> dict[str, Any]:
+        startup_events.append("collect_system_metrics_snapshot")
+        return {"cpu_percent": 12.5}
+
+    def _create_task(coro: Any, *, name: str | None = None) -> _FakeTask:
+        coro.close()
+        task = _FakeTask(name or "unnamed")
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(main, "ensure_models_state", _ensure_models_state)
+    monkeypatch.setattr(main, "prime_system_metrics_counters", _prime_system_metrics_counters)
+    monkeypatch.setattr(main, "collect_system_metrics_snapshot", _collect_system_metrics_snapshot)
+    monkeypatch.setattr(main, "get_monotonic_time", lambda: 123.0)
+    monkeypatch.setattr(main.asyncio, "create_task", _create_task)
+
+    app = main.create_app(runtime=runtime, enable_orchestrator=True)
+
+    with TestClient(app):
+        app.state.model_download_task = download_task
+        app.state.llama_process = llama_process
+
+        assert app.state.startup_monotonic == 123.0
+        assert app.state.system_metrics_snapshot == {"cpu_percent": 12.5}
+        assert startup_events == [
+            "ensure_models_state",
+            "prime_system_metrics_counters",
+            "collect_system_metrics_snapshot",
+        ]
+        assert [task.name for task in created_tasks] == [
+            "potato-system-metrics",
+            "potato-orchestrator",
+        ]
+
+    assert all(task.cancel_called for task in created_tasks)
+    assert all(task.awaited for task in created_tasks)
+    assert download_task.cancel_called is True
+    assert download_task.awaited is True
+    assert llama_process.terminated is True
+    assert llama_process.waited is True

--- a/tests/unit/test_chat_repository.py
+++ b/tests/unit/test_chat_repository.py
@@ -37,7 +37,7 @@ class _FakeAsyncClient:
         self.closed = True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llama_stream_closes_upstream_and_client_when_consumer_closes(monkeypatch: pytest.MonkeyPatch):
     upstream = _FakeUpstream()
     client = _FakeAsyncClient(upstream)
@@ -66,7 +66,7 @@ async def test_llama_stream_closes_upstream_and_client_when_consumer_closes(monk
     assert client.closed is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fake_stream_uses_test_mode_prefill_and_chunk_delay(monkeypatch: pytest.MonkeyPatch):
     sleep_calls: list[float] = []
 
@@ -96,7 +96,7 @@ async def test_fake_stream_uses_test_mode_prefill_and_chunk_delay(monkeypatch: p
     assert 0.04 in sleep_calls
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fake_stream_honors_prefill_delay_override_without_test_mode(monkeypatch: pytest.MonkeyPatch):
     sleep_calls: list[float] = []
 


### PR DESCRIPTION
## Summary
- replace deprecated FastAPI startup/shutdown event handlers with a lifespan handler
- add lifecycle regression coverage for startup/shutdown behavior and deprecation avoidance
- remove the repo's remaining `pytest-asyncio` usage so Python 3.14 deprecation noise no longer loads into the suite

Closes #15

## Risk / Rollback
- low risk: this is startup/shutdown wiring cleanup with regression coverage and no intended behavior changes
- rollback: revert commit `7fda181`

## Test Evidence
Commands run:
- `.venv/bin/python -m pytest -q tests/unit/test_app_lifecycle.py tests/unit/test_chat_repository.py`
- `.venv/bin/python -m pytest -q`

Results:
- focused lifecycle/chat tests: `10 passed`
- full suite: `194 passed, 0 warnings in 8.30s`

Warning baseline improvement:
- before: `192 passed, 296 warnings`
- after: `194 passed, 0 warnings`

## Notes
- Pi QA is not required for this ticket because it does not change runtime behavior on device or user-facing UI behavior; it only updates app lifecycle wiring and test dependency noise.
- The remaining async tests now use `pytest.mark.anyio`, which matches the rest of the suite.
