### PR TITLE
fix(version): add import fallback for Pi runtime

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -678,7 +678,10 @@ async def build_status(
         raw_system_snapshot.get("power_estimate") if isinstance(raw_system_snapshot, dict) else None,
     )
 
-    from app.__version__ import __version__ as _app_version
+    try:
+        from app.__version__ import __version__ as _app_version
+    except ModuleNotFoundError:
+        from __version__ import __version__ as _app_version  # type: ignore[no-redef]
 
     return {
         "version": _app_version,
@@ -1444,7 +1447,10 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
                 except asyncio.CancelledError:
                     pass
 
-    from app.__version__ import __version__ as _app_version
+    try:
+        from app.__version__ import __version__ as _app_version
+    except ModuleNotFoundError:
+        from __version__ import __version__ as _app_version  # type: ignore[no-redef]
 
     app = FastAPI(title="Potato Web", version=_app_version, lifespan=_lifespan)
     app.mount("/assets", StaticFiles(directory=str(WEB_ASSETS_DIR)), name="assets")


### PR DESCRIPTION
## Summary

`from app.__version__` crashes on the Pi where the app runs directly from `/opt/potato/app/` without a package install. Adds the same `try/except ModuleNotFoundError` fallback used by every other import in main.py.

## Test plan

- [x] Version tests passing
- [ ] Pi QA: verify app starts after deploy