### PR TITLE
chore(release): bump app version to 0.3.6-pre-alpha

### DIFF
--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,3 +1,3 @@
 """Canonical version for Potato OS — the single source of truth."""
 
-__version__ = "0.3.4-pre-alpha"
+__version__ = "0.3.6-pre-alpha"


### PR DESCRIPTION
## Summary
- bump the canonical app version to `0.3.6-pre-alpha`
- prepare the repo state for the `v0.3.6` image release

Closes #111

## Validation
- Built lite pi-gen image successfully:
  - `./bin/build_local_image.sh --variant lite --setup-docker --clean-artifacts-yes`
- Verified dry-run release metadata:
  - `./bin/publish_image_release.sh --version v0.3.6 --variant lite --bundle-dir output/images/local-test-lite-potato-lite-20260319-175259 --dry-run`
- Dry-run output showed:
  - release tag `v0.3.6`
  - app version `0.3.6-pre-alpha`
  - Imager name `Potato OS v0.3.6 (lite, Raspberry Pi 5)`

## QA
- Real build completed locally via pi-gen/Docker
- User confirmed the resulting image/ticket path is good for release
