### PR TITLE
chore(release): standardize imager branding and shared build helpers

### DIFF
--- a/bin/build_local_image.sh
+++ b/bin/build_local_image.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/branding.sh
+source "${REPO_ROOT}/bin/lib/branding.sh"
+# shellcheck source=lib/build_helpers.sh
+source "${REPO_ROOT}/bin/lib/build_helpers.sh"
 OUTPUT_DIR="${POTATO_IMAGE_OUTPUT_DIR:-${REPO_ROOT}/output/images}"
 VARIANT="lite"
 NO_UPDATE_PI_GEN=1
@@ -92,18 +96,8 @@ maybe_clean_output_artifacts() {
   esac
 }
 
-sha256_line() {
-  local file_path="$1"
-  if has_cmd sha256sum; then
-    sha256sum "${file_path}"
-    return
-  fi
-  if has_cmd shasum; then
-    shasum -a 256 "${file_path}"
-    return
-  fi
-  die "Missing sha256 utility (sha256sum or shasum)"
-}
+# SHA256 via shared helper (potato_sha256 from build_helpers.sh)
+sha256_line() { potato_sha256 "$1"; }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -252,13 +246,9 @@ collect_variant_bundle() {
   printf '%s  %s\n' "${actual_sha}" "${image_name}" > "${bundle_dir}/SHA256SUMS"
 
   local imager_manifest="${bundle_dir}/potato-${target_variant}.rpi-imager-manifest"
-  cp -f "${REPO_ROOT}/bin/assets/potato-imager-icon.svg" "${bundle_dir}/potato-imager-icon.svg"
+  cp -f "${REPO_ROOT}/bin/assets/${POTATO_ICON_FILENAME}" "${bundle_dir}/${POTATO_ICON_FILENAME}"
   echo "[potato-local-build] Generating Raspberry Pi Imager manifest (this may take a minute)..."
-  python3 "${REPO_ROOT}/bin/generate_imager_manifest.py" \
-    --image "${bundle_dir}/${image_name}" \
-    --output "${imager_manifest}" \
-    --name "Potato OS (${target_variant}, Raspberry Pi 4 / 5)" \
-    --icon "${bundle_dir}/potato-imager-icon.svg" \
+  generate_potato_manifest "${bundle_dir}/${image_name}" "${imager_manifest}" "${bundle_dir}/${POTATO_ICON_FILENAME}" "${target_variant}" \
     || die "Manifest generation failed for ${bundle_dir}/${image_name}"
 
   local image_size_bytes
@@ -296,10 +286,10 @@ Generated at: ${timestamp}
 3. Choose \`Use custom file\`.
 4. Select: \`potato-${target_variant}.rpi-imager-manifest\`.
 5. Click \`Apply & Restart\`.
-6. Select \`Potato OS (${target_variant}, Raspberry Pi 4 / 5)\` and flash.
+6. Select **${POTATO_PROJECT_NAME}** and flash.
 
 ## Important
-- This bundle supports Raspberry Pi 4 (8 GB) and Pi 5 (8 GB / 16 GB).
+- This bundle supports ${POTATO_DEVICE_LABEL}.
 - Do not use \`METADATA.json\` or \`potato-${target_variant}-build-info.json\` in Imager.
 
 ## Files

--- a/bin/lib/branding.sh
+++ b/bin/lib/branding.sh
@@ -1,0 +1,9 @@
+# Shared branding and device constants for Potato OS build/release scripts.
+# Source this file — do not hardcode these values in individual scripts.
+
+POTATO_PROJECT_NAME="Potato OS"
+POTATO_IMAGER_TAGLINE="Local AI, No Cloud"
+POTATO_IMAGER_DESCRIPTION="Potato OS — local AI, zero cloud dependency."
+POTATO_SUPPORTED_DEVICE_TAGS="pi5-64bit pi4-64bit"
+POTATO_DEVICE_LABEL="Raspberry Pi 4 (8 GB) / Raspberry Pi 5 (8 GB / 16 GB)"
+POTATO_ICON_FILENAME="potato-imager-icon.svg"

--- a/bin/lib/build_helpers.sh
+++ b/bin/lib/build_helpers.sh
@@ -1,0 +1,74 @@
+# Shared build/release helper functions for Potato OS.
+# Source this file from build, image, and publish scripts.
+
+# Resolve the repository root from this file's location.
+_build_helpers_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_build_helpers_repo_root="$(cd "${_build_helpers_lib_dir}/../.." && pwd)"
+
+# Source branding constants if not already loaded.
+if [ -z "${POTATO_IMAGER_TAGLINE:-}" ] && [ -f "${_build_helpers_lib_dir}/branding.sh" ]; then
+  # shellcheck source=branding.sh
+  source "${_build_helpers_lib_dir}/branding.sh"
+fi
+
+# generate_potato_manifest <image> <output> <icon> <variant> [version] [download_url]
+#
+# Generates a Raspberry Pi Imager manifest JSON with consistent naming.
+# Uses POTATO_IMAGER_TAGLINE from branding.sh for the display name.
+generate_potato_manifest() {
+  local image_file="$1"
+  local output_path="$2"
+  local icon_path="$3"
+  local variant="${4:-}"
+  local version="${5:-}"
+  local download_url="${6:-}"
+
+  local name_parts="${POTATO_PROJECT_NAME:-Potato OS}"
+  [ -n "${version}" ] && name_parts="${name_parts} ${version}"
+  [ -n "${variant}" ] && name_parts="${name_parts} (${variant})"
+  name_parts="${name_parts} — ${POTATO_IMAGER_TAGLINE:-Local AI, No Cloud}"
+
+  local args=(
+    python3 "${_build_helpers_repo_root}/bin/generate_imager_manifest.py"
+    --image "${image_file}"
+    --output "${output_path}"
+    --name "${name_parts}"
+    --icon "${icon_path}"
+  )
+  [ -n "${download_url}" ] && args+=(--download-url "${download_url}")
+  "${args[@]}"
+}
+
+# potato_sha256 <file>
+#
+# Cross-platform SHA256 checksum (sha256sum on Linux, shasum on macOS).
+# Outputs: "<hash>  <filename>"
+potato_sha256() {
+  local path="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}"
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}"
+    return
+  fi
+  printf 'ERROR: Missing sha256 utility (sha256sum or shasum)\n' >&2
+  return 1
+}
+
+# find_github_remote [repo_slug]
+#
+# Finds the git remote whose URL matches the given GitHub repo slug.
+# Prints the remote name, or empty string if none found.
+find_github_remote() {
+  local repo="${1:-${GITHUB_REPO:-slomin/potato-os}}"
+  local _remote _remote_url
+  for _remote in $(git remote 2>/dev/null); do
+    _remote_url="$(git remote get-url "${_remote}" 2>/dev/null || true)"
+    if printf '%s' "${_remote_url}" | grep -q "${repo}"; then
+      printf '%s' "${_remote}"
+      return
+    fi
+  done
+}

--- a/bin/publish_image_release.sh
+++ b/bin/publish_image_release.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 #   ./bin/publish_image_release.sh --version v0.3 --dry-run
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/branding.sh
+source "${REPO_ROOT}/bin/lib/branding.sh"
+# shellcheck source=lib/build_helpers.sh
+source "${REPO_ROOT}/bin/lib/build_helpers.sh"
 GITHUB_REPO="${POTATO_GITHUB_REPO:-slomin/potato-os}"
 
 VERSION=""
@@ -101,12 +105,7 @@ STAGING="$(mktemp -d)"
 trap 'rm -rf "${STAGING}"' EXIT
 
 MANIFEST_PATH="${STAGING}/${MANIFEST_NAME}"
-python3 "${REPO_ROOT}/bin/generate_imager_manifest.py" \
-  --image "${IMAGE_FILE}" \
-  --output "${MANIFEST_PATH}" \
-  --name "Potato OS ${VERSION} (${VARIANT}) — Local AI, No Cloud" \
-  --icon "${ICON_URL}" \
-  --download-url "${IMAGE_URL}" \
+generate_potato_manifest "${IMAGE_FILE}" "${MANIFEST_PATH}" "${ICON_URL}" "${VARIANT}" "${VERSION}" "${IMAGE_URL}" \
   || die "Manifest generation failed"
 
 printf '\n'
@@ -151,14 +150,7 @@ if gh release view "${VERSION}" --repo "${GITHUB_REPO}" >/dev/null 2>&1; then
 fi
 
 # ── Resolve push remote ────────────────────────────────────────────────
-PUSH_REMOTE=""
-for _remote in $(git remote 2>/dev/null); do
-  _remote_url="$(git remote get-url "${_remote}" 2>/dev/null || true)"
-  if printf '%s' "${_remote_url}" | grep -q "${GITHUB_REPO}"; then
-    PUSH_REMOTE="${_remote}"
-    break
-  fi
-done
+PUSH_REMOTE="$(find_github_remote "${GITHUB_REPO}")"
 
 RELEASE_NOTES="$(cat <<NOTES
 ## Potato OS ${VERSION}
@@ -241,12 +233,7 @@ STABLE_BASE="https://github.com/${GITHUB_REPO}/releases/download/${STABLE_TAG}"
 
 # Regenerate manifest with download URLs pointing at the versioned release assets
 STABLE_MANIFEST="${STAGING}/${MANIFEST_NAME}"
-python3 "${REPO_ROOT}/bin/generate_imager_manifest.py" \
-  --image "${IMAGE_FILE}" \
-  --output "${STABLE_MANIFEST}" \
-  --name "Potato OS ${VERSION} (${VARIANT}) — Local AI, No Cloud" \
-  --icon "${STABLE_BASE}/potato-imager-icon.svg" \
-  --download-url "${IMAGE_URL}" \
+generate_potato_manifest "${IMAGE_FILE}" "${STABLE_MANIFEST}" "${STABLE_BASE}/${POTATO_ICON_FILENAME}" "${VARIANT}" "${VERSION}" "${IMAGE_URL}" \
   || die "Stable manifest generation failed"
 
 printf '\nUpdating stable pointer release...\n'

--- a/bin/publish_runtime.sh
+++ b/bin/publish_runtime.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 #   ./bin/publish_runtime.sh --family ik_llama --dry-run
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/build_helpers.sh
+source "${REPO_ROOT}/bin/lib/build_helpers.sh"
 GITHUB_REPO="${POTATO_GITHUB_REPO:-slomin/potato-os}"
 DEFAULT_SLOT_ROOT="${REPO_ROOT}/references/old_reference_design/llama_cpp_binary/runtimes"
 
@@ -122,14 +124,7 @@ fi
 # Resolve the git remote that matches the target GitHub repo.
 # If no remote matches, skip git push — gh release create will
 # create the tag on the target repo automatically.
-PUSH_REMOTE=""
-for _remote in $(git remote 2>/dev/null); do
-  _remote_url="$(git remote get-url "${_remote}" 2>/dev/null || true)"
-  if printf '%s' "${_remote_url}" | grep -q "${GITHUB_REPO}"; then
-    PUSH_REMOTE="${_remote}"
-    break
-  fi
-done
+PUSH_REMOTE="$(find_github_remote "${GITHUB_REPO}")"
 
 git tag "${TAG_NAME}" 2>/dev/null || true
 if [ -n "${PUSH_REMOTE}" ]; then

--- a/image/lib/common.sh
+++ b/image/lib/common.sh
@@ -19,31 +19,29 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "Missing command: $1"
 }
 
-sha256_file() {
-  local path="$1"
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "${path}"
-    return
-  fi
-  if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "${path}"
-    return
-  fi
-  die "Missing sha256 utility (sha256sum or shasum)"
-}
-
 resolve_repo_root() {
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   cd "${script_dir}/../.." && pwd
 }
 
-# Source shared release download helpers
+# Source shared helpers
 _common_repo_root="$(resolve_repo_root)"
+if [ -f "${_common_repo_root}/bin/lib/branding.sh" ]; then
+  # shellcheck source=../../bin/lib/branding.sh
+  source "${_common_repo_root}/bin/lib/branding.sh"
+fi
+if [ -f "${_common_repo_root}/bin/lib/build_helpers.sh" ]; then
+  # shellcheck source=../../bin/lib/build_helpers.sh
+  source "${_common_repo_root}/bin/lib/build_helpers.sh"
+fi
 if [ -f "${_common_repo_root}/bin/lib/runtime_release.sh" ]; then
   # shellcheck source=../../bin/lib/runtime_release.sh
   source "${_common_repo_root}/bin/lib/runtime_release.sh"
 fi
+
+# SHA256 via shared helper (potato_sha256 from build_helpers.sh), keep legacy name for callers
+sha256_file() { potato_sha256 "$1"; }
 
 resolve_llama_bundle_src() {
   local repo_root="$1"
@@ -368,12 +366,8 @@ run_build() {
     *.img|*.img.xz)
       info "Generating Raspberry Pi Imager manifest (this may take a minute for xz decompression)..."
       rm -f "${output_dir}/potato-${variant}.rpi-imager-manifest"
-      cp -f "${repo_root}/bin/assets/potato-imager-icon.svg" "${output_dir}/potato-imager-icon.svg"
-      python3 "${repo_root}/bin/generate_imager_manifest.py" \
-        --image "${out_image}" \
-        --output "${output_dir}/potato-${variant}.rpi-imager-manifest" \
-        --name "Potato OS (${variant}) — Local AI, No Cloud" \
-        --icon "${output_dir}/potato-imager-icon.svg" \
+      cp -f "${repo_root}/bin/assets/${POTATO_ICON_FILENAME}" "${output_dir}/${POTATO_ICON_FILENAME}"
+      generate_potato_manifest "${out_image}" "${output_dir}/potato-${variant}.rpi-imager-manifest" "${output_dir}/${POTATO_ICON_FILENAME}" "${variant}" \
         || die "Manifest generation failed for ${out_image}"
       info "Manifest generated: ${output_dir}/potato-${variant}.rpi-imager-manifest"
       ;;

--- a/tests/unit/test_image_contracts.py
+++ b/tests/unit/test_image_contracts.py
@@ -69,12 +69,9 @@ def test_local_image_build_script_collects_artifacts_for_flash_test():
     assert 'cat > "${bundle_dir}/README.md"' in script
     assert "Use In Raspberry Pi Imager" in script
     assert "Content Repository" in script
-    assert "generate_imager_manifest.py" in script
+    assert "generate_potato_manifest" in script
     assert ".rpi-imager-manifest" in script
-    assert "Raspberry Pi 4 / 5" in script
-    assert "python3" in script
-    assert "--icon" in script
-    assert "potato-imager-icon.svg" in script
+    assert "POTATO_ICON_FILENAME" in script
     assert "--clean-artifacts <mode>" in script
     assert "--clean-artifacts-yes" in script
     assert "--clean-artifacts-no" in script
@@ -98,11 +95,9 @@ def test_publish_image_release_script_validates_bundle_and_creates_release():
     assert "--variant" in script
     assert "--dry-run" in script
     assert "gh release create" in script
-    assert "generate_imager_manifest.py" in script
-    assert "--download-url" in script
-    assert "--icon" in script
+    assert "generate_potato_manifest" in script
     assert "github.com/${GITHUB_REPO}/releases/download/${VERSION}" in script
-    assert "potato-imager-icon.svg" in script
+    assert "POTATO_ICON_FILENAME" in script
     assert "SHA256SUMS" in script
     assert ".rpi-imager-manifest" in script
     assert "Raspberry Pi Imager" in script
@@ -187,11 +182,10 @@ def test_image_build_scripts_exist_for_lite_and_full_variants():
     assert "POTATO_IMAGE_OUTPUT_DIR" in common
     assert "potato-lite" in common
     assert "potato-full" in common
-    assert "generate_imager_manifest.py" in common
-    assert "--icon" in common
-    assert "potato-imager-icon.svg" in common
+    assert "generate_potato_manifest" in common
+    assert "POTATO_ICON_FILENAME" in common
     assert "potato-${variant}.rpi-imager-manifest" in common
-    assert "Local AI, No Cloud" in common
+    assert "branding.sh" in common
     assert "uv run --script" in all_in_one
     assert "--variant" in uv_script
     assert "https://github.com/RPi-Distro/pi-gen.git" in uv_script

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -843,6 +843,85 @@ def test_publish_image_release_notes_template_supports_pi4():
     )
 
 
+def test_branding_constants_defined():
+    """branding.sh must define all shared branding and device constants."""
+    branding = REPO_ROOT / "bin" / "lib" / "branding.sh"
+    assert branding.exists(), "bin/lib/branding.sh must exist"
+    text = branding.read_text(encoding="utf-8")
+
+    for var in ("POTATO_PROJECT_NAME", "POTATO_IMAGER_TAGLINE", "POTATO_IMAGER_DESCRIPTION",
+                "POTATO_SUPPORTED_DEVICE_TAGS", "POTATO_ICON_FILENAME"):
+        assert f'{var}=' in text, f"branding.sh must define {var}"
+
+
+def test_build_helpers_defines_shared_functions():
+    """build_helpers.sh must define generate_potato_manifest, potato_sha256, and find_github_remote."""
+    helpers = REPO_ROOT / "bin" / "lib" / "build_helpers.sh"
+    assert helpers.exists(), "bin/lib/build_helpers.sh must exist"
+    text = helpers.read_text(encoding="utf-8")
+
+    for fn in ("generate_potato_manifest", "potato_sha256", "find_github_remote"):
+        assert f"{fn}()" in text, f"build_helpers.sh must define {fn}()"
+
+
+def test_manifest_scripts_use_shared_branding():
+    """All scripts that generate manifests must source branding.sh and not hardcode the tagline."""
+    for script_path in (
+        REPO_ROOT / "bin" / "publish_image_release.sh",
+        REPO_ROOT / "bin" / "build_local_image.sh",
+        REPO_ROOT / "image" / "lib" / "common.sh",
+    ):
+        script = script_path.read_text(encoding="utf-8")
+        assert "branding.sh" in script, (
+            f"{script_path.name} must source branding.sh"
+        )
+        # Must not hardcode the tagline directly — use the variable or the shared function
+        assert '"Local AI, No Cloud"' not in script, (
+            f"{script_path.name} hardcodes tagline — must use POTATO_IMAGER_TAGLINE variable"
+        )
+
+
+def test_manifest_scripts_use_shared_generate_function():
+    """Scripts that generate manifests must call generate_potato_manifest, not call Python directly."""
+    for script_path in (
+        REPO_ROOT / "bin" / "publish_image_release.sh",
+        REPO_ROOT / "bin" / "build_local_image.sh",
+        REPO_ROOT / "image" / "lib" / "common.sh",
+    ):
+        script = script_path.read_text(encoding="utf-8")
+        assert "build_helpers.sh" in script, (
+            f"{script_path.name} must source build_helpers.sh"
+        )
+        assert "generate_potato_manifest" in script, (
+            f"{script_path.name} must use generate_potato_manifest function"
+        )
+
+
+def test_publish_scripts_use_shared_git_remote():
+    """Publish scripts must use find_github_remote from build_helpers.sh."""
+    for script_path in (
+        REPO_ROOT / "bin" / "publish_image_release.sh",
+        REPO_ROOT / "bin" / "publish_runtime.sh",
+    ):
+        script = script_path.read_text(encoding="utf-8")
+        assert "find_github_remote" in script, (
+            f"{script_path.name} must use find_github_remote from build_helpers.sh"
+        )
+
+
+def test_sha256_not_duplicated_across_scripts():
+    """SHA256 logic must live in build_helpers.sh, not be reimplemented in each script."""
+    for script_path in (
+        REPO_ROOT / "bin" / "build_local_image.sh",
+        REPO_ROOT / "image" / "lib" / "common.sh",
+    ):
+        script = script_path.read_text(encoding="utf-8")
+        # Scripts should call potato_sha256, not define their own sha256 function
+        assert "potato_sha256" in script or "sha256_file" not in script, (
+            f"{script_path.name} defines its own SHA256 function — use potato_sha256 from build_helpers.sh"
+        )
+
+
 def test_vision_e2e_script_exercises_multimodal_requests():
     script = (REPO_ROOT / "tests" / "e2e" / "vision_multi_image_pi.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- standardize Potato OS Raspberry Pi Imager branding while preserving `lite` / `full` variant distinction
- extract shared branding and build helper libraries for manifest generation, checksums, and GitHub remote discovery
- update release/build scripts and shell coverage to use the shared helpers consistently

## Validation

- `uv run python -m pytest tests/unit/test_shell_scripts.py tests/unit/test_image_contracts.py -q -k 'publish_image_release or imager'`
- `./bin/publish_image_release.sh --version v9.9.9 --variant lite --bundle-dir output/images/local-test-lite-potato-lite-20260322-102028 --dry-run`
- GitHub Actions `tests` and `ui-tests` are green

## Status / Risk

- QA completed before merge and no open findings remain
- Rollback: revert this PR to restore the prior per-script branding strings and helper layout

Refs #147
