### PR TITLE
fix(image): include version in Imager manifest name

### DIFF
--- a/bin/build_local_image.sh
+++ b/bin/build_local_image.sh
@@ -247,8 +247,10 @@ collect_variant_bundle() {
 
   local imager_manifest="${bundle_dir}/potato-${target_variant}.rpi-imager-manifest"
   cp -f "${REPO_ROOT}/bin/assets/${POTATO_ICON_FILENAME}" "${bundle_dir}/${POTATO_ICON_FILENAME}"
+  local app_version
+  app_version="$(python3 -c "import sys; sys.path.insert(0,'${REPO_ROOT}'); from app.__version__ import __version__; print(__version__)")"
   echo "[potato-local-build] Generating Raspberry Pi Imager manifest (this may take a minute)..."
-  generate_potato_manifest "${bundle_dir}/${image_name}" "${imager_manifest}" "${bundle_dir}/${POTATO_ICON_FILENAME}" "${target_variant}" \
+  generate_potato_manifest "${bundle_dir}/${image_name}" "${imager_manifest}" "${bundle_dir}/${POTATO_ICON_FILENAME}" "${target_variant}" "v${app_version}" \
     || die "Manifest generation failed for ${bundle_dir}/${image_name}"
 
   local image_size_bytes

--- a/image/lib/common.sh
+++ b/image/lib/common.sh
@@ -367,7 +367,9 @@ run_build() {
       info "Generating Raspberry Pi Imager manifest (this may take a minute for xz decompression)..."
       rm -f "${output_dir}/potato-${variant}.rpi-imager-manifest"
       cp -f "${repo_root}/bin/assets/${POTATO_ICON_FILENAME}" "${output_dir}/${POTATO_ICON_FILENAME}"
-      generate_potato_manifest "${out_image}" "${output_dir}/potato-${variant}.rpi-imager-manifest" "${output_dir}/${POTATO_ICON_FILENAME}" "${variant}" \
+      local _app_ver
+      _app_ver="$(python3 -c "import sys; sys.path.insert(0,'${repo_root}'); from app.__version__ import __version__; print(__version__)" 2>/dev/null || true)"
+      generate_potato_manifest "${out_image}" "${output_dir}/potato-${variant}.rpi-imager-manifest" "${output_dir}/${POTATO_ICON_FILENAME}" "${variant}" "${_app_ver:+v${_app_ver}}" \
         || die "Manifest generation failed for ${out_image}"
       info "Manifest generated: ${output_dir}/potato-${variant}.rpi-imager-manifest"
       ;;


### PR DESCRIPTION
## Summary
- Local image builds were missing version in Raspberry Pi Imager display name
- Now reads `__version__.py` and passes it to `generate_potato_manifest`
- Also fixed the live v0.6.0 and stable manifests on GitHub (uploaded corrected versions)

## Before
`Potato OS (lite) — Local AI, No Cloud` (no icon, no version)

## After
`Potato OS v0.6.0 (lite) — Local AI, No Cloud` (icon + version)