### PR TITLE
feat(platform): reject concurrent completions with 429 across built-in apps

### DIFF
--- a/apps/chat/assets/chat-engine.js
+++ b/apps/chat/assets/chat-engine.js
@@ -20,6 +20,9 @@ import { saveActiveSession } from "./session-manager.js";
     }
 
     export function formatChatFailureMessage(statusCode, body, requestCtx = {}) {
+      if (statusCode === 429) {
+        return "Potato is busy with another request. Try again in a moment.";
+      }
       const apiMessage = extractApiErrorMessage(body);
       const normalized = apiMessage.toLowerCase();
       if (

--- a/apps/chat/tests/chat.spec.js
+++ b/apps/chat/tests/chat.spec.js
@@ -19,6 +19,13 @@ test("shows staged prefill estimate before first token and clears after generati
     window.__POTATO_PREFILL_FINISH_DURATION_MS__ = 300;
     window.__POTATO_PREFILL_FINISH_HOLD_MS__ = 350;
   });
+  await page.route("**/v1/chat/completions", async (route) => {
+    await new Promise((r) => setTimeout(r, 600));
+    await fulfillStreamingChat(route, {
+      content: "[fake-llama.cpp] Prefill test response",
+      timings: { prompt_ms: 600, predicted_ms: 400, predicted_n: 10, predicted_per_second: 25 },
+    });
+  });
   await waitUntilReady(page);
 
   await page.locator("#userPrompt").fill("Give me one sentence about Potato OS.");
@@ -131,6 +138,8 @@ test("assistant markdown strips remote resource tags while keeping safe formatti
 });
 
 test("cancel during prefill stops cleanly and shows stopped reason", async ({ page }) => {
+  // Hold the response so the UI stays in prefill state until cancel fires
+  await page.route("**/v1/chat/completions", () => {});
   await waitUntilReady(page);
 
   await page.locator("#userPrompt").fill("Explain distributed systems in detail.");
@@ -462,6 +471,7 @@ test("editing while a reply is generating cancels it and restarts from that turn
 
 
 test("chat request sends stream true and messages array to the backend", async ({ page }) => {
+  await page.route("**/v1/chat/completions", (route) => fulfillStreamingChat(route));
   await waitUntilReady(page);
 
   const requestPromise = page.waitForRequest("**/v1/chat/completions");
@@ -616,6 +626,35 @@ test("stream error before any tokens shows standard error message", async ({ pag
 
   const meta = page.locator(".message-row.assistant .message-meta").last();
   await expect(meta).toBeHidden();
+});
+
+// ── Concurrent completion guard (#197) ─────────────────────────────
+
+test("busy runtime shows friendly message on 429", async ({ page }) => {
+  await page.route("**/status", (route) =>
+    route.fulfill({ json: makeStatusPayload() })
+  );
+  await page.route("**/v1/chat/completions", (route) =>
+    route.fulfill({
+      status: 429,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: {
+          message: "A completion is already in progress. Try again shortly.",
+          type: "concurrent_request",
+          code: 429,
+        },
+      }),
+    })
+  );
+
+  await waitUntilReady(page);
+  await page.locator("#userPrompt").fill("Hello");
+  await page.locator("#userPrompt").press("Enter");
+
+  const bubble = page.locator(".message-row.assistant .message-bubble").last();
+  await expect(bubble).toContainText("Potato is busy");
+  await expect(page.locator("#sendBtn")).toHaveText("Send", { timeout: 5000 });
 });
 
 // ── Quick model switcher (#52) ──────────────────────────────────────

--- a/apps/chat/tests/image.spec.js
+++ b/apps/chat/tests/image.spec.js
@@ -19,6 +19,17 @@ test("large image selection shows loading phases and optimization metadata", asy
     window.__POTATO_PREFILL_FINISH_DURATION_MS__ = 300;
     window.__POTATO_PREFILL_FINISH_HOLD_MS__ = 350;
   });
+
+  // Mock completion route with a delay so prefill UI is reliably visible
+  // under parallel test load (the real fake backend responds too fast).
+  await page.route("**/v1/chat/completions", async (route) => {
+    await new Promise((r) => setTimeout(r, 600));
+    await fulfillStreamingChat(route, {
+      content: "[fake-llama.cpp] Image response",
+      timings: { prompt_ms: 600, predicted_ms: 400, predicted_n: 10, predicted_per_second: 25 },
+    });
+  });
+
   await waitUntilReady(page);
 
   await page.locator("#imageInput").setInputFiles("tests/ui/fixtures/test-cat.jpg");
@@ -53,6 +64,9 @@ test("large image selection shows loading phases and optimization metadata", asy
 });
 
 test("image upload returns typing focus to prompt and keeps it after enter-send", async ({ page }) => {
+  await page.route("**/v1/chat/completions", (route) =>
+    fulfillStreamingChat(route, { content: "[fake-llama.cpp] Image focus test" })
+  );
   await waitUntilReady(page);
 
   await page.locator("#imageInput").setInputFiles("tests/ui/fixtures/test-cat.jpg");
@@ -294,7 +308,7 @@ test("image-send failures show friendly guidance and leave the composer ready fo
       return;
     }
 
-    await route.continue();
+    await fulfillStreamingChat(route, { content: "[fake-llama.cpp] Text-only follow-up" });
   });
 
   await waitUntilReady(page);
@@ -326,6 +340,8 @@ test("cancel image generation uses cancel endpoint and avoids restart endpoint",
   await page.addInitScript(() => {
     window.__POTATO_CANCEL_RECOVERY_DELAY_MS__ = 250;
   });
+  // Hold the response so the request stays in-flight until cancel fires
+  await page.route("**/v1/chat/completions", () => {});
   await waitUntilReady(page);
 
   const cancelCalls = [];

--- a/core/main.py
+++ b/core/main.py
@@ -1739,6 +1739,7 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
     app.state.llama_readiness_state = _empty_llama_readiness_state()
     app.state.update_task = None
     app.state.update_lock = asyncio.Lock()
+    app.state.inference_lock = asyncio.Lock()
     app.state.terminal_sessions: dict = {}
     import secrets as _secrets
     app.state.terminal_token: str = _secrets.token_urlsafe(32)

--- a/core/routes/chat.py
+++ b/core/routes/chat.py
@@ -45,62 +45,94 @@ async def chat_completions(
     runtime_cfg: RuntimeConfig = Depends(get_runtime),
     chat_repository: ChatRepositoryManager = Depends(get_chat_repository),
 ) -> Response:
-    download_active, auto_start_remaining = await _get_status_download_context(request.app, runtime_cfg)
-    status_payload = await _build_status(
-        runtime_cfg,
-        app=request.app,
-        download_active=download_active,
-        auto_start_remaining_seconds=auto_start_remaining,
-        system_snapshot=request.app.state.system_metrics_snapshot,
-    )
-    if status_payload["state"] != "READY":
-        return JSONResponse(status_code=503, content=status_payload)
-
-    try:
-        payload = await request.json()
-    except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
-    except Exception as exc:
-        if type(exc).__name__ == "ClientDisconnect":
-            return Response(status_code=499)
-        raise
-
-    payload = merge_active_model_chat_defaults(payload, runtime=runtime_cfg)
-    payload = merge_chat_defaults(payload)
-    payload = apply_model_chat_defaults(
-        payload,
-        active_model_filename=str(status_payload.get("model", {}).get("filename") or ""),
-    )
-    headers = _forward_headers(request)
-    active_backend = status_payload["backend"]["active"]
-
-    try:
-        backend_response = await chat_repository.create_chat_completion(
-            backend=active_backend,
-            payload=payload,
-            forward_headers=headers,
+    lock = request.app.state.inference_lock
+    if lock.locked():
+        return JSONResponse(
+            status_code=429,
+            content={
+                "error": {
+                    "message": "A completion is already in progress. Try again shortly.",
+                    "type": "concurrent_request",
+                    "code": 429,
+                }
+            },
         )
-    except BackendProxyError as exc:
-        if runtime_cfg.chat_backend_mode == "auto" and active_backend == "llama":
+
+    # Acquire immediately after locked() check — no awaits in between so no
+    # scheduling window for a second request to slip past.  asyncio.Lock.acquire()
+    # is synchronous (no yield) when the lock is free.
+    await lock.acquire()
+    released = False
+    try:
+        download_active, auto_start_remaining = await _get_status_download_context(request.app, runtime_cfg)
+        status_payload = await _build_status(
+            runtime_cfg,
+            app=request.app,
+            download_active=download_active,
+            auto_start_remaining_seconds=auto_start_remaining,
+            system_snapshot=request.app.state.system_metrics_snapshot,
+        )
+        if status_payload["state"] != "READY":
+            return JSONResponse(status_code=503, content=status_payload)
+
+        try:
+            payload = await request.json()
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
+        except Exception as exc:
+            if type(exc).__name__ == "ClientDisconnect":
+                return Response(status_code=499)
+            raise
+
+        payload = merge_active_model_chat_defaults(payload, runtime=runtime_cfg)
+        payload = merge_chat_defaults(payload)
+        payload = apply_model_chat_defaults(
+            payload,
+            active_model_filename=str(status_payload.get("model", {}).get("filename") or ""),
+        )
+        headers = _forward_headers(request)
+        active_backend = status_payload["backend"]["active"]
+
+        try:
             backend_response = await chat_repository.create_chat_completion(
-                backend="fake",
+                backend=active_backend,
                 payload=payload,
                 forward_headers=headers,
             )
-        else:
-            logger.exception("Backend proxy error")
-            raise HTTPException(status_code=502, detail=f"backend unavailable: {exc}") from exc
+        except BackendProxyError as exc:
+            if runtime_cfg.chat_backend_mode == "auto" and active_backend == "llama":
+                backend_response = await chat_repository.create_chat_completion(
+                    backend="fake",
+                    payload=payload,
+                    forward_headers=headers,
+                )
+            else:
+                logger.exception("Backend proxy error")
+                raise HTTPException(status_code=502, detail=f"backend unavailable: {exc}") from exc
 
-    if backend_response.stream is not None:
-        return StreamingResponse(
-            backend_response.stream,
+        if backend_response.stream is not None:
+            original = backend_response.stream
+
+            async def _guarded_stream():
+                try:
+                    async for chunk in original:
+                        yield chunk
+                finally:
+                    lock.release()
+
+            released = True
+            return StreamingResponse(
+                _guarded_stream(),
+                status_code=backend_response.status_code,
+                headers=backend_response.headers,
+                background=backend_response.background,
+            )
+
+        return Response(
+            content=backend_response.body or b"",
             status_code=backend_response.status_code,
             headers=backend_response.headers,
-            background=backend_response.background,
         )
-
-    return Response(
-        content=backend_response.body or b"",
-        status_code=backend_response.status_code,
-        headers=backend_response.headers,
-    )
+    finally:
+        if not released:
+            lock.release()

--- a/tests/api/test_chat_proxy.py
+++ b/tests/api/test_chat_proxy.py
@@ -406,6 +406,108 @@ def _stream_response(status_code: int, payload: bytes):
     )
 
 
+def _pre_locked():
+    """Return an asyncio.Lock whose locked() reports True."""
+    from unittest.mock import MagicMock
+    fake = MagicMock()
+    fake.locked.return_value = True
+    return fake
+
+
+def test_concurrent_completion_returns_429(client, monkeypatch):
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    client.app.state.inference_lock = _pre_locked()
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "qwen", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 429
+    body = response.json()
+    assert "error" in body
+    assert "message" in body["error"]
+
+
+def test_429_response_body_format(client, monkeypatch):
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    client.app.state.inference_lock = _pre_locked()
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "qwen", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    body = response.json()
+    assert body["error"]["type"] == "concurrent_request"
+    assert body["error"]["code"] == 429
+
+
+def test_lock_released_after_non_streaming_completion(client, runtime, monkeypatch):
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    runtime.model_path.write_bytes(b"gguf")
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://llama.test:8080/v1/chat/completions").mock(
+            return_value=_json_response(
+                200,
+                {
+                    "id": "chatcmpl-lock",
+                    "object": "chat.completion",
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+                },
+            )
+        )
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    assert response.status_code == 200
+    assert not client.app.state.inference_lock.locked()
+
+
+def test_lock_released_after_streaming_completion(client, runtime, monkeypatch):
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    runtime.model_path.write_bytes(b"gguf")
+
+    sse = b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n'
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://llama.test:8080/v1/chat/completions").mock(
+            return_value=_stream_response(200, sse),
+        )
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={
+                "model": "qwen",
+                "stream": True,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        ) as response:
+            assert response.status_code == 200
+            _ = response.read()
+
+    assert not client.app.state.inference_lock.locked()
+
+
+def test_lock_released_on_backend_error(client, runtime, monkeypatch):
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    runtime.model_path.write_bytes(b"gguf")
+
+    with respx.mock(assert_all_called=True) as router:
+        router.post("http://llama.test:8080/v1/chat/completions").mock(
+            return_value=_json_response(500, {"error": "boom"}),
+        )
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    assert response.status_code == 500
+    assert not client.app.state.inference_lock.locked()
+
+
 def test_chat_sets_cache_prompt_true_by_default(client, runtime, monkeypatch):
     monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
     runtime.model_path.write_bytes(b"gguf")

--- a/tests/ui/settings.spec.js
+++ b/tests/ui/settings.spec.js
@@ -15,6 +15,7 @@ const {
 
 
 test("seed mode defaults to random, toggles deterministic, persists, and controls request payload", async ({ page }) => {
+  await page.route("**/v1/chat/completions", (route) => fulfillStreamingChat(route));
   await waitUntilReady(page);
 
   const generationMode = page.locator("#generationMode");
@@ -86,6 +87,7 @@ test("seed mode defaults to random, toggles deterministic, persists, and control
 
 test("product chat requests still stream when saved model settings say stream false", async ({ page }) => {
   const promptField = page.locator("#userPrompt");
+  await page.route("**/v1/chat/completions", (route) => fulfillStreamingChat(route));
   await page.route("**/status", async (route) => {
     await route.fulfill({
       status: 200,
@@ -558,8 +560,7 @@ test("model-first settings save per model, yaml can be applied, and projector do
     });
   });
 
-  await page.goto("/");
-  await expect(page.locator("#composerForm")).toBeVisible({ timeout: 5000 });
+  await waitUntilReady(page);
   await openSettingsModal(page);
 
   await expect(page.locator("#settingsModelWorkspace")).toBeVisible();
@@ -808,7 +809,7 @@ test("model settings block cross-model actions until edits are saved or discarde
     });
   });
 
-  await page.goto("/");
+  await waitUntilReady(page);
   await openSettingsModal(page);
 
   await page.locator('#modelsList .model-row[data-model-id="default"]').click();
@@ -935,7 +936,7 @@ test("settings show installed projector state from canonical backend payload", a
     });
   });
 
-  await page.goto("/");
+  await waitUntilReady(page);
   await openSettingsModal(page);
 
   await expect(page.locator("#projectorStatusText")).toContainText("mmproj-F16.gguf");
@@ -983,7 +984,7 @@ test("add model by URL shows inline validation feedback", async ({ page }) => {
     });
   });
 
-  await page.goto("/");
+  await waitUntilReady(page);
   await openSettingsModal(page);
 
   await page.locator("#modelUrlInput").fill("http://example.com/bad-model.gguf");


### PR DESCRIPTION
## Summary
- add a shared inference lock so built-in apps cannot overlap completions against the same runtime
- return an explicit `429 concurrent_request` response while another completion is active
- surface the busy state in chat with a friendly user-facing message
- harden API and UI coverage for lock handling, release paths, and parallel-safe mocked completions

## Testing
- `uv run python -m pytest tests/api/test_chat_proxy.py -q`
  - `19 passed`
- `npx playwright test --reporter=dot --timeout=15000 --workers=75% 2>&1`
  - `97 passed`

## Pi QA
- Maintainer confirmed real-Pi QA is complete and the issue is already in `QA`
- Detailed Pi QA notes were not recorded in the branch before PR creation

Closes #197
