### PR TITLE
feat(runtime): add model loading indicator from residency diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ Tests are organized under `tests/`:
 - First-time Playwright setup: `npx playwright install chromium`
 
 ### Pi deployment
-- Fast asset deploy: `sshpass -e rsync -az --delete --rsync-path="sudo rsync" -e "ssh -o StrictHostKeyChecking=accept-new" core/ pi@potato.local:/opt/potato/app/`
+- Fast core deploy: `sshpass -e rsync -az --delete --rsync-path="sudo rsync" -e "ssh -o StrictHostKeyChecking=accept-new" core/ pi@potato.local:/opt/potato/core/`
+- Fast apps deploy: `sshpass -e rsync -az --rsync-path="sudo rsync" -e "ssh -o StrictHostKeyChecking=accept-new" apps/ pi@potato.local:/opt/potato/apps/`
 - Full install: `sshpass -e ssh pi@potato.local "cd /tmp/potato-os && sudo ./bin/install_dev.sh"`
 - Restart service: `sshpass -e ssh pi@potato.local "sudo systemctl restart potato"`
 

--- a/core/assets/runtime-ui.js
+++ b/core/assets/runtime-ui.js
@@ -153,10 +153,15 @@ import { formatBytes, formatPercent, formatClockMHz, percentFromRatio, applyRunt
           : "";
         if (llamaRssDetail) llamaRssDetail.textContent = `${formatBytes(llamaRssBytes)}${llPct}`;
         if (modelRamRow) modelRamRow.style.display = "";
+        const ml = statusPayload?.model_loading;
         if (modelRamDetail) {
-          modelRamDetail.textContent = Number.isFinite(modelRamBytes) && modelRamBytes > 0
-            ? formatBytes(modelRamBytes)
-            : "--";
+          if (ml?.active === true && typeof ml.progress_percent === "number") {
+            modelRamDetail.textContent = `${formatBytes(ml.resident_bytes)} / ${formatBytes(ml.model_size_bytes)} (${ml.progress_percent}%)`;
+          } else {
+            modelRamDetail.textContent = Number.isFinite(modelRamBytes) && modelRamBytes > 0
+              ? formatBytes(modelRamBytes)
+              : "--";
+          }
         }
       } else {
         if (llamaRssRow) llamaRssRow.style.display = "none";

--- a/core/assets/shell.css
+++ b/core/assets/shell.css
@@ -740,6 +740,12 @@
       transform: none;
     }
 
+    @property --load-pct {
+      syntax: "<number>";
+      inherits: false;
+      initial-value: 0;
+    }
+
     .chip-spinner {
       width: 14px;
       height: 14px;
@@ -748,6 +754,22 @@
       border-top-color: currentColor;
       animation: chip-spin 0.9s linear infinite;
       flex: 0 0 auto;
+    }
+
+    .chip-spinner.has-progress {
+      border: none;
+      background: conic-gradient(
+        currentColor calc(var(--load-pct) * 3.6deg),
+        color-mix(in srgb, currentColor 15%, transparent) calc(var(--load-pct) * 3.6deg)
+      );
+      -webkit-mask: radial-gradient(circle, transparent 3px, black 4px);
+      mask: radial-gradient(circle, transparent 3px, black 4px);
+      animation: chip-spin 6s linear infinite;
+      transition: --load-pct 0.3s ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .chip-spinner, .chip-spinner.has-progress { animation: none; }
     }
 
     .chip-cancel-btn {

--- a/core/assets/status.js
+++ b/core/assets/status.js
@@ -37,7 +37,11 @@ import { formatBytes, formatCountdownSeconds } from "./utils.js";
       badge.classList.remove("online", "loading", "failed", "offline");
       dot.classList.remove("online", "loading", "failed", "offline");
       dot.hidden = false;
-      if (spinner) spinner.hidden = true;
+      if (spinner) {
+        spinner.hidden = true;
+        spinner.classList.remove("has-progress");
+        spinner.style.removeProperty("--load-pct");
+      }
       if (backendMode === "fake" && isReady) {
         badge.classList.add("online");
         dot.classList.add("online");
@@ -51,7 +55,13 @@ import { formatBytes, formatCountdownSeconds } from "./utils.js";
         dot.classList.add("loading");
         dot.hidden = true;
         if (spinner) spinner.hidden = false;
-        label.textContent = `LOADING:llama.cpp${modelSuffix}`;
+        const loadPct = statusPayload?.model_loading?.progress_percent;
+        if (spinner && typeof loadPct === "number") {
+          spinner.classList.add("has-progress");
+          spinner.style.setProperty("--load-pct", loadPct);
+        }
+        const pctSuffix = typeof loadPct === "number" ? `:${loadPct}%` : modelSuffix;
+        label.textContent = `LOADING:llama.cpp${pctSuffix}`;
       } else if (isFailed) {
         badge.classList.add("failed");
         dot.classList.add("failed");

--- a/core/main.py
+++ b/core/main.py
@@ -95,11 +95,13 @@ try:
         POWER_CALIBRATION_DEFAULT_A,
         POWER_CALIBRATION_DEFAULT_B,
         RuntimeConfig,
+        _MODEL_LOADING_INACTIVE,
         build_large_model_compatibility,
         build_llama_large_model_override_status,
         build_llama_memory_loading_status,
         build_llama_runtime_status,
         build_power_calibration_status,
+        compute_model_loading_progress,
         build_power_estimate_status,
         check_llama_health,
         check_runtime_device_compatibility,
@@ -216,11 +218,13 @@ except ModuleNotFoundError:
         POWER_CALIBRATION_DEFAULT_A,
         POWER_CALIBRATION_DEFAULT_B,
         RuntimeConfig,
+        _MODEL_LOADING_INACTIVE,
         build_large_model_compatibility,
         build_llama_large_model_override_status,
         build_llama_memory_loading_status,
         build_llama_runtime_status,
         build_power_calibration_status,
+        compute_model_loading_progress,
         build_power_estimate_status,
         check_llama_health,
         check_runtime_device_compatibility,
@@ -727,6 +731,15 @@ def _build_status_fs(
         classify_runtime_device(pi_model_name=raw_system_snapshot.get("pi_model_name") if isinstance(raw_system_snapshot, dict) else None)
     )
 
+    memory_loading_status = build_llama_memory_loading_status(runtime)
+    model_loading = compute_model_loading_progress(
+        state=state,
+        has_model=has_model,
+        model_size_bytes=active_model_size_bytes,
+        no_mmap_env=memory_loading_status.get("no_mmap_env", "0"),
+        llama_rss=system_payload.get("llama_rss", {}),
+    )
+
     try:
         from core.__version__ import __version__ as _app_version
     except ModuleNotFoundError:
@@ -747,6 +760,7 @@ def _build_status_fs(
         "models": models_payload,
         "download": download_payload,
         "upload": upload_snapshot,
+        "model_loading": model_loading,
         "llama_server": {
             "running": llama_running or llama_transport_healthy,
             "healthy": llama_ready,
@@ -799,6 +813,7 @@ async def build_status(
             })
             result["backend"]["active"] = active_backend
             result["backend"]["fallback_active"] = fallback_active
+            result["model_loading"] = dict(_MODEL_LOADING_INACTIVE)
     return result
 
 

--- a/core/runtime_state.py
+++ b/core/runtime_state.py
@@ -596,6 +596,46 @@ def build_llama_memory_loading_status(runtime: RuntimeConfig) -> dict[str, Any]:
     }
 
 
+_MODEL_LOADING_INACTIVE: dict[str, Any] = {
+    "active": False,
+    "progress_percent": None,
+    "resident_bytes": None,
+    "model_size_bytes": None,
+}
+
+
+def compute_model_loading_progress(
+    *,
+    state: str,
+    has_model: bool,
+    model_size_bytes: int,
+    no_mmap_env: str,
+    llama_rss: dict[str, Any],
+) -> dict[str, Any]:
+    if state != "BOOTING" or not has_model or model_size_bytes <= 0:
+        return dict(_MODEL_LOADING_INACTIVE)
+    if not llama_rss.get("available"):
+        return dict(_MODEL_LOADING_INACTIVE)
+    if no_mmap_env == "1":
+        resident_bytes = llama_rss.get("rss_anon_bytes")
+    elif no_mmap_env == "auto":
+        anon = llama_rss.get("rss_anon_bytes") or 0
+        file = llama_rss.get("rss_file_bytes") or 0
+        resident_bytes = max(anon, file) if (anon or file) else None
+    else:
+        resident_bytes = llama_rss.get("rss_file_bytes")
+    if resident_bytes is None or not isinstance(resident_bytes, (int, float)):
+        return dict(_MODEL_LOADING_INACTIVE)
+    resident_bytes = int(resident_bytes)
+    progress_percent = min(100, max(0, int(resident_bytes * 100 / model_size_bytes)))
+    return {
+        "active": True,
+        "progress_percent": progress_percent,
+        "resident_bytes": resident_bytes,
+        "model_size_bytes": model_size_bytes,
+    }
+
+
 def build_llama_large_model_override_status(runtime: RuntimeConfig) -> dict[str, Any]:
     settings = read_llama_runtime_settings(runtime)
     enabled = normalize_allow_unsupported_large_models(settings.get("allow_unsupported_large_models"))

--- a/tests/api/test_status.py
+++ b/tests/api/test_status.py
@@ -767,3 +767,29 @@ def test_restart_llama_terminates_stale_processes_when_no_managed_process(runtim
     body = response.json()
     assert body["restarted"] is True
     assert body["reason"] == "terminated_stale_processes"
+
+
+# -- model_loading field in /status ------------------------------------------------
+
+
+def test_status_includes_model_loading_inactive_when_ready(client, runtime, monkeypatch):
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    runtime.model_path.write_bytes(b"gguf")
+
+    body = client.get("/status").json()
+
+    ml = body["model_loading"]
+    assert ml["active"] is False
+    assert ml["progress_percent"] is None
+    assert ml["resident_bytes"] is None
+    assert ml["model_size_bytes"] is None
+
+
+def test_status_includes_model_loading_inactive_when_booting(client, monkeypatch):
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_false)
+
+    body = client.get("/status").json()
+
+    assert body["state"] == "BOOTING"
+    ml = body["model_loading"]
+    assert ml["active"] is False

--- a/tests/ui/helpers.js
+++ b/tests/ui/helpers.js
@@ -138,6 +138,7 @@ function makeStatusPayload(overrides = {}) {
       },
     ],
     upload: { active: false, model_id: null, bytes_total: 0, bytes_received: 0, percent: 0, error: null },
+    model_loading: { active: false, progress_percent: null, resident_bytes: null, model_size_bytes: null },
     download: {
       bytes_total: 0,
       bytes_downloaded: 0,

--- a/tests/ui/runtime.spec.js
+++ b/tests/ui/runtime.spec.js
@@ -771,6 +771,91 @@ test("memory severity uses PSI thresholds when pressure data available", async (
   await expect(page.locator("#runtimeDetailPressureValue")).toHaveText("15.0%");
 });
 
+test("composer chip shows determinate loading progress when model_loading is active", async ({ page }) => {
+  await page.route("**/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(makeStatusPayload({
+        state: "BOOTING",
+        llama_server: { healthy: false, running: true, url: "http://127.0.0.1:8080" },
+        model_loading: {
+          active: true,
+          progress_percent: 67,
+          resident_bytes: 1_700_000_000,
+          model_size_bytes: 2_500_000_000,
+        },
+      })),
+    });
+  });
+  await page.goto("/");
+  await waitForStatusApplied(page);
+  // Badge shows loading state with progress ring and percentage
+  await expect(page.locator("#statusLabel")).toHaveText("LOADING:llama.cpp:67%");
+  await expect(page.locator("#statusBadge")).toHaveClass(/loading/);
+  await expect(page.locator("#statusSpinner")).toBeVisible();
+  await expect(page.locator("#statusSpinner")).toHaveClass(/has-progress/);
+  // Send button disabled during loading
+  await expect(page.locator("#sendBtn")).toBeDisabled();
+});
+
+test("runtime detail shows loading progress in model RAM row", async ({ page }) => {
+  await page.route("**/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(makeStatusPayload({
+        state: "BOOTING",
+        llama_server: { healthy: false, running: true, url: "http://127.0.0.1:8080" },
+        model_loading: {
+          active: true,
+          progress_percent: 67,
+          resident_bytes: 1_700_000_000,
+          model_size_bytes: 2_500_000_000,
+        },
+        system: {
+          available: true,
+          cpu_percent: 50,
+          cpu_cores_percent: [50, 50, 50, 50],
+          cpu_clock_arm_hz: 2400000000,
+          memory_total_bytes: 8_000_000_000,
+          memory_used_bytes: 4_000_000_000,
+          memory_free_bytes: 4_000_000_000,
+          memory_available_bytes: 4_000_000_000,
+          memory_percent: 50,
+          memory_pressure: { available: false },
+          llama_rss: {
+            available: true,
+            rss_bytes: 2_000_000_000,
+            rss_anon_bytes: 300_000_000,
+            rss_file_bytes: 1_700_000_000,
+          },
+          swap_total_bytes: 0,
+          swap_used_bytes: 0,
+          swap_percent: 0,
+          storage_total_bytes: 32_000_000_000,
+          storage_used_bytes: 16_000_000_000,
+          storage_free_bytes: 16_000_000_000,
+          storage_percent: 50,
+          temperature_c: 50,
+          throttling: { raw: 0 },
+        },
+        llama_runtime: {
+          current: { family: "ik_llama", llama_cpp_commit: "abc12345", profile: "pi5-opt", has_server_binary: true },
+          available_runtimes: [{ family: "ik_llama", is_active: true, compatible: true }],
+          switch: { active: false, target_family: null, error: null },
+          memory_loading: { mode: "auto", label: "Automatic", no_mmap_env: "0" },
+          large_model_override: { enabled: false },
+        },
+      })),
+    });
+  });
+  await page.goto("/");
+  await waitForStatusApplied(page);
+  await page.locator("#systemRuntimeCard").click();
+  await expect(page.locator("#runtimeDetailModelRamValue")).toContainText("67%");
+});
+
 test("large-model warning is hidden when model fits within storage limits", async ({ page }) => {
   await page.route("**/status", async (route) => {
     await route.fulfill({

--- a/tests/ui/settings.spec.js
+++ b/tests/ui/settings.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require("@playwright/test");
 const {
   waitUntilReady,
+  waitForStatusApplied,
   openSettingsModal,
   closeSettingsModal,
   openAdvancedSettingsModal,
@@ -79,6 +80,7 @@ test("seed mode defaults to random, toggles deterministic, persists, and control
   await closeSettingsModal(page);
 
   await page.reload();
+  await waitForStatusApplied(page);
   await openSettingsModal(page);
   await expect(page.locator("#generationMode")).toHaveValue("deterministic");
   await expect(page.locator("#seed")).toHaveValue("1337");

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -14,6 +14,7 @@ from core.runtime_state import (
     check_llama_health,
     check_runtime_device_compatibility,
     collect_system_metrics_snapshot,
+    compute_model_loading_progress,
     compute_required_download_bytes,
     classify_runtime_device,
     decode_throttled_bits,
@@ -1227,3 +1228,162 @@ def test_parse_llama_rss_handles_none():
     result = _parse_llama_rss_from_proc_status(None)
 
     assert result["available"] is False
+
+
+# -- compute_model_loading_progress ------------------------------------------------
+
+
+def _rss(*, available=True, rss_bytes=None, rss_anon_bytes=None, rss_file_bytes=None):
+    return {
+        "available": available,
+        "rss_bytes": rss_bytes,
+        "rss_anon_bytes": rss_anon_bytes,
+        "rss_file_bytes": rss_file_bytes,
+    }
+
+
+def test_compute_model_loading_progress_mmap_mode():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=2_500_000_000,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=1_500_000_000, rss_anon_bytes=100_000),
+    )
+    assert result["active"] is True
+    assert result["progress_percent"] == 60
+    assert result["resident_bytes"] == 1_500_000_000
+    assert result["model_size_bytes"] == 2_500_000_000
+
+
+def test_compute_model_loading_progress_no_mmap_mode():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=2_500_000_000,
+        no_mmap_env="1",
+        llama_rss=_rss(rss_anon_bytes=625_000_000, rss_file_bytes=0),
+    )
+    assert result["active"] is True
+    assert result["progress_percent"] == 25
+    assert result["resident_bytes"] == 625_000_000
+
+
+def test_compute_model_loading_progress_clamps_to_100():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=1_000_000,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=1_200_000),
+    )
+    assert result["active"] is True
+    assert result["progress_percent"] == 100
+
+
+def test_compute_model_loading_progress_zero_resident():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=2_000_000_000,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=0),
+    )
+    assert result["active"] is True
+    assert result["progress_percent"] == 0
+
+
+def test_compute_model_loading_progress_inactive_when_ready():
+    result = compute_model_loading_progress(
+        state="READY",
+        has_model=True,
+        model_size_bytes=2_000_000_000,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=2_000_000_000),
+    )
+    assert result["active"] is False
+    assert result["progress_percent"] is None
+    assert result["resident_bytes"] is None
+    assert result["model_size_bytes"] is None
+
+
+def test_compute_model_loading_progress_inactive_when_no_model():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=False,
+        model_size_bytes=0,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=500_000),
+    )
+    assert result["active"] is False
+
+
+def test_compute_model_loading_progress_inactive_when_rss_unavailable():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=2_000_000_000,
+        no_mmap_env="0",
+        llama_rss=_rss(available=False),
+    )
+    assert result["active"] is False
+
+
+def test_compute_model_loading_progress_inactive_when_model_size_zero():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=0,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=500_000),
+    )
+    assert result["active"] is False
+
+
+def test_compute_model_loading_progress_inactive_when_bucket_none():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=2_000_000_000,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=None),
+    )
+    assert result["active"] is False
+
+
+def test_compute_model_loading_progress_uses_floor():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=1000,
+        no_mmap_env="0",
+        llama_rss=_rss(rss_file_bytes=997),
+    )
+    assert result["active"] is True
+    assert result["progress_percent"] == 99
+
+
+def test_compute_model_loading_progress_auto_mode_uses_anon_when_larger():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=2_000_000_000,
+        no_mmap_env="auto",
+        llama_rss=_rss(rss_anon_bytes=1_000_000_000, rss_file_bytes=100_000),
+    )
+    assert result["active"] is True
+    assert result["progress_percent"] == 50
+    assert result["resident_bytes"] == 1_000_000_000
+
+
+def test_compute_model_loading_progress_auto_mode_uses_file_when_larger():
+    result = compute_model_loading_progress(
+        state="BOOTING",
+        has_model=True,
+        model_size_bytes=2_000_000_000,
+        no_mmap_env="auto",
+        llama_rss=_rss(rss_anon_bytes=50_000, rss_file_bytes=1_500_000_000),
+    )
+    assert result["active"] is True
+    assert result["progress_percent"] == 75
+    assert result["resident_bytes"] == 1_500_000_000


### PR DESCRIPTION
## Summary

- Add a user-facing model loading indicator that shows how far the selected model has loaded into RAM during llama startup
- Derive progress from model-resident RSS vs model file size — works in both mmap and no-mmap modes
- Badge shows `LOADING:llama.cpp:XX%` with a conic-gradient progress ring that fills as the model loads
- Runtime detail row shows `loaded / total (pct%)` during loading
- Smooth CSS transitions via `@property --load-pct`, accessibility via `prefers-reduced-motion`
- Clamps progress 0-100, handles missing data gracefully (falls back to model name + indeterminate spinner)

Closes #195

## Test plan

- [x] 10 unit tests for `compute_model_loading_progress()` — mmap/no-mmap modes, clamping, edge cases
- [x] 2 API tests for `model_loading` field in `/status` response
- [x] 4 UI tests — badge progress ring, composer chip, send button disabled, runtime detail row
- [x] Fixed pre-existing flaky test (seed mode settings init race)
- [x] All 650 tests green (550 Python + 100 Playwright)
- [x] Pi QA on potato.local — model swap shows progress ring filling in badge, transitions to CONNECTED
- [x] Fixed Pi deploy paths in AGENTS.md (core/ not app/, added apps/ deploy command)

```
uv run python -m pytest tests/unit tests/api -q -n auto
550 passed in 9.79s

npx playwright test --reporter=dot --timeout=15000 --workers=75%
100 passed (30.7s)
```