### PR TITLE
feat(update): add canonical changelog and What's new modal

### DIFF
--- a/bin/publish_ota_release.sh
+++ b/bin/publish_ota_release.sh
@@ -174,7 +174,13 @@ else
     git push "${PUSH_REMOTE}" "${VERSION}" 2>/dev/null || true
   fi
 
-  RELEASE_NOTES="$(cat <<NOTES
+  CHANGELOG_FILE="${REPO_ROOT}/docs/releases/${VERSION}.md"
+  if [ -f "${CHANGELOG_FILE}" ]; then
+    RELEASE_NOTES="$(cat "${CHANGELOG_FILE}")"
+    printf 'Using changelog: %s\n' "${CHANGELOG_FILE}"
+  else
+    printf 'No changelog at %s — using default template.\n' "${CHANGELOG_FILE}"
+    RELEASE_NOTES="$(cat <<NOTES
 ## Potato OS ${VERSION} — OTA Update
 
 | Field | Value |
@@ -193,7 +199,8 @@ Devices running Potato OS can check for and apply this update via the built-in u
 sha256sum -c ${CHECKSUM_NAME}
 \`\`\`
 NOTES
-  )"
+    )"
+  fi
 
   gh release create "${VERSION}" \
     "${TARBALL_PATH}" \

--- a/core/assets/chat.html
+++ b/core/assets/chat.html
@@ -400,6 +400,20 @@
     </div>
   </div>
 
+  <div id="changelogBackdrop" class="settings-backdrop" hidden></div>
+  <div id="changelogModal" class="settings-modal changelog-modal" role="dialog" aria-modal="true" aria-labelledby="changelogModalTitle" hidden>
+    <div class="settings-modal-shell changelog-modal-shell">
+      <div class="settings-modal-header">
+        <div>
+          <h2 id="changelogModalTitle" class="settings-modal-title">What's new</h2>
+          <p id="changelogModalSubtitle" class="settings-modal-note"></p>
+        </div>
+        <button id="changelogCloseBtn" class="ghost-btn settings-close-btn" type="button" aria-label="Close">Close</button>
+      </div>
+      <div id="changelogContent" class="changelog-content"></div>
+    </div>
+  </div>
+
   <div id="terminalBackdrop" class="settings-backdrop" hidden></div>
   <div id="terminalModal" class="settings-modal terminal-modal" role="dialog" aria-modal="true" aria-labelledby="terminalModalTitle" hidden>
     <div class="settings-modal-shell terminal-modal-shell">

--- a/core/assets/index.html
+++ b/core/assets/index.html
@@ -355,6 +355,20 @@
     </div>
   </div>
 
+  <div id="changelogBackdrop" class="settings-backdrop" hidden></div>
+  <div id="changelogModal" class="settings-modal changelog-modal" role="dialog" aria-modal="true" aria-labelledby="changelogModalTitle" hidden>
+    <div class="settings-modal-shell changelog-modal-shell">
+      <div class="settings-modal-header">
+        <div>
+          <h2 id="changelogModalTitle" class="settings-modal-title">What's new</h2>
+          <p id="changelogModalSubtitle" class="settings-modal-note"></p>
+        </div>
+        <button id="changelogCloseBtn" class="ghost-btn settings-close-btn" type="button" aria-label="Close">Close</button>
+      </div>
+      <div id="changelogContent" class="changelog-content"></div>
+    </div>
+  </div>
+
   <div id="terminalBackdrop" class="settings-backdrop" hidden></div>
   <div id="terminalModal" class="settings-modal terminal-modal" role="dialog" aria-modal="true" aria-labelledby="terminalModalTitle" hidden>
     <div class="settings-modal-shell terminal-modal-shell">

--- a/core/assets/platform-controls.js
+++ b/core/assets/platform-controls.js
@@ -25,7 +25,7 @@ import { appState, RUNTIME_RECONNECT_INTERVAL_MS, RUNTIME_RECONNECT_TIMEOUT_MS, 
 import { formatBytes } from "./utils.js";
 import { isLocalModelConnected, findResumableFailedModel, renderDownloadPrompt } from "./status.js";
 import { setModelUploadStatus, setLlamaRuntimeSwitchStatus, setLlamaRuntimeSwitchButtonState, setLlamaMemoryLoadingStatus, setLlamaMemoryLoadingButtonState, setLargeModelOverrideStatus, setLargeModelOverrideButtonState, setPowerCalibrationStatus, setPowerCalibrationButtonsState } from "./runtime-ui.js";
-import { setUpdateCheckInFlight, setUpdateStartInFlight, isUpdateExecutionActive } from "./update-ui.js";
+import { setUpdateCheckInFlight, setUpdateStartInFlight, isUpdateExecutionActive, openChangelogModal } from "./update-ui.js";
 import { setModelUrlStatus, formatModelUrlStatus, resolveSelectedSettingsModel, selectedModelHasUnsavedChanges, blockModelSelectionChange, renderSettingsWorkspace } from "./settings-ui.js";
 import { showPlatformNotice } from "./platform-notify.js";
 import * as platformApi from "./platform-api.js";
@@ -640,8 +640,12 @@ export async function startUpdate() {
 }
 
 export function showUpdateReleaseNotes() {
-  const notes = appState.latestStatus?.update?.release_notes;
-  showPlatformNotice(notes || "No release notes available.", { level: "info", durationMs: 15000 });
+  const update = appState.latestStatus?.update;
+  const notes = update?.release_notes;
+  const latest = String(update?.latest_version || "");
+  const current = String(update?.current_version || "");
+  const subtitle = (current && latest) ? `v${current} \u2192 v${latest}` : "";
+  openChangelogModal({ version: latest, notes: notes || null, subtitle });
 }
 
 function stopUpdateReconnectWatch() {

--- a/core/assets/platform-notify.js
+++ b/core/assets/platform-notify.js
@@ -31,7 +31,7 @@ function ensureNoticeBar() {
 }
 
 function isModalOpen() {
-  return appState.settingsModalOpen || appState.legacySettingsModalOpen;
+  return appState.settingsModalOpen || appState.legacySettingsModalOpen || appState.changelogModalOpen;
 }
 
 export function showPlatformNotice(message, { level = "info", durationMs = 6000 } = {}) {

--- a/core/assets/shell.css
+++ b/core/assets/shell.css
@@ -1994,3 +1994,46 @@ body.terminal-modal-open #terminalModal { display: grid; }
     height: calc(100vh - 140px);
   }
 }
+
+/* ── Changelog modal ───────────────────────────────────────────────── */
+
+body.changelog-modal-open { overflow: hidden; }
+
+body.changelog-modal-open #changelogBackdrop { display: block; }
+body.changelog-modal-open #changelogModal { display: grid; }
+
+.changelog-modal-shell {
+  width: min(640px, calc(100vw - 28px));
+  max-height: calc(100vh - 28px);
+  display: flex;
+  flex-direction: column;
+}
+
+.changelog-content {
+  overflow-y: auto;
+  max-height: 60vh;
+  padding: 8px 0;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.changelog-content h1,
+.changelog-content h2,
+.changelog-content h3 { margin: 16px 0 8px; }
+.changelog-content p { margin: 0 0 10px; }
+.changelog-content ul,
+.changelog-content ol { padding-left: 20px; margin: 0 0 10px; }
+.changelog-content code { font-size: 13px; padding: 2px 6px; border-radius: 4px; background: var(--panel-muted); }
+.changelog-content pre { padding: 12px; border-radius: 8px; background: var(--panel-muted); overflow-x: auto; }
+.changelog-content a { color: var(--link); text-decoration: underline; }
+.changelog-content table { width: 100%; border-collapse: collapse; margin: 0 0 10px; font-size: 14px; }
+.changelog-content th,
+.changelog-content td { padding: 6px 10px; border: 1px solid var(--border); text-align: left; }
+.changelog-content th { background: var(--panel-muted); font-weight: 600; }
+
+@media (max-width: 900px) {
+  .changelog-modal-shell {
+    width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+  }
+}

--- a/core/assets/shell.js
+++ b/core/assets/shell.js
@@ -4,7 +4,7 @@ import { appState, defaultSettings, STATUS_POLL_TIMEOUT_MS } from "./state.js";
 import { formatCountdownSeconds } from "./utils.js";
 import { isLocalModelConnected, updateLlamaIndicator, renderDownloadPrompt, renderStatusActions, renderCompatibilityWarnings, formatSidebarStatusDetail, findResumableFailedModel } from "./status.js";
 import { setRuntimeDetailsExpanded, renderSystemRuntime, renderLlamaRuntimeStatus, renderUploadState } from "./runtime-ui.js";
-import { renderUpdateCard } from "./update-ui.js";
+import { renderUpdateCard, closeChangelogModal, bindChangelogModal } from "./update-ui.js";
 import { populateModelSwitcher, openModelSwitcher, closeModelSwitcher, toggleModelSwitcher } from "./model-switcher.js";
 import { loadSettings, saveSettings, renderSettingsWorkspace, closeSettingsModal, closeLegacySettingsModal, setSettingsModalOpen, registerSettingsPlatformCallbacks } from "./settings-ui.js";
 import { registerPlatformShell } from "./platform-controls.js";
@@ -84,6 +84,10 @@ import { registerPlatformShell } from "./platform-controls.js";
             return;
           }
           if (_appEscapeHandler && _appEscapeHandler()) return;
+          if (appState.changelogModalOpen) {
+            closeChangelogModal();
+            return;
+          }
           if (appState.legacySettingsModalOpen) {
             closeLegacySettingsModal();
             return;
@@ -372,6 +376,7 @@ import { registerPlatformShell } from "./platform-controls.js";
 
     // Bind shell event handlers (these are shell-owned, safe before app loads)
     bindMobileSidebar();
+    bindChangelogModal();
     document.getElementById("themeToggle").addEventListener("click", toggleTheme);
     document.getElementById("sidebarToggle").addEventListener("click", () => setSidebarOpen(!document.body.classList.contains("sidebar-open")));
     document.getElementById("sidebarCloseBtn").addEventListener("click", () => setSidebarOpen(false));

--- a/core/assets/state.js
+++ b/core/assets/state.js
@@ -39,6 +39,7 @@ export const appState = {
   settingsModalOpenedAtMs: 0,
   editModalOpen: false,
   terminalModalOpen: false,
+  changelogModalOpen: false,
   modelSwitcherOpen: false,
   settingsWorkspaceTab: "model",
   selectedSettingsModelId: "",
@@ -108,6 +109,7 @@ export const IMAGE_CANCEL_RESTART_DELAY_MS = Math.max(
   2000,
   Number(window.__POTATO_CANCEL_RESTART_DELAY_MS__ || 45000),
 );
+export const CHANGELOG_SEEN_KEY = "potato_changelog_seen_v";
 export const SESSIONS_DB_NAME = "potato_sessions";
 export const SESSIONS_DB_VERSION = 1;
 export const SESSIONS_STORE = "sessions";

--- a/core/assets/update-ui.js
+++ b/core/assets/update-ui.js
@@ -1,6 +1,7 @@
 "use strict";
 
-import { appState } from "./state.js";
+import { appState, CHANGELOG_SEEN_KEY } from "./state.js";
+import { flushPendingNoticeDismissal } from "./platform-notify.js";
 
 const ACTIVE_STATES = new Set(["downloading", "staging", "applying", "restart_pending"]);
 
@@ -31,6 +32,12 @@ export function renderUpdateCard(updatePayload) {
   const error = String(updatePayload?.progress?.error || "");
   const hasNotes = Boolean(updatePayload?.release_notes);
   const isActive = ACTIVE_STATES.has(state);
+
+  // Post-update auto-open — must run before early returns that hide the card
+  const justUpdatedTo = String(updatePayload?.just_updated_to || "");
+  if (justUpdatedTo) {
+    maybeAutoOpenChangelog(updatePayload);
+  }
 
   // Default: hide everything
   if (startBtn) startBtn.hidden = true;
@@ -159,4 +166,71 @@ export function setUpdateStartInFlight(inFlight) {
     retryBtn.disabled = Boolean(inFlight);
     retryBtn.textContent = inFlight ? "Retrying..." : "Retry";
   }
+}
+
+// ── Changelog modal ───────────────────────────────────────────────────
+
+let _markdownConfigured = false;
+
+function _renderMarkdown(source) {
+  if (!_markdownConfigured && window.marked) {
+    window.marked.setOptions({ gfm: true, breaks: true });
+    _markdownConfigured = true;
+  }
+  const html = window.marked?.parse(source) || "";
+  return window.DOMPurify?.sanitize(html, {
+    ALLOWED_TAGS: ["a", "blockquote", "br", "code", "em", "h1", "h2", "h3", "h4", "li", "ol", "p", "pre", "strong", "table", "tbody", "td", "th", "thead", "tr", "ul"],
+    ALLOWED_ATTR: ["href", "title"],
+  }) || "";
+}
+
+export function openChangelogModal({ version, notes, subtitle } = {}) {
+  appState.changelogModalOpen = true;
+  document.body.classList.add("changelog-modal-open");
+  const backdrop = document.getElementById("changelogBackdrop");
+  const modal = document.getElementById("changelogModal");
+  if (backdrop) backdrop.hidden = false;
+  if (modal) modal.hidden = false;
+
+  const titleEl = document.getElementById("changelogModalTitle");
+  const subtitleEl = document.getElementById("changelogModalSubtitle");
+  const contentEl = document.getElementById("changelogContent");
+
+  if (titleEl) titleEl.textContent = version ? `What's new in v${version}` : "What's new";
+  if (subtitleEl) subtitleEl.textContent = subtitle || "";
+  if (contentEl) {
+    contentEl.innerHTML = notes
+      ? _renderMarkdown(notes)
+      : "No release notes available for this version.";
+  }
+}
+
+export function closeChangelogModal() {
+  appState.changelogModalOpen = false;
+  document.body.classList.remove("changelog-modal-open");
+  const backdrop = document.getElementById("changelogBackdrop");
+  const modal = document.getElementById("changelogModal");
+  if (backdrop) backdrop.hidden = true;
+  if (modal) modal.hidden = true;
+  flushPendingNoticeDismissal();
+}
+
+export function bindChangelogModal() {
+  const closeBtn = document.getElementById("changelogCloseBtn");
+  const backdrop = document.getElementById("changelogBackdrop");
+  if (closeBtn) closeBtn.addEventListener("click", closeChangelogModal);
+  if (backdrop) backdrop.addEventListener("click", closeChangelogModal);
+}
+
+function maybeAutoOpenChangelog(updatePayload) {
+  const version = String(updatePayload?.just_updated_to || "");
+  if (!version) return;
+  const seen = localStorage.getItem(CHANGELOG_SEEN_KEY);
+  if (seen === version) return;
+  localStorage.setItem(CHANGELOG_SEEN_KEY, version);
+  openChangelogModal({
+    version,
+    notes: updatePayload?.just_updated_release_notes || updatePayload?.release_notes || null,
+    subtitle: "You\u2019ve updated to this version.",
+  });
 }

--- a/core/update_state.py
+++ b/core/update_state.py
@@ -159,6 +159,8 @@ def build_update_status(runtime: RuntimeConfig) -> dict[str, Any]:
             "deferred": deferred,
             "defer_reason": "download_active" if deferred else None,
             "progress": {"phase": exec_phase, "percent": exec_percent, "error": progress_error},
+            "just_updated_to": None,
+            "just_updated_release_notes": None,
         }
 
     latest_version = state.get("latest_version")
@@ -176,6 +178,8 @@ def build_update_status(runtime: RuntimeConfig) -> dict[str, Any]:
         "deferred": deferred,
         "defer_reason": "download_active" if deferred else None,
         "progress": {"phase": exec_phase, "percent": exec_percent, "error": progress_error},
+        "just_updated_to": state.get("just_updated_to"),
+        "just_updated_release_notes": state.get("just_updated_release_notes"),
     }
 
 
@@ -330,6 +334,8 @@ def detect_post_update_state(runtime: RuntimeConfig) -> bool:
     state["execution_error"] = None
     state["execution_target_version"] = None
     state["execution_started_at_unix"] = None
+    state["just_updated_to"] = target or __version__
+    state["just_updated_release_notes"] = state.get("release_notes")
     _atomic_write_json(runtime.update_state_path, state)
     return True
 

--- a/docs/releases/v0.6.2.md
+++ b/docs/releases/v0.6.2.md
@@ -1,0 +1,12 @@
+## Potato OS v0.6.2
+
+### Highlights
+
+- Model loading progress is now surfaced from residency diagnostics
+- Concurrent built-in app completions are rejected with 429
+
+### Improvements
+
+- Disabled unused llama-server WebUI across bundled runtimes
+- Extracted app-scoped chat styles and renamed shell.css
+- Converted chat into the first built-in Potato app

--- a/tests/api/test_update.py
+++ b/tests/api/test_update.py
@@ -88,6 +88,8 @@ def test_status_includes_update_key_with_default_shape(client, monkeypatch):
     assert update["state"] == "idle"
     assert update["deferred"] is False
     assert update["defer_reason"] is None
+    assert update["just_updated_to"] is None
+    assert update["just_updated_release_notes"] is None
     assert update["progress"] == {"phase": None, "percent": 0, "error": None}
 
 

--- a/tests/ui/helpers.js
+++ b/tests/ui/helpers.js
@@ -166,6 +166,8 @@ function makeStatusPayload(overrides = {}) {
       deferred: false,
       defer_reason: null,
       progress: { phase: null, percent: 0, error: null },
+      just_updated_to: null,
+      just_updated_release_notes: null,
     },
     llama_runtime: {
       current: { family: "ik_llama", llama_cpp_commit: "abc12345", profile: "pi5-opt", has_server_binary: true },

--- a/tests/ui/update.spec.js
+++ b/tests/ui/update.spec.js
@@ -13,6 +13,8 @@ function makeUpdatePayload(overrides = {}) {
       deferred: false,
       defer_reason: null,
       progress: { phase: null, percent: 0, error: null },
+      just_updated_to: null,
+      just_updated_release_notes: null,
       ...overrides,
     },
   });
@@ -241,7 +243,7 @@ test("install button calls start endpoint", async ({ page }) => {
   expect(startCalled).toBe(true);
 });
 
-test("release notes displayed as platform notice", async ({ page }) => {
+test("release notes button opens changelog modal", async ({ page }) => {
   const status = makeUpdatePayload({
     available: true,
     current_version: "0.4.0",
@@ -256,7 +258,151 @@ test("release notes displayed as platform notice", async ({ page }) => {
   await waitForStatusApplied(page);
 
   await page.locator("#updateNotesBtn").click();
-  await expect(page.locator("#platformNotice")).toContainText("Feature A", { timeout: 5000 });
+  await expect(page.locator("#changelogModal")).toBeVisible();
+  await expect(page.locator("#changelogContent")).toContainText("Feature A");
+});
+
+test("changelog modal closes on close button click", async ({ page }) => {
+  const status = makeUpdatePayload({
+    available: true,
+    current_version: "0.4.0",
+    latest_version: "0.5.0",
+    state: "idle",
+    release_notes: "Some notes",
+  });
+  await page.route("**/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(status) })
+  );
+  await page.goto("/");
+  await waitForStatusApplied(page);
+
+  await page.locator("#updateNotesBtn").click();
+  await expect(page.locator("#changelogModal")).toBeVisible();
+  await page.locator("#changelogCloseBtn").click();
+  await expect(page.locator("#changelogModal")).toBeHidden();
+});
+
+test("changelog modal closes on Escape key", async ({ page }) => {
+  const status = makeUpdatePayload({
+    available: true,
+    current_version: "0.4.0",
+    latest_version: "0.5.0",
+    state: "idle",
+    release_notes: "Some notes",
+  });
+  await page.route("**/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(status) })
+  );
+  await page.goto("/");
+  await waitForStatusApplied(page);
+
+  await page.locator("#updateNotesBtn").click();
+  await expect(page.locator("#changelogModal")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator("#changelogModal")).toBeHidden();
+});
+
+test("changelog modal renders markdown as HTML", async ({ page }) => {
+  const status = makeUpdatePayload({
+    available: true,
+    current_version: "0.4.0",
+    latest_version: "0.5.0",
+    state: "idle",
+    release_notes: "## Heading\n- bullet one\n- bullet two",
+  });
+  await page.route("**/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(status) })
+  );
+  await page.goto("/");
+  await waitForStatusApplied(page);
+
+  await page.locator("#updateNotesBtn").click();
+  await expect(page.locator("#changelogContent h2")).toBeVisible();
+  await expect(page.locator("#changelogContent li")).toHaveCount(2);
+});
+
+test("changelog auto-opens after update with just_updated_to", async ({ page }) => {
+  const status = makeUpdatePayload({
+    available: false,
+    current_version: "0.5.0",
+    latest_version: "0.5.0",
+    state: "idle",
+    release_notes: "## What's new\n- Feature A",
+    just_updated_to: "0.5.0",
+    just_updated_release_notes: "## What's new\n- Feature A",
+  });
+  await page.route("**/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(status) })
+  );
+  await page.goto("/");
+  await waitForStatusApplied(page);
+
+  await expect(page.locator("#changelogModal")).toBeVisible({ timeout: 5000 });
+  await expect(page.locator("#changelogContent")).toContainText("Feature A");
+});
+
+test("changelog auto-open uses snapshotted notes over stale release_notes", async ({ page }) => {
+  const status = makeUpdatePayload({
+    available: false,
+    current_version: "0.5.0",
+    latest_version: "0.5.0",
+    state: "idle",
+    release_notes: "## vNEXT notes (stale)",
+    just_updated_to: "0.5.0",
+    just_updated_release_notes: "## v0.5.0 notes (correct)",
+  });
+  await page.route("**/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(status) })
+  );
+  await page.goto("/");
+  await waitForStatusApplied(page);
+
+  await expect(page.locator("#changelogModal")).toBeVisible({ timeout: 5000 });
+  await expect(page.locator("#changelogContent")).toContainText("v0.5.0 notes (correct)");
+  await expect(page.locator("#changelogContent")).not.toContainText("stale");
+});
+
+test("changelog does not auto-open when version already seen", async ({ page }) => {
+  const status = makeUpdatePayload({
+    available: false,
+    current_version: "0.5.0",
+    latest_version: "0.5.0",
+    state: "idle",
+    release_notes: "## What's new\n- Feature A",
+    just_updated_to: "0.5.0",
+  });
+  await page.route("**/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(status) })
+  );
+
+  // Pre-set the "already seen" key before navigating
+  await page.goto("/");
+  await page.evaluate(() => localStorage.setItem("potato_changelog_seen_v", "0.5.0"));
+  await page.goto("/");
+  await waitForStatusApplied(page);
+
+  // Wait a tick and confirm modal did not open
+  await page.waitForTimeout(1000);
+  await expect(page.locator("#changelogModal")).toBeHidden();
+});
+
+test("changelog modal shows fallback when no release notes", async ({ page }) => {
+  const status = makeUpdatePayload({
+    available: false,
+    current_version: "0.5.0",
+    latest_version: "0.5.0",
+    state: "idle",
+    release_notes: null,
+    just_updated_to: "0.5.0",
+  });
+  await page.route("**/status", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(status) })
+  );
+  await page.goto("/");
+  await waitForStatusApplied(page);
+
+  await expect(page.locator("#changelogModal")).toBeVisible({ timeout: 5000 });
+  await expect(page.locator("#changelogContent")).toContainText("No release notes available");
 });
 
 test("check button disabled during active update execution", async ({ page }) => {

--- a/tests/unit/test_update_state.py
+++ b/tests/unit/test_update_state.py
@@ -273,6 +273,27 @@ def test_build_update_status_uses_live_version_not_cached(runtime, monkeypatch):
     assert result["current_version"] == "0.3.6-pre-alpha"
 
 
+def test_build_update_status_just_updated_to_null_by_default(runtime):
+    result = build_update_status(runtime)
+    assert result["just_updated_to"] is None
+    assert result["just_updated_release_notes"] is None
+
+
+def test_build_update_status_includes_just_updated_to_when_set(runtime):
+    state = {
+        "available": False,
+        "latest_version": "0.5.0",
+        "checked_at_unix": 1711000000,
+        "error": None,
+        "just_updated_to": "0.5.0",
+        "just_updated_release_notes": "Notes for 0.5.0",
+    }
+    runtime.update_state_path.write_text(json.dumps(state), encoding="utf-8")
+    result = build_update_status(runtime)
+    assert result["just_updated_to"] == "0.5.0"
+    assert result["just_updated_release_notes"] == "Notes for 0.5.0"
+
+
 def test_build_update_status_deferred_when_download_active(runtime):
     runtime.download_state_path.write_text(
         json.dumps({"bytes_total": 1000, "bytes_downloaded": 500, "percent": 50}),
@@ -773,6 +794,40 @@ def test_detect_post_update_state_fails_on_version_mismatch(runtime, monkeypatch
     after = read_update_state(runtime)
     assert after["execution_state"] == "failed"
     assert after["execution_error"] == "version_unchanged_after_restart"
+
+
+def test_detect_post_update_state_sets_just_updated_to(runtime, monkeypatch):
+    monkeypatch.setattr("core.update_state.__version__", "0.5.0")
+    state = {
+        "available": True,
+        "latest_version": "0.5.0",
+        "release_notes": "Notes for 0.5.0",
+        "execution_state": "restart_pending",
+        "execution_target_version": "0.5.0",
+    }
+    runtime.update_state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    assert detect_post_update_state(runtime) is True
+
+    after = read_update_state(runtime)
+    assert after["just_updated_to"] == "0.5.0"
+    assert after["just_updated_release_notes"] == "Notes for 0.5.0"
+
+
+def test_detect_post_update_state_does_not_set_just_updated_to_on_failure(runtime, monkeypatch):
+    monkeypatch.setattr("core.update_state.__version__", "0.4.0")
+    state = {
+        "available": True,
+        "latest_version": "0.5.0",
+        "execution_state": "restart_pending",
+        "execution_target_version": "0.5.0",
+    }
+    runtime.update_state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    assert detect_post_update_state(runtime) is False
+
+    after = read_update_state(runtime)
+    assert after.get("just_updated_to") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a `just_updated_to` field to the post-update status payload so the frontend knows when an OTA update just landed
- Replaces the transient 15-second platform notice with a proper changelog modal that renders release notes as markdown via marked.js + DOMPurify
- Auto-opens the modal after a successful update (including first-boot auto-update); localStorage tracks acknowledged version to prevent re-showing
- Sources OTA release notes from per-release files in `docs/releases/` when publishing, falling back to the existing boilerplate template

Closes #199

## Test plan

- [x] 556 Python tests pass (`uv run python -m pytest tests/unit tests/api -q -n auto`)
- [x] 105 Playwright tests pass (`npx playwright test --reporter=dot --timeout=15000 --workers=75%`)
- [ ] Pi QA: trigger OTA update, verify modal renders markdown, dismiss, reload to confirm no re-open
- [ ] Pi QA: verify first-boot auto-update surfaces post-update changelog