### PR TITLE
chore(platform): isolate apps from base image and generalize app lifecycle

### DIFF
--- a/apps/chat/app.json
+++ b/apps/chat/app.json
@@ -8,5 +8,8 @@
   "ui_path": "assets/",
   "socket": "chat.sock",
   "inferno": true,
+  "routes": "routes.py",
+  "route_prefix": "",
+  "icon": "assets/icon.svg",
   "description": "Chat interface — the first Potato app"
 }

--- a/apps/chat/assets/icon.svg
+++ b/apps/chat/assets/icon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/chat/routes.py
+++ b/apps/chat/routes.py
@@ -26,18 +26,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Late-bound references set by main.py during app creation
-_build_status = None
-_get_status_download_context = None
-_forward_headers = None
-
-
-def register_chat_helpers(*, build_status, get_status_download_context, forward_headers):
-    global _build_status, _get_status_download_context, _forward_headers
-    _build_status = build_status
-    _get_status_download_context = get_status_download_context
-    _forward_headers = forward_headers
-
 
 @router.post("/v1/chat/completions")
 async def chat_completions(
@@ -64,6 +52,9 @@ async def chat_completions(
     await lock.acquire()
     released = False
     try:
+        _get_status_download_context = request.app.state.get_status_download_context
+        _build_status = request.app.state.build_status
+
         download_active, auto_start_remaining = await _get_status_download_context(request.app, runtime_cfg)
         status_payload = await _build_status(
             runtime_cfg,
@@ -90,7 +81,7 @@ async def chat_completions(
             payload,
             active_model_filename=str(status_payload.get("model", {}).get("filename") or ""),
         )
-        headers = _forward_headers(request)
+        headers = request.app.state.forward_headers(request)
         active_backend = status_payload["backend"]["active"]
 
         try:

--- a/apps/permitato/app.json
+++ b/apps/permitato/app.json
@@ -9,5 +9,7 @@
   "socket": "permitato.sock",
   "inferno": true,
   "routes": "routes.py",
+  "lifecycle": "lifecycle.py",
+  "icon": "assets/icon.svg",
   "description": "Conversational AI attention guard on Pi-hole"
 }

--- a/apps/permitato/assets/icon.svg
+++ b/apps/permitato/assets/icon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/permitato/install.sh
+++ b/apps/permitato/install.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Permitato infrastructure: install & configure Pi-hole v6
+# Called by install_dev.sh when Permitato is in POTATO_IMAGE_APPS.
+# Idempotent — safe to re-run.
+set -euo pipefail
+
+TARGET_ROOT="${POTATO_TARGET_ROOT:-/opt/potato}"
+POTATO_USER="${POTATO_USER:-potato}"
+POTATO_GROUP="${POTATO_GROUP:-potato}"
+
+# Detect active network interface for Pi-hole DNS binding
+_pihole_iface="$(ip route show default 2>/dev/null | awk '{print $5; exit}')"
+_pihole_iface="${_pihole_iface:-eth0}"
+
+if command -v pihole >/dev/null 2>&1; then
+  printf 'Pi-hole already installed — skipping install, applying configuration.\n'
+else
+  printf 'Installing Pi-hole v6 (unattended, interface=%s)...\n' "${_pihole_iface}"
+  mkdir -p /etc/pihole
+
+  pihole_vars_tmp="$(mktemp)"
+  cat > "${pihole_vars_tmp}" <<PIHOLE_VARS
+PIHOLE_INTERFACE=${_pihole_iface}
+PIHOLE_DNS_1=1.1.1.1
+PIHOLE_DNS_2=8.8.8.8
+QUERY_LOGGING=true
+INSTALL_WEB_SERVER=true
+INSTALL_WEB_INTERFACE=true
+BLOCKING_ENABLED=true
+DNSMASQ_LISTENING=local
+WEBPASSWORD=
+PIHOLE_VARS
+  install -m 0644 "${pihole_vars_tmp}" /etc/pihole/setupVars.conf
+  rm -f "${pihole_vars_tmp}"
+
+  pihole_installer_tmp="$(mktemp)"
+  curl -sSL https://install.pi-hole.net -o "${pihole_installer_tmp}"
+  bash "${pihole_installer_tmp}" --unattended
+  rm -f "${pihole_installer_tmp}"
+fi
+
+# Set web server to port 8081 (avoids conflict with llama-server on 8080)
+if command -v pihole-FTL >/dev/null 2>&1; then
+  pihole-FTL --config webserver.port 8081 || true
+fi
+
+# Generate app password if not already stored
+if [ ! -f "${TARGET_ROOT}/config/permitato_pihole_password" ]; then
+  pihole_pw="$(openssl rand -hex 16)"
+  pihole setpassword "${pihole_pw}" || true
+  pihole_pw_tmp="$(mktemp)"
+  printf '%s\n' "${pihole_pw}" > "${pihole_pw_tmp}"
+  install -m 0640 -o "${POTATO_USER}" -g "${POTATO_GROUP}" \
+    "${pihole_pw_tmp}" "${TARGET_ROOT}/config/permitato_pihole_password"
+  rm -f "${pihole_pw_tmp}"
+fi
+
+# Sudoers: let potato user manage pihole-FTL
+pihole_sudoers_tmp="$(mktemp)"
+cat > "${pihole_sudoers_tmp}" <<'SUDOERS'
+potato ALL=(root) NOPASSWD: /bin/systemctl restart pihole-FTL
+potato ALL=(root) NOPASSWD: /usr/bin/systemctl restart pihole-FTL
+potato ALL=(root) NOPASSWD: /bin/systemctl stop pihole-FTL
+potato ALL=(root) NOPASSWD: /usr/bin/systemctl stop pihole-FTL
+potato ALL=(root) NOPASSWD: /bin/systemctl start pihole-FTL
+potato ALL=(root) NOPASSWD: /usr/bin/systemctl start pihole-FTL
+SUDOERS
+install -m 0440 "${pihole_sudoers_tmp}" /etc/sudoers.d/potato-pihole
+rm -f "${pihole_sudoers_tmp}"
+
+systemctl restart pihole-FTL || true
+printf 'Pi-hole configured — web UI at http://localhost:8081/admin/\n'

--- a/apps/permitato/lifecycle.py
+++ b/apps/permitato/lifecycle.py
@@ -1,0 +1,75 @@
+"""Permitato app lifecycle hooks — called by platform during startup/shutdown."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from apps.permitato.state import initialize_permitato, shutdown_permitato
+
+logger = logging.getLogger(__name__)
+
+
+async def on_startup(app, app_dir: Path, data_dir: Path) -> None:
+    """Initialize Permitato: connect to Pi-hole, start expiry loop."""
+    app.state.permit_state = None
+    app.state.permit_expiry_task = None
+
+    pw_path = app.state.runtime.base_dir / "config" / "permitato_pihole_password"
+    if not pw_path.exists():
+        logger.info("Pi-hole password not found at %s — skipping Permitato init", pw_path)
+        return
+
+    pihole_pw = pw_path.read_text(encoding="utf-8").strip()
+    permit_data_dir = data_dir / "permitato"
+    app.state.permit_state = await initialize_permitato(
+        data_dir=permit_data_dir,
+        pihole_password=pihole_pw,
+    )
+
+    app.state.permit_expiry_task = asyncio.create_task(
+        _exception_expiry_loop(app),
+        name="permitato-expiry",
+    )
+
+
+async def on_shutdown(app) -> None:
+    """Shutdown Permitato: cancel expiry, disconnect adapter."""
+    expiry_task = getattr(app.state, "permit_expiry_task", None)
+    if expiry_task is not None:
+        expiry_task.cancel()
+        try:
+            await expiry_task
+        except asyncio.CancelledError:
+            pass
+
+    permit_state = getattr(app.state, "permit_state", None)
+    if permit_state is not None:
+        await shutdown_permitato(permit_state)
+
+
+async def _exception_expiry_loop(app) -> None:
+    """Background task: revoke expired exceptions every 30s."""
+    from apps.permitato.audit import write_audit_entry
+
+    while True:
+        await asyncio.sleep(30)
+        state = getattr(app.state, "permit_state", None)
+        if state and state.exception_store:
+            for exc in state.exception_store.get_expired():
+                if state.adapter and state.pihole_available:
+                    try:
+                        await state.adapter.delete_domain_rule(
+                            exc.regex_pattern, "allow", "regex",
+                        )
+                    except Exception:
+                        pass
+                write_audit_entry(state.data_dir, {
+                    "event": "exception_expired",
+                    "domain": exc.domain,
+                    "exception_id": exc.id,
+                })
+            revoked = state.exception_store.cleanup_expired()
+            if revoked:
+                state.exception_store.persist()

--- a/apps/permitato/tests/test_lifecycle.py
+++ b/apps/permitato/tests/test_lifecycle.py
@@ -1,0 +1,67 @@
+"""Tests for the Permitato app lifecycle hooks."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_on_startup_skips_when_no_password_file(tmp_path):
+    from apps.permitato import lifecycle
+
+    app = MagicMock()
+    app.state.runtime.base_dir = tmp_path  # no config/permitato_pihole_password
+    await lifecycle.on_startup(app, tmp_path / "apps" / "permitato", tmp_path / "data")
+    assert app.state.permit_state is None
+
+
+@pytest.mark.anyio
+async def test_on_startup_initializes_state(tmp_path, monkeypatch):
+    from apps.permitato import lifecycle
+
+    pw_dir = tmp_path / "config"
+    pw_dir.mkdir()
+    (pw_dir / "permitato_pihole_password").write_text("secret")
+
+    fake_state = MagicMock()
+    mock_init = AsyncMock(return_value=fake_state)
+    monkeypatch.setattr(lifecycle, "initialize_permitato", mock_init)
+    monkeypatch.setattr(asyncio, "create_task", lambda coro, **kw: (coro.close(), MagicMock())[1])
+
+    app = MagicMock()
+    app.state.runtime.base_dir = tmp_path
+
+    await lifecycle.on_startup(app, tmp_path / "apps" / "permitato", tmp_path / "data")
+
+    mock_init.assert_awaited_once()
+    assert app.state.permit_state == fake_state
+
+
+@pytest.mark.anyio
+async def test_on_shutdown_cleans_up(monkeypatch):
+    from apps.permitato import lifecycle
+
+    mock_shutdown = AsyncMock()
+    monkeypatch.setattr(lifecycle, "shutdown_permitato", mock_shutdown)
+
+    app = MagicMock()
+
+    class _FakeTask:
+        def __init__(self):
+            self.cancel_called = False
+        def cancel(self):
+            self.cancel_called = True
+        def __await__(self):
+            return asyncio.sleep(0).__await__()
+
+    task = _FakeTask()
+    app.state.permit_expiry_task = task
+    app.state.permit_state = MagicMock()
+
+    await lifecycle.on_shutdown(app)
+
+    assert task.cancel_called
+    mock_shutdown.assert_awaited_once_with(app.state.permit_state)

--- a/bin/install_dev.sh
+++ b/bin/install_dev.sh
@@ -168,9 +168,38 @@ normalize_runtime_dir_permissions
 
 run_sudo rsync -a "${REPO_ROOT}/core/" "${TARGET_ROOT}/core/"
 run_sudo rsync -a "${REPO_ROOT}/bin/" "${TARGET_ROOT}/bin/"
-if [ -d "${REPO_ROOT}/apps" ]; then
-  run_sudo rsync -a "${REPO_ROOT}/apps/" "${TARGET_ROOT}/apps/"
+# Deploy selected apps (default: chat only). Chat is always included —
+# /v1/chat/completions is a platform endpoint other apps depend on.
+POTATO_IMAGE_APPS="${POTATO_IMAGE_APPS:-chat}"
+IFS=',' read -ra _selected_apps <<< "${POTATO_IMAGE_APPS}"
+_has_chat=false
+for _a in "${_selected_apps[@]}"; do [ "$_a" = "chat" ] && _has_chat=true; done
+if [ "$_has_chat" = "false" ]; then
+  _selected_apps+=("chat")
 fi
+# Remove apps from a previous install that are no longer selected
+if [ -d "${TARGET_ROOT}/apps" ]; then
+  for _existing in "${TARGET_ROOT}/apps"/*/; do
+    [ -d "${_existing}" ] || continue
+    _ename="$(basename "${_existing}")"
+    _keep=false
+    for _a in "${_selected_apps[@]}"; do [ "$_a" = "$_ename" ] && _keep=true; done
+    [ "$_ename" = "skeleton" ] && _keep=true
+    if [ "$_keep" = "false" ]; then
+      run_sudo rm -rf "${_existing}"
+      printf 'Removed previously installed app: %s\n' "${_ename}"
+    fi
+  done
+fi
+for _app_name in "${_selected_apps[@]}"; do
+  _app_src="${REPO_ROOT}/apps/${_app_name}"
+  if [ -d "${_app_src}" ]; then
+    run_sudo mkdir -p "${TARGET_ROOT}/apps/${_app_name}"
+    run_sudo rsync -a "${_app_src}/" "${TARGET_ROOT}/apps/${_app_name}/"
+  else
+    printf 'WARNING: app directory not found: %s\n' "${_app_src}" >&2
+  fi
+done
 if [ -d "${REPO_ROOT}/nginx" ]; then
   run_sudo rsync -a "${REPO_ROOT}/nginx/" "${TARGET_ROOT}/nginx/"
 fi
@@ -211,80 +240,16 @@ fi
 run_sudo "${TARGET_ROOT}/venv/bin/pip" install --upgrade pip
 run_sudo "${TARGET_ROOT}/venv/bin/pip" install -r "${TARGET_ROOT}/core/requirements.txt"
 
-# --- Pi-hole v6 installation (Permitato infrastructure) ---
-# Pi-hole provides DNS-level blocking used by the Permitato app.
-# Install is guarded; configuration is always applied (idempotent upgrade path).
-
-# Detect active network interface for Pi-hole DNS binding
-_pihole_iface="$(ip route show default 2>/dev/null | awk '{print $5; exit}')"
-_pihole_iface="${_pihole_iface:-eth0}"
-
-if command -v pihole >/dev/null 2>&1; then
-  printf 'Pi-hole already installed — skipping install, applying configuration.\n'
-else
-  printf 'Installing Pi-hole v6 (unattended, interface=%s)...\n' "${_pihole_iface}"
-  run_sudo mkdir -p /etc/pihole
-
-  # Pre-seed setup variables for unattended install
-  pihole_vars_tmp="$(mktemp)"
-  cat > "${pihole_vars_tmp}" <<PIHOLE_VARS
-PIHOLE_INTERFACE=${_pihole_iface}
-PIHOLE_DNS_1=1.1.1.1
-PIHOLE_DNS_2=8.8.8.8
-QUERY_LOGGING=true
-INSTALL_WEB_SERVER=true
-INSTALL_WEB_INTERFACE=true
-BLOCKING_ENABLED=true
-DNSMASQ_LISTENING=local
-WEBPASSWORD=
-PIHOLE_VARS
-  run_sudo install -m 0644 "${pihole_vars_tmp}" /etc/pihole/setupVars.conf
-  rm -f "${pihole_vars_tmp}"
-
-  # Download installer to a temp file so stdin is free for run_sudo's PI_PASSWORD pipe
-  pihole_installer_tmp="$(mktemp)"
-  curl -sSL https://install.pi-hole.net -o "${pihole_installer_tmp}"
-  run_sudo bash "${pihole_installer_tmp}" --unattended
-  rm -f "${pihole_installer_tmp}"
-fi
-
-# --- Permitato configuration (always applied, idempotent) ---
-
-# Set web server to port 8081 (v6 defaults to 8080 which conflicts with llama-server).
-# Uses pihole-FTL --config to target only the webserver port, not the DNS port.
-if command -v pihole-FTL >/dev/null 2>&1; then
-  run_sudo pihole-FTL --config webserver.port 8081 || true
-fi
-
-# Generate app password if not already stored
-if [ ! -f "${TARGET_ROOT}/config/permitato_pihole_password" ]; then
-  pihole_pw="$(openssl rand -hex 16)"
-  run_sudo pihole setpassword "${pihole_pw}" || true
-  # Write password to a temp file then install it — avoids piping through run_sudo
-  # which consumes stdin for the PI_PASSWORD pipe in remote deploys.
-  pihole_pw_tmp="$(mktemp)"
-  printf '%s\n' "${pihole_pw}" > "${pihole_pw_tmp}"
-  run_sudo install -m 0640 -o "${POTATO_USER}" -g "${POTATO_GROUP}" \
-    "${pihole_pw_tmp}" "${TARGET_ROOT}/config/permitato_pihole_password"
-  rm -f "${pihole_pw_tmp}"
-fi
-
-# Sudoers: let potato user manage pihole-FTL (idempotent — overwrites on every run)
-pihole_sudoers_tmp="$(mktemp)"
-cat > "${pihole_sudoers_tmp}" <<'SUDOERS'
-potato ALL=(root) NOPASSWD: /bin/systemctl restart pihole-FTL
-potato ALL=(root) NOPASSWD: /usr/bin/systemctl restart pihole-FTL
-potato ALL=(root) NOPASSWD: /bin/systemctl stop pihole-FTL
-potato ALL=(root) NOPASSWD: /usr/bin/systemctl stop pihole-FTL
-potato ALL=(root) NOPASSWD: /bin/systemctl start pihole-FTL
-potato ALL=(root) NOPASSWD: /usr/bin/systemctl start pihole-FTL
-SUDOERS
-run_sudo install -m 0440 "${pihole_sudoers_tmp}" /etc/sudoers.d/potato-pihole
-rm -f "${pihole_sudoers_tmp}"
-
-run_sudo systemctl restart pihole-FTL || true
-printf 'Pi-hole configured — web UI at http://localhost:8081/admin/\n'
-# --- end Pi-hole ---
+# --- App-specific install hooks ---
+# Each app can provide install.sh for infrastructure setup (e.g., Pi-hole for Permitato).
+for _app_name in "${_selected_apps[@]}"; do
+  _app_installer="${TARGET_ROOT}/apps/${_app_name}/install.sh"
+  if [ -f "${_app_installer}" ]; then
+    printf 'Running install hook for app: %s\n' "${_app_name}"
+    POTATO_TARGET_ROOT="${TARGET_ROOT}" POTATO_USER="${POTATO_USER}" POTATO_GROUP="${POTATO_GROUP}" \
+      run_sudo bash "${_app_installer}"
+  fi
+done
 
 run_sudo chown -R "${POTATO_USER}:${POTATO_GROUP}" "${TARGET_ROOT}"
 normalize_runtime_dir_permissions

--- a/bin/prepare_imager_bundle.sh
+++ b/bin/prepare_imager_bundle.sh
@@ -149,7 +149,7 @@ trap 'rm -rf "\${tmpdir}"' EXIT
 tar -xzf "\${PAYLOAD}" -C "\${tmpdir}"
 
 cd "\${tmpdir}/payload/potato-os"
-PI_PASSWORD="\${PI_PASSWORD:-raspberry}" POTATO_LLAMA_BUNDLE_SRC="\${tmpdir}/payload/llama_bundle" ./bin/install_dev.sh
+PI_PASSWORD="\${PI_PASSWORD:-raspberry}" POTATO_LLAMA_BUNDLE_SRC="\${tmpdir}/payload/llama_bundle" POTATO_IMAGE_APPS="${POTATO_IMAGE_APPS:-chat}" ./bin/install_dev.sh
 
 touch "\${DONE_MARKER}"
 echo "[potato-bundle] complete: \$(date -Iseconds)"
@@ -244,6 +244,26 @@ rsync -a --delete \
   --exclude 'raspberry_os_clean_image' \
   --exclude 'references' \
   "${REPO_ROOT}/" "${payload_repo}/"
+
+# Remove non-selected apps from payload (default: chat only).
+# Chat is always kept — /v1/chat/completions is a platform endpoint.
+POTATO_IMAGE_APPS="${POTATO_IMAGE_APPS:-chat}"
+IFS=',' read -ra _selected_apps <<< "${POTATO_IMAGE_APPS}"
+if [ -d "${payload_repo}/apps" ]; then
+  for _app_dir in "${payload_repo}/apps"/*/; do
+    [ -d "${_app_dir}" ] || continue
+    _app_name="$(basename "${_app_dir}")"
+    _keep=false
+    for _a in "${_selected_apps[@]}"; do
+      [ "${_a}" = "${_app_name}" ] && _keep=true
+    done
+    [ "${_app_name}" = "chat" ] && _keep=true
+    [ "${_app_name}" = "skeleton" ] && _keep=true
+    if [ "${_keep}" = "false" ]; then
+      rm -rf "${_app_dir}"
+    fi
+  done
+fi
 
 rsync -a --delete "${bundle_src}/" "${payload_llama}/"
 

--- a/core/app_lifecycle.py
+++ b/core/app_lifecycle.py
@@ -1,0 +1,47 @@
+"""Dynamic lifecycle module loading for apps that declare lifecycle hooks."""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+try:
+    from core.app_manifest import AppManifest
+except ModuleNotFoundError:
+    from app_manifest import AppManifest  # type: ignore[no-redef]
+
+logger = logging.getLogger(__name__)
+
+
+def load_app_lifecycle(
+    manifest: AppManifest,
+    app_dir: Path,
+):
+    """Load an app's lifecycle module, or None if not declared."""
+    if not manifest.lifecycle:
+        return None
+
+    lifecycle_path = app_dir / manifest.lifecycle
+    if not lifecycle_path.is_file():
+        logger.warning("App %s declares lifecycle=%s but file not found: %s", manifest.id, manifest.lifecycle, lifecycle_path)
+        return None
+
+    try:
+        apps_parent = str(app_dir.parent.parent)
+        if apps_parent not in sys.path:
+            sys.path.insert(0, apps_parent)
+
+        spec = importlib.util.spec_from_file_location(f"app_{manifest.id}_lifecycle", lifecycle_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    except Exception:
+        logger.exception("Failed to load lifecycle for app %s from %s", manifest.id, lifecycle_path)
+        return None
+
+    if not hasattr(mod, "on_startup") or not hasattr(mod, "on_shutdown"):
+        logger.warning("App %s lifecycle module missing on_startup/on_shutdown: %s", manifest.id, lifecycle_path)
+        return None
+
+    return mod

--- a/core/app_manifest.py
+++ b/core/app_manifest.py
@@ -25,6 +25,9 @@ class AppManifest:
     inferno: bool = False
     description: str = ""
     routes: str = ""
+    lifecycle: str = ""
+    route_prefix: str | None = None
+    icon: str = ""
 
     @classmethod
     def from_file(cls, path: Path) -> AppManifest:
@@ -49,6 +52,9 @@ class AppManifest:
             inferno=bool(data.get("inferno", False)),
             description=str(data.get("description", "")),
             routes=str(data.get("routes", "")),
+            lifecycle=str(data.get("lifecycle", "")),
+            route_prefix=data.get("route_prefix"),
+            icon=str(data.get("icon", "")),
         )
 
     def validate(self) -> list[str]:

--- a/core/app_routes.py
+++ b/core/app_routes.py
@@ -30,7 +30,7 @@ def load_app_router(
 
     try:
         # Ensure the apps parent directory is importable so app modules can
-        # use absolute imports like `from apps.permitato.modes import ...`
+        # use absolute imports like `from apps.myapp.models import ...`
         apps_parent = str(app_dir.parent.parent)
         if apps_parent not in sys.path:
             sys.path.insert(0, apps_parent)
@@ -47,5 +47,8 @@ def load_app_router(
         logger.warning("App %s routes module has no 'router' attribute: %s", manifest.id, routes_path)
         return None
 
-    prefix = f"/app/{manifest.id}/api"
+    if manifest.route_prefix is not None:
+        prefix = manifest.route_prefix
+    else:
+        prefix = f"/app/{manifest.id}/api"
     return router, prefix

--- a/core/assets/index.html
+++ b/core/assets/index.html
@@ -108,18 +108,7 @@
       </div>
     </aside>
 
-    <nav id="appSwitcher" class="app-switcher" aria-label="App navigation">
-      <button class="app-switcher-btn active" data-app="chat" aria-label="Potato Chat" title="Potato Chat">
-        <svg class="app-switcher-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </button>
-      <button class="app-switcher-btn" data-app="permitato" aria-label="Permitato" title="Permitato">
-        <svg class="app-switcher-icon" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </button>
-    </nav>
+    <nav id="appSwitcher" class="app-switcher" aria-label="App navigation"></nav>
 
     <main class="chat-shell">
       <header class="chat-header">

--- a/core/assets/shell.js
+++ b/core/assets/shell.js
@@ -395,21 +395,62 @@ import { registerPlatformShell } from "./platform-controls.js";
       }, 2000);
     }
 
-    // --- Dynamic app switching ---
-    const APP_REGISTRY = {
-      chat: { module: "/app/chat/assets/app.js", title: "Potato Chat" },
-      permitato: { module: "/app/permitato/assets/app.js", title: "Permitato" },
-    };
+    // --- Dynamic app switching (built from /internal/apps) ---
+    let _appRegistry = {};
     let _activeAppId = null;
     let _activeAppModule = null;
     const _appWrappers = {};   // appId → persistent wrapper div (stays in DOM)
     const _appModules = {};    // appId → loaded module
     const shellApi = { pollStatus, setSidebarOpen, isMobileSidebarViewport, registerEscapeHandler, bindModelSwitcher };
 
+    async function _discoverApps() {
+      let uiApps = [{ id: "chat", name: "Potato Chat", icon: "/app/chat/assets/icon.svg" }];
+      try {
+        const resp = await fetch("/internal/apps");
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.ui_apps && data.ui_apps.length > 0) uiApps = data.ui_apps;
+        }
+      } catch { /* fallback to chat-only */ }
+
+      _appRegistry = {};
+      for (const a of uiApps) {
+        _appRegistry[a.id] = { module: `/app/${a.id}/assets/app.js`, title: a.name, icon: a.icon };
+      }
+      _buildSwitcher(uiApps);
+    }
+
+    function _buildSwitcher(uiApps) {
+      const nav = document.getElementById("appSwitcher");
+      if (!nav) return;
+      nav.innerHTML = "";
+      // Hide switcher when only one app is installed
+      nav.style.display = uiApps.length <= 1 ? "none" : "";
+      for (const a of uiApps) {
+        const btn = document.createElement("button");
+        btn.className = "app-switcher-btn" + (a.id === (_activeAppId || "chat") ? " active" : "");
+        btn.dataset.app = a.id;
+        btn.setAttribute("aria-label", a.name);
+        btn.title = a.name;
+        if (a.icon) {
+          const img = document.createElement("img");
+          img.src = a.icon;
+          img.className = "app-switcher-icon";
+          img.alt = "";
+          img.setAttribute("aria-hidden", "true");
+          btn.appendChild(img);
+        }
+        btn.addEventListener("click", () => {
+          if (a.id !== _activeAppId) switchApp(a.id);
+        });
+        nav.appendChild(btn);
+      }
+    }
+
     async function switchApp(appId) {
       const container = document.getElementById("appContainer");
       if (!container) return;
-      const entry = APP_REGISTRY[appId];
+      const entry = _appRegistry[appId];
       if (!entry) return;
 
       // Hide all app wrappers
@@ -451,25 +492,13 @@ import { registerPlatformShell } from "./platform-controls.js";
       }
     }
 
-    // Bind app switcher buttons and hide unavailable apps
-    document.querySelectorAll(".app-switcher-btn").forEach(btn => {
-      btn.addEventListener("click", () => {
-        const appId = btn.dataset.app;
-        if (appId && appId !== _activeAppId) switchApp(appId);
-      });
-      // Hide non-default apps whose assets aren't installed
-      const appId = btn.dataset.app;
-      if (appId && appId !== "chat" && APP_REGISTRY[appId]) {
-        fetch(APP_REGISTRY[appId].module, { method: "HEAD" }).then(r => {
-          if (!r.ok) btn.style.display = "none";
-        }).catch(() => { btn.style.display = "none"; });
-      }
-    });
-
-    // Load default app (chat), then start polling
+    // Discover apps, then load the first available UI app, then start polling
     const appContainer = document.getElementById("appContainer");
     if (appContainer) {
-      switchApp("chat").then(() => startPollingLoop()).catch(() => startPollingLoop());
+      _discoverApps().then(() => {
+        const defaultApp = Object.keys(_appRegistry)[0] || "chat";
+        return switchApp(defaultApp);
+      }).then(() => startPollingLoop()).catch(() => startPollingLoop());
     } else {
       startPollingLoop();
     }

--- a/core/main.py
+++ b/core/main.py
@@ -1676,54 +1676,39 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
                 name="potato-app-supervisor",
             )
 
-        # Permitato: init state + background expiry task
-        app.state.permit_state = None
-        app.state.permit_expiry_task = None
+        # App lifecycle hooks — discover and run on_startup for installed apps
         try:
-            # Ensure apps/ is importable (on Pi, cwd is core/ not repo root)
-            _apps_parent = str(Path(__file__).resolve().parent.parent)
-            if _apps_parent not in sys.path:
-                sys.path.insert(0, _apps_parent)
-            from apps.permitato.state import initialize_permitato, shutdown_permitato
-            pw_path = app.state.runtime.base_dir / "config" / "permitato_pihole_password"
-            if pw_path.exists():
-                pihole_pw = pw_path.read_text(encoding="utf-8").strip()
-                data_dir = app.state.runtime.base_dir / "data" / "permitato"
-                app.state.permit_state = await initialize_permitato(
-                    data_dir=data_dir,
-                    pihole_password=pihole_pw,
-                )
+            from core.app_manifest import discover_apps as _discover_apps_lifecycle
+            from core.app_lifecycle import load_app_lifecycle
+        except ModuleNotFoundError:
+            from app_manifest import discover_apps as _discover_apps_lifecycle  # type: ignore[no-redef]
+            from app_lifecycle import load_app_lifecycle  # type: ignore[no-redef]
 
-                async def _exception_expiry_loop():
-                    while True:
-                        await asyncio.sleep(30)
-                        state = app.state.permit_state
-                        if state and state.exception_store:
-                            # Revoke Pi-hole allow rules BEFORE removing from store
-                            for exc in state.exception_store.get_expired():
-                                if state.adapter and state.pihole_available:
-                                    try:
-                                        await state.adapter.delete_domain_rule(
-                                            exc.regex_pattern, "allow", "regex",
-                                        )
-                                    except Exception:
-                                        pass
-                                from apps.permitato.audit import write_audit_entry
-                                write_audit_entry(state.data_dir, {
-                                    "event": "exception_expired",
-                                    "domain": exc.domain,
-                                    "exception_id": exc.id,
-                                })
-                            revoked = state.exception_store.cleanup_expired()
-                            if revoked:
-                                state.exception_store.persist()
+        _apps_parent = str(Path(__file__).resolve().parent.parent)
+        if _apps_parent not in sys.path:
+            sys.path.insert(0, _apps_parent)
 
-                app.state.permit_expiry_task = asyncio.create_task(
-                    _exception_expiry_loop(),
-                    name="permitato-expiry",
-                )
-        except (ImportError, Exception) as exc:
-            logger.debug("Permitato init skipped: %s", exc)
+        _lifecycle_modules = []
+        _lc_seen_ids: set[str] = set()
+        _lc_repo_apps = Path(__file__).resolve().parent.parent / "apps"
+        _lc_runtime_apps = app.state.runtime.base_dir / "apps"
+        _lc_data_dir = app.state.runtime.base_dir / "data"
+        for _lc_apps_dir in (_lc_runtime_apps, _lc_repo_apps):
+            if not _lc_apps_dir.is_dir():
+                continue
+            for _lc_manifest in _discover_apps_lifecycle(_lc_apps_dir):
+                if _lc_manifest.id in _lc_seen_ids:
+                    continue
+                _lc_seen_ids.add(_lc_manifest.id)
+                _lc_app_dir = _lc_apps_dir / _lc_manifest.id
+                _lc_mod = load_app_lifecycle(_lc_manifest, _lc_app_dir)
+                if _lc_mod is not None:
+                    try:
+                        await _lc_mod.on_startup(app, _lc_app_dir, _lc_data_dir)
+                        _lifecycle_modules.append(_lc_mod)
+                    except Exception:
+                        logger.warning("App %s lifecycle startup failed", _lc_manifest.id, exc_info=True)
+        app.state._app_lifecycle_modules = _lifecycle_modules
 
         try:
             yield
@@ -1782,20 +1767,12 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
                 except asyncio.CancelledError:
                     pass
 
-            # Permitato shutdown
-            expiry_task = app.state.permit_expiry_task
-            if expiry_task is not None:
-                expiry_task.cancel()
+            # App lifecycle shutdown (reverse order)
+            for _lc_mod in reversed(getattr(app.state, "_app_lifecycle_modules", [])):
                 try:
-                    await expiry_task
-                except asyncio.CancelledError:
-                    pass
-            if app.state.permit_state is not None:
-                try:
-                    from apps.permitato.state import shutdown_permitato
-                    await shutdown_permitato(app.state.permit_state)
-                except (ImportError, Exception):
-                    pass
+                    await _lc_mod.on_shutdown(app)
+                except Exception:
+                    logger.warning("App lifecycle shutdown error", exc_info=True)
 
     try:
         from core.__version__ import __version__ as _app_version
@@ -1836,9 +1813,8 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
     if enable_orchestrator is not None:
         app.state.runtime.enable_orchestrator = enable_orchestrator
 
-    # Routes — extracted to app/routes/*.py
+    # Platform routes — app-specific routes loaded via app discovery below
     try:
-        from core.routes.chat import router as chat_router, register_chat_helpers
         from core.routes.settings import router as settings_router, register_settings_helpers
         from core.routes.status import router as status_router, register_status_helpers
         from core.routes.runtime import router as runtime_router, register_runtime_helpers
@@ -1847,7 +1823,6 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
         from core.routes.terminal import router as terminal_router, register_terminal_helpers
         from core.routes.apps import router as apps_router
     except ModuleNotFoundError:
-        from routes.chat import router as chat_router, register_chat_helpers  # type: ignore[no-redef]
         from routes.settings import router as settings_router, register_settings_helpers  # type: ignore[no-redef]
         from routes.status import router as status_router, register_status_helpers  # type: ignore[no-redef]
         from routes.runtime import router as runtime_router, register_runtime_helpers  # type: ignore[no-redef]
@@ -1856,11 +1831,11 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
         from routes.terminal import router as terminal_router, register_terminal_helpers  # type: ignore[no-redef]
         from routes.apps import router as apps_router  # type: ignore[no-redef]
 
-    register_chat_helpers(
-        build_status=build_status,
-        get_status_download_context=get_status_download_context,
-        forward_headers=_forward_headers,
-    )
+    # Platform helpers on app.state — used by chat routes (and any future app)
+    app.state.build_status = build_status
+    app.state.get_status_download_context = get_status_download_context
+    app.state.forward_headers = _forward_headers
+
     register_settings_helpers(
         restart_managed_llama_process=restart_managed_llama_process,
     )
@@ -1871,7 +1846,6 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
     register_models_helpers(main_module=_this_module)
     register_update_helpers(main_module=_this_module)
     register_terminal_helpers()
-    app.include_router(chat_router)
     app.include_router(settings_router)
     app.include_router(status_router)
     app.include_router(runtime_router)
@@ -1893,6 +1867,7 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
     _repo_apps = Path(__file__).resolve().parent.parent / "apps"
     _runtime_apps = app.state.runtime.base_dir / "apps"
     _mounted_app_ids: set[str] = set()
+    _discovered_ui_apps: list[dict] = []
     for apps_dir in (_runtime_apps, _repo_apps):
         if not apps_dir.is_dir():
             continue
@@ -1914,7 +1889,23 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
                         StaticFiles(directory=str(app_assets_dir)),
                         name=f"app-{manifest.id}",
                     )
+                if manifest.icon:
+                    icon_file = manifest.icon.split("/")[-1]
+                    _discovered_ui_apps.append({
+                        "id": manifest.id,
+                        "name": manifest.name,
+                        "has_ui": True,
+                        "icon": f"/app/{manifest.id}/assets/{icon_file}",
+                    })
+                else:
+                    _discovered_ui_apps.append({
+                        "id": manifest.id,
+                        "name": manifest.name,
+                        "has_ui": True,
+                        "icon": "",
+                    })
             _mounted_app_ids.add(manifest.id)
+    app.state.discovered_ui_apps = _discovered_ui_apps
 
     return app
 

--- a/core/routes/apps.py
+++ b/core/routes/apps.py
@@ -10,6 +10,7 @@ router = APIRouter()
 @router.get("/internal/apps")
 async def list_apps(request: Request):
     instances = getattr(request.app.state, "app_instances", {})
+    ui_apps = getattr(request.app.state, "discovered_ui_apps", [])
     return {
         "apps": [
             {
@@ -24,4 +25,5 @@ async def list_apps(request: Request):
             }
             for inst in instances.values()
         ],
+        "ui_apps": ui_apps,
     }

--- a/image/lib/common.sh
+++ b/image/lib/common.sh
@@ -166,9 +166,19 @@ build_stage_payload() {
 
   rsync -a "${repo_root}/core/" "${potato_root}/core/"
   rsync -a "${repo_root}/bin/" "${potato_root}/bin/"
-  if [ -d "${repo_root}/apps" ]; then
-    rsync -a "${repo_root}/apps/" "${potato_root}/apps/"
-  fi
+  # Deploy selected apps (default: chat only).
+  # Chat is always included — /v1/chat/completions is a platform endpoint.
+  local _img_apps="${POTATO_IMAGE_APPS:-chat}"
+  IFS=',' read -ra _sel_apps <<< "${_img_apps}"
+  local _has_chat=false
+  for _a in "${_sel_apps[@]}"; do [ "$_a" = "chat" ] && _has_chat=true; done
+  if [ "$_has_chat" = "false" ]; then _sel_apps+=("chat"); fi
+  for _app_name in "${_sel_apps[@]}"; do
+    if [ -d "${repo_root}/apps/${_app_name}" ]; then
+      mkdir -p "${potato_root}/apps/${_app_name}"
+      rsync -a "${repo_root}/apps/${_app_name}/" "${potato_root}/apps/${_app_name}/"
+    fi
+  done
   rsync -a "${repo_root}/systemd/" "${potato_root}/systemd/"
   rsync -a "${repo_root}/nginx/" "${potato_root}/nginx/"
   install -m 0644 "${repo_root}/requirements.txt" "${potato_root}/core/requirements.txt"

--- a/tests/api/test_apps.py
+++ b/tests/api/test_apps.py
@@ -7,6 +7,8 @@ def test_internal_apps_returns_empty_list_when_no_apps(client):
     body = response.json()
     assert "apps" in body
     assert isinstance(body["apps"], list)
+    assert "ui_apps" in body
+    assert isinstance(body["ui_apps"], list)
 
 
 def test_internal_apps_returns_discovered_app(client, runtime, monkeypatch):

--- a/tests/unit/test_app_routes.py
+++ b/tests/unit/test_app_routes.py
@@ -155,3 +155,92 @@ def test_load_app_router_returns_none_when_file_missing(tmp_path):
     )
     result = load_app_router(manifest, app_dir)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# route_prefix — None vs empty string matters
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_route_prefix_none_by_default():
+    from core.app_manifest import AppManifest
+
+    manifest = AppManifest(id="t", name="T", entry="main.py")
+    assert manifest.route_prefix is None
+
+
+def test_manifest_route_prefix_parses_empty_string(tmp_path):
+    import json
+    from core.app_manifest import AppManifest
+
+    p = tmp_path / "app.json"
+    p.write_text(json.dumps({"id": "t", "name": "T", "entry": "main.py", "route_prefix": ""}))
+    m = AppManifest.from_file(p)
+    assert m.route_prefix == ""
+
+
+def test_load_app_router_uses_custom_prefix(tmp_path):
+    from core.app_manifest import AppManifest
+    from core.app_routes import load_app_router
+
+    app_dir = tmp_path / "apps" / "myapp"
+    app_dir.mkdir(parents=True)
+    (app_dir / "routes.py").write_text(
+        "from fastapi import APIRouter\nrouter = APIRouter()\n"
+    )
+    manifest = AppManifest(id="myapp", name="My", entry="main.py", routes="routes.py", route_prefix="")
+    _, prefix = load_app_router(manifest, app_dir)
+    assert prefix == ""
+
+
+def test_load_app_router_uses_default_prefix_when_none(tmp_path):
+    from core.app_manifest import AppManifest
+    from core.app_routes import load_app_router
+
+    app_dir = tmp_path / "apps" / "myapp"
+    app_dir.mkdir(parents=True)
+    (app_dir / "routes.py").write_text(
+        "from fastapi import APIRouter\nrouter = APIRouter()\n"
+    )
+    manifest = AppManifest(id="myapp", name="My", entry="main.py", routes="routes.py")
+    _, prefix = load_app_router(manifest, app_dir)
+    assert prefix == "/app/myapp/api"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle module loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_app_lifecycle_returns_module(tmp_path):
+    from core.app_manifest import AppManifest
+    from core.app_lifecycle import load_app_lifecycle
+
+    app_dir = tmp_path / "apps" / "myapp"
+    app_dir.mkdir(parents=True)
+    (app_dir / "lifecycle.py").write_text(
+        "async def on_startup(app, app_dir, data_dir): pass\n"
+        "async def on_shutdown(app): pass\n"
+    )
+    manifest = AppManifest(id="myapp", name="My", entry="main.py", lifecycle="lifecycle.py")
+    mod = load_app_lifecycle(manifest, app_dir)
+    assert mod is not None
+    assert hasattr(mod, "on_startup")
+    assert hasattr(mod, "on_shutdown")
+
+
+def test_load_app_lifecycle_returns_none_when_not_declared():
+    from core.app_manifest import AppManifest
+    from core.app_lifecycle import load_app_lifecycle
+    from pathlib import Path
+
+    manifest = AppManifest(id="t", name="T", entry="main.py")
+    assert load_app_lifecycle(manifest, Path("/nonexistent")) is None
+
+
+def test_load_app_lifecycle_returns_none_when_file_missing(tmp_path):
+    from core.app_manifest import AppManifest
+    from core.app_lifecycle import load_app_lifecycle
+
+    manifest = AppManifest(id="t", name="T", entry="main.py", lifecycle="lifecycle.py")
+    assert load_app_lifecycle(manifest, tmp_path) is None

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -1144,101 +1144,68 @@ printf '%s\\n' "$@" > "$ARGS_OUT"
 # ---------------------------------------------------------------------------
 
 
-def test_install_dev_pihole_install_is_guarded():
+# ---------------------------------------------------------------------------
+# Selective app deployment
+# ---------------------------------------------------------------------------
+
+_PERMITATO_INSTALL_SH = REPO_ROOT / "apps" / "permitato" / "install.sh"
+
+
+def test_install_dev_uses_selective_app_deployment():
+    """install_dev.sh must deploy apps selectively via POTATO_IMAGE_APPS."""
+    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
+    assert "POTATO_IMAGE_APPS" in script
+    assert "_selected_apps" in script
+
+
+def test_install_dev_runs_app_install_hooks():
+    """install_dev.sh must run apps/{app}/install.sh for each selected app."""
+    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
+    assert "install.sh" in script
+    assert "_app_installer" in script or "install.sh" in script
+
+
+def test_permitato_install_script_exists():
+    assert _PERMITATO_INSTALL_SH.exists()
+    assert _PERMITATO_INSTALL_SH.stat().st_mode & 0o111  # executable
+
+
+def test_permitato_install_pihole_is_guarded():
     """Pi-hole install must be guarded so it skips when pihole is already present."""
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
-    assert "command -v pihole" in script, (
-        "install_dev.sh must check 'command -v pihole' to skip re-install"
-    )
+    script = _PERMITATO_INSTALL_SH.read_text(encoding="utf-8")
+    assert "command -v pihole" in script
 
 
-def test_install_dev_pihole_has_marked_section():
-    """Pi-hole section must be clearly delimited for maintenance."""
+def test_permitato_install_config_runs_on_rerun():
+    """Port, password, sudoers must apply even if Pi-hole is already installed."""
     import re
 
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
-    pihole_section = re.search(
-        r"# --- Pi-hole.*?# --- end Pi-hole",
-        script,
-        re.DOTALL | re.IGNORECASE,
-    )
-    assert pihole_section, "install_dev.sh must have a marked Pi-hole section"
-
-
-def test_install_dev_pihole_config_runs_on_rerun():
-    """Permitato config (port, password, sudoers) must apply even if Pi-hole is already installed."""
-    import re
-
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
-    pihole_section = re.search(
-        r"# --- Pi-hole.*?# --- end Pi-hole",
-        script,
-        re.DOTALL | re.IGNORECASE,
-    )
-    assert pihole_section
-    section = pihole_section.group(0)
-    # Port config and sudoers must be outside the install guard
-    # (i.e., they run even when 'command -v pihole' succeeds)
-    install_guard = re.search(r"if command -v pihole.*?fi", section, re.DOTALL)
+    script = _PERMITATO_INSTALL_SH.read_text(encoding="utf-8")
+    install_guard = re.search(r"if command -v pihole.*?fi", script, re.DOTALL)
     assert install_guard
-    after_guard = section[install_guard.end():]
-    assert "8081" in after_guard, "Port config must run outside the install guard"
-    assert "sudoers" in after_guard.lower(), "Sudoers must run outside the install guard"
+    after_guard = script[install_guard.end():]
+    assert "8081" in after_guard
+    assert "sudoers" in after_guard.lower()
 
 
-def test_install_dev_pihole_uses_scoped_port_config():
-    """Pi-hole port must be set via pihole-FTL --config, not a blanket sed on pihole.toml."""
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
-    assert "pihole-FTL --config webserver.port" in script, (
-        "Must use pihole-FTL --config to set webserver port (not sed)"
-    )
+def test_permitato_install_uses_scoped_port_config():
+    script = _PERMITATO_INSTALL_SH.read_text(encoding="utf-8")
+    assert "pihole-FTL --config webserver.port" in script
     assert "8081" in script
 
 
-def test_install_dev_pihole_detects_interface():
-    """Pi-hole interface must be detected, not hardcoded to eth0."""
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
-    assert "ip route show default" in script, (
-        "Must detect active interface from default route"
-    )
+def test_permitato_install_detects_interface():
+    script = _PERMITATO_INSTALL_SH.read_text(encoding="utf-8")
+    assert "ip route show default" in script
 
 
-def test_install_dev_pihole_downloads_installer_to_file():
-    """Installer must be downloaded to a temp file so stdin is free for PI_PASSWORD."""
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
-    # Must not pipe curl to bash /dev/stdin (breaks when run_sudo consumes stdin)
-    assert "bash /dev/stdin" not in script, (
-        "Must not pipe installer via stdin — breaks with PI_PASSWORD"
-    )
-    assert "curl -sSL https://install.pi-hole.net -o" in script, (
-        "Must download installer to a temp file"
-    )
+def test_permitato_install_downloads_installer_to_file():
+    script = _PERMITATO_INSTALL_SH.read_text(encoding="utf-8")
+    assert "bash /dev/stdin" not in script
+    assert "curl -sSL https://install.pi-hole.net -o" in script
 
 
-def test_install_dev_pihole_stores_app_password():
-    """Pi-hole app password must be stored for Permitato to read."""
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
+def test_permitato_install_stores_app_password():
+    script = _PERMITATO_INSTALL_SH.read_text(encoding="utf-8")
     assert "permitato_pihole_password" in script
-
-
-def test_install_dev_pihole_no_stdin_pipes_through_run_sudo():
-    """No data should be piped into run_sudo in the Pi-hole section.
-
-    run_sudo uses 'printf PI_PASSWORD | sudo -S' in remote deploys, which
-    consumes stdin. Piping data through run_sudo (e.g., printf | run_sudo tee)
-    silently loses the data. Write to temp files instead.
-    """
-    import re
-
-    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
-    pihole_section = re.search(
-        r"# --- Pi-hole.*?# --- end Pi-hole",
-        script,
-        re.DOTALL | re.IGNORECASE,
-    )
-    assert pihole_section
-    section = pihole_section.group(0)
-    assert "| run_sudo" not in section, (
-        "Do not pipe data through run_sudo — stdin is consumed by PI_PASSWORD"
-    )
 


### PR DESCRIPTION
## Summary

- Generalize app lifecycle hooks — apps declare `lifecycle` in `app.json`, platform discovers and calls `on_startup`/`on_shutdown` dynamically. Zero app-specific imports in `core/`.
- Move Chat backend from `core/routes/chat.py` to `apps/chat/routes.py` using app-provided routes with `route_prefix: ""` for root mounting.
- Build app switcher dynamically from `/internal/apps` API — no hardcoded HTML buttons or JS registry. Switcher auto-hides when only one UI app is installed.
- Selective app deployment via `POTATO_IMAGE_APPS` env var (default: `chat`). Pi-hole setup extracted into `apps/permitato/install.sh`.

Closes #217

## Test plan

- [x] 599 unit+API tests passing
- [x] 46 app-colocated tests passing
- [x] 106 Playwright UI tests passing
- [x] `grep -r "from apps\." core/` returns zero results
- [x] Pi QA: deploy, restart, `/status` READY, chat completions 200
- [x] Pi QA: remove `apps/permitato/` → service stays READY, sidebar hidden
- [x] Pi QA: restore `apps/permitato/` → both icons return after restart