### PR TITLE
fix(permitato): harden Pi-hole recovery, persistence, and exception consistency

### DIFF
--- a/apps/permitato/audit.py
+++ b/apps/permitato/audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 
@@ -29,3 +30,19 @@ def read_audit_log(data_dir: Path, limit: int = 100) -> list[dict]:
         except json.JSONDecodeError:
             continue
     return entries
+
+
+def rotate_audit_log(data_dir: Path, max_lines: int = 5000) -> int:
+    """Rotate audit log, keeping the last max_lines entries. Returns lines removed."""
+    log_path = data_dir / "audit.jsonl"
+    if not log_path.exists():
+        return 0
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    if len(lines) <= max_lines:
+        return 0
+    removed = len(lines) - max_lines
+    kept = "\n".join(lines[-max_lines:]) + "\n"
+    tmp = log_path.with_suffix(".jsonl.tmp")
+    tmp.write_text(kept, encoding="utf-8")
+    os.replace(str(tmp), str(log_path))
+    return removed

--- a/apps/permitato/exceptions.py
+++ b/apps/permitato/exceptions.py
@@ -17,6 +17,9 @@ _DOMAIN_RE = re.compile(r"^[\w][\w.-]*\.[\w]{2,}$")
 
 def build_domain_regex(domain: str) -> str:
     """Build a Pi-hole regex that matches domain and all subdomains."""
+    # Reject control characters and non-space whitespace before cleanup
+    if any(c in domain for c in "\n\r\t"):
+        raise ValueError(f"Invalid domain: {domain!r}")
     domain = domain.strip().lower()
     if not domain or "." not in domain or not _DOMAIN_RE.match(domain):
         raise ValueError(f"Invalid domain: {domain!r}")
@@ -96,13 +99,14 @@ class ExceptionStore:
         return [exc.to_dict() for exc in self._exceptions.values()]
 
     def persist(self) -> None:
-        self.data_dir.mkdir(parents=True, exist_ok=True)
+        from apps.permitato.state import atomic_write
+
         path = self.data_dir / "exceptions.json"
         data = {
             "version": 1,
             "exceptions": {eid: exc.to_dict() for eid, exc in self._exceptions.items()},
         }
-        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        atomic_write(path, json.dumps(data, indent=2))
 
     def load(self) -> None:
         path = self.data_dir / "exceptions.json"

--- a/apps/permitato/lifecycle.py
+++ b/apps/permitato/lifecycle.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from apps.permitato.state import initialize_permitato, shutdown_permitato
+from apps.permitato.state import initialize_permitato, shutdown_permitato, reconnect_pihole
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +32,22 @@ async def on_startup(app, app_dir: Path, data_dir: Path) -> None:
         _exception_expiry_loop(app),
         name="permitato-expiry",
     )
+    app.state.permit_reconnect_task = asyncio.create_task(
+        _pihole_reconnection_loop(app),
+        name="permitato-reconnect",
+    )
 
 
 async def on_shutdown(app) -> None:
-    """Shutdown Permitato: cancel expiry, disconnect adapter."""
-    expiry_task = getattr(app.state, "permit_expiry_task", None)
-    if expiry_task is not None:
-        expiry_task.cancel()
-        try:
-            await expiry_task
-        except asyncio.CancelledError:
-            pass
+    """Shutdown Permitato: cancel background tasks, disconnect adapter."""
+    for attr in ("permit_expiry_task", "permit_reconnect_task"):
+        task = getattr(app.state, attr, None)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     permit_state = getattr(app.state, "permit_state", None)
     if permit_state is not None:
@@ -73,3 +78,17 @@ async def _exception_expiry_loop(app) -> None:
             revoked = state.exception_store.cleanup_expired()
             if revoked:
                 state.exception_store.persist()
+
+
+async def _pihole_reconnection_loop(app) -> None:
+    """Background task: attempt Pi-hole reconnection every 60s when degraded."""
+    from apps.permitato.audit import write_audit_entry
+
+    while True:
+        await asyncio.sleep(60)
+        state = getattr(app.state, "permit_state", None)
+        if state and not state.pihole_available:
+            was_degraded = not state.pihole_available
+            await reconnect_pihole(state)
+            if was_degraded and state.pihole_available:
+                write_audit_entry(state.data_dir, {"event": "pihole_recovered"})

--- a/apps/permitato/permitato-readme.md
+++ b/apps/permitato/permitato-readme.md
@@ -1,0 +1,87 @@
+# Permitato Milestone Plan
+
+Productize Permitato from a working pilot into a durable daily-driver attention guard.
+Epic: #219 | Milestone: [Permitato](https://github.com/slomin/potato-os/milestone/8)
+
+## Execution Phases
+
+### Phase 1: Foundation
+
+These two tickets fix the ground everything else builds on. Sequential — #222 uses the hardened persistence from #221.
+
+| Order | Ticket | Summary | Key files |
+|-------|--------|---------|-----------|
+| 1 | **#221** | Harden Pi-hole recovery, persistence, exception consistency | `state.py`, `exceptions.py`, `audit.py`, `lifecycle.py`, `pihole_adapter.py` |
+| 2 | **#222** | Install and controlled-client onboarding flow | `routes.py`, `state.py`, `assets/*`, new onboarding UI |
+
+**#221 in detail** (first ticket):
+- Atomic writes for `state.json` and `exceptions.json` (write-tmp + `os.replace`)
+- Pi-hole reconnection loop in `lifecycle.py` (60s interval, re-seeds groups on recovery)
+- Exception-to-Pi-hole compensation after reconnection (needs new `get_domain_rules()` on adapter)
+- Audit log rotation in `audit.py` (keep last N lines, atomic rewrite)
+- Hardened domain validation in `exceptions.py`
+- `degraded_since` timestamp on `PermitState` surfaced in `/status`
+
+**#222 in detail:**
+- Client discovery endpoint using existing `adapter.get_clients()`
+- First-run onboarding modal when `client_id` is empty
+- Selected-client validation on startup (check it still exists in Pi-hole)
+- Recovery flow when saved client disappears
+
+### Phase 2: UX Polish
+
+These two are independent — can run in parallel or either order.
+
+| Order | Ticket | Summary | Key files |
+|-------|--------|---------|-----------|
+| 3 | **#223** | Active exceptions panel with TTL and revoke controls | `assets/permitato.html`, `assets/permitato.js`, `assets/permitato.css` |
+| 4 | **#226** | User-defined domain lists per mode | `modes.py`, `state.py`, `routes.py`, new custom-lists UI |
+
+### Phase 3: Intelligence
+
+Both read from `audit.jsonl` — independent of each other but benefit from #221's rotation.
+
+| Order | Ticket | Summary | Key files |
+|-------|--------|---------|-----------|
+| 5 | **#224** | Smart unblock negotiation with recent audit context | `system_prompt.py`, `audit.py` (backend only) |
+| 6 | **#225** | Attention stats and streaks from audit history | New stats module, `routes.py`, `assets/*` |
+
+### Phase 4: Orchestration
+
+Largest feature — touches state, UI, persistence, and background tasks. Goes last so everything it integrates with is stable.
+
+| Order | Ticket | Summary | Key files |
+|-------|--------|---------|-----------|
+| 7 | **#220** | Scheduled modes and manual override | New `schedule.py`, `lifecycle.py`, `state.py`, `routes.py`, schedule UI |
+
+## Dependency Graph
+
+```
+#221 (harden)
+  ├──> #222 (onboarding)
+  │      ├──> #223 (exceptions panel)
+  │      └──> #226 (custom domain lists)
+  ├──> #224 (smart context)
+  ├──> #225 (stats/streaks)
+  └──────────────────────────> #220 (scheduling) ──> #219 epic done
+                                                      (also needs #166 LAN auth)
+```
+
+## Recurring Patterns
+
+- **Atomic writes**: Extract `atomic_write(path, data)` helper in #221, reuse in every ticket that persists state
+- **Pi-hole adapter**: #221 adds `get_domain_rules()`, #226 reuses it for custom list management
+- **UI panels**: Each feature adds a `<section>` to `permitato.html` — exceptions panel, stats panel, custom lists, schedule editor, onboarding modal
+- **Audit reads**: #224 and #225 both build summaries from `audit.jsonl` — coordinate the read helpers
+- **Test infra**: No API/routes tests or Playwright tests exist yet — build the fixtures in #221, reuse everywhere
+
+## Notes
+
+- **#166 (LAN auth)** is in Inbox, not started. It's a soft dependency for epic completion (security gate) but doesn't block any individual ticket.
+- **#227** was a duplicate of #226 and has been closed.
+- All tickets follow TDD-first per WORKFLOW.md.
+- Each ticket gets its own branch: `feat/issue-<id>-<slug>` or `fix/issue-<id>-<slug>`.
+
+---
+
+> **Cleanup**: Delete this file once the Permitato milestone is complete. It's a coordination artifact, not documentation.

--- a/apps/permitato/pihole_adapter.py
+++ b/apps/permitato/pihole_adapter.py
@@ -112,6 +112,10 @@ class PiholeAdapter:
         )
         return resp.json()
 
+    async def get_domain_rules(self, rule_type: str, kind: str) -> list[dict]:
+        resp = await self._request("GET", f"/domains/{rule_type}/{kind}")
+        return resp.json().get("domains", [])
+
     async def delete_domain_rule(self, domain: str, rule_type: str, kind: str) -> None:
         await self._request("DELETE", f"/domains/{rule_type}/{kind}/{quote(domain, safe='')}")
 

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -45,6 +45,7 @@ async def permitato_status(request: Request):
         "active_exceptions": state.exception_store.active_count() if state.exception_store else 0,
         "exceptions": state.exception_store.list_active() if state.exception_store else [],
         "pihole_available": state.pihole_available,
+        "degraded_since": state.degraded_since,
         "client_id": state.client_id,
     }
 

--- a/apps/permitato/state.py
+++ b/apps/permitato/state.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -12,6 +14,14 @@ from apps.permitato.modes import MODES, get_mode, WORK_DENY_DOMAINS, SFW_DENY_DO
 from apps.permitato.pihole_adapter import PiholeAdapter, PiholeUnavailableError
 
 logger = logging.getLogger(__name__)
+
+
+def atomic_write(path: Path, data: str) -> None:
+    """Write data to path atomically via tmp + os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(data, encoding="utf-8")
+    os.replace(str(tmp), str(path))
 
 
 @dataclass
@@ -23,16 +33,16 @@ class PermitState:
     group_map: dict = field(default_factory=dict)
     exception_group_id: int = 0
     pihole_available: bool = False
+    degraded_since: float | None = None
     data_dir: Path = field(default_factory=lambda: Path("/opt/potato/data/permitato"))
 
     def persist(self) -> None:
-        self.data_dir.mkdir(parents=True, exist_ok=True)
         path = self.data_dir / "state.json"
-        path.write_text(json.dumps({
+        atomic_write(path, json.dumps({
             "version": 1,
             "mode": self.mode,
             "client_id": self.client_id,
-        }, indent=2), encoding="utf-8")
+        }, indent=2))
 
     def load(self) -> None:
         path = self.data_dir / "state.json"
@@ -85,6 +95,7 @@ async def initialize_permitato(
 
     except PiholeUnavailableError:
         state.pihole_available = False
+        state.degraded_since = time.time()
         logger.warning("Pi-hole unavailable at %s — running in degraded mode", pihole_base_url)
 
     return state
@@ -170,3 +181,78 @@ async def apply_mode_to_client(state: PermitState) -> None:
             await state.adapter.add_client(state.client_id, groups)
         except Exception:
             logger.warning("Failed to set client groups for %s", state.client_id, exc_info=True)
+
+
+async def reconnect_pihole(state: PermitState) -> None:
+    """Attempt to reconnect to Pi-hole if currently degraded."""
+    if state.pihole_available or not state.adapter:
+        return
+
+    try:
+        await state.adapter.connect()
+    except PiholeUnavailableError:
+        return
+
+    # Connected — but don't mark healthy until full recovery completes
+    try:
+        state.group_map = await _ensure_groups(state.adapter)
+        state.exception_group_id = state.group_map.get("permitato_exceptions", 0)
+        await _seed_domain_lists(state.adapter, state.group_map)
+        await compensate_exceptions(state)
+    except Exception:
+        logger.warning("Pi-hole connected but recovery failed — staying degraded", exc_info=True)
+        return
+
+    state.pihole_available = True
+    state.degraded_since = None
+    logger.info("Pi-hole connection recovered")
+
+    # Reapply mode to client now that we're healthy
+    await apply_mode_to_client(state)
+
+
+async def compensate_exceptions(state: PermitState) -> None:
+    """Reconcile local exception store with Pi-hole allow rules."""
+    if not state.adapter or not state.exception_store:
+        return
+
+    exc_gid = state.exception_group_id
+    if not exc_gid:
+        return
+
+    # What Pi-hole currently has — filtered to Permitato-owned rules only
+    all_rules = await state.adapter.get_domain_rules("allow", "regex")
+    pihole_rules = [
+        r for r in all_rules
+        if exc_gid in r.get("groups", [])
+        and r.get("comment", "").startswith("Permitato:")
+    ]
+    pihole_domains = {r["domain"] for r in pihole_rules}
+
+    # What we expect to be there
+    local_exceptions = state.exception_store.list_active()
+    local_patterns = {exc["regex_pattern"] for exc in local_exceptions}
+
+    # Re-add missing rules
+    for exc in local_exceptions:
+        if exc["regex_pattern"] not in pihole_domains:
+            try:
+                await state.adapter.add_domain_rule(
+                    domain=exc["regex_pattern"],
+                    rule_type="allow",
+                    kind="regex",
+                    groups=[exc_gid],
+                    comment=f"Permitato: {exc.get('reason', '')}",
+                )
+                logger.info("Compensation: re-added missing allow rule for %s", exc["domain"])
+            except Exception:
+                logger.warning("Compensation: failed to re-add rule for %s", exc["domain"])
+
+    # Remove orphaned Permitato rules
+    for rule in pihole_rules:
+        if rule["domain"] not in local_patterns:
+            try:
+                await state.adapter.delete_domain_rule(rule["domain"], "allow", "regex")
+                logger.info("Compensation: removed orphaned allow rule %s", rule["domain"])
+            except Exception:
+                logger.warning("Compensation: failed to remove orphaned rule %s", rule["domain"])

--- a/apps/permitato/tests/test_hardening.py
+++ b/apps/permitato/tests/test_hardening.py
@@ -1,0 +1,482 @@
+"""Tests for Permitato hardening — atomic writes, reconnection, compensation, rotation."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import respx
+from httpx import Response
+
+
+# ---------------------------------------------------------------------------
+# Atomic persistence — corruption resistance via write-tmp + os.replace
+# ---------------------------------------------------------------------------
+
+
+def test_state_persist_does_not_corrupt_on_replace_failure(tmp_path):
+    from apps.permitato.state import PermitState
+
+    # Write valid state first
+    state = PermitState(data_dir=tmp_path, mode="work", client_id="10.0.0.1")
+    state.persist()
+
+    # Now try to persist with os.replace failing
+    state.mode = "sfw"
+    with patch("os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError):
+            state.persist()
+
+    # Original file should still be intact
+    path = tmp_path / "state.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["mode"] == "work"
+
+
+def test_exception_persist_does_not_corrupt_on_replace_failure(tmp_path):
+    from apps.permitato.exceptions import ExceptionStore
+
+    store = ExceptionStore(data_dir=tmp_path)
+    store.grant("twitter.com", "DMs", ttl_seconds=3600)
+    store.persist()
+
+    # Grant another and fail the write
+    store.grant("reddit.com", "research", ttl_seconds=1800)
+    with patch("os.replace", side_effect=OSError("disk full")):
+        with pytest.raises(OSError):
+            store.persist()
+
+    # Original file should have only 1 exception
+    store2 = ExceptionStore(data_dir=tmp_path)
+    store2.load()
+    assert store2.active_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Pi-hole reconnection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reconnect_recovers_from_degraded(tmp_path):
+    from apps.permitato.state import PermitState, reconnect_pihole
+
+    adapter = AsyncMock()
+    adapter.connect = AsyncMock()
+    adapter.get_groups = AsyncMock(return_value=[
+        {"name": "permitato_work", "id": 1},
+        {"name": "permitato_sfw", "id": 2},
+        {"name": "permitato_exceptions", "id": 3},
+    ])
+    adapter.add_domain_rule = AsyncMock()
+    adapter.get_domain_rules = AsyncMock(return_value=[])
+    adapter.update_client = AsyncMock()
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=False,
+        degraded_since=time.time() - 60,
+    )
+    state.exception_store = MagicMock()
+    state.exception_store.list_active.return_value = []
+
+    await reconnect_pihole(state)
+
+    assert state.pihole_available is True
+    assert state.degraded_since is None
+    adapter.connect.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_reconnect_noop_when_already_connected(tmp_path):
+    from apps.permitato.state import PermitState, reconnect_pihole
+
+    adapter = AsyncMock()
+    adapter.is_healthy = AsyncMock(return_value=True)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+    )
+
+    await reconnect_pihole(state)
+
+    adapter.connect.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_reconnect_stays_degraded_on_failure(tmp_path):
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+    from apps.permitato.state import PermitState, reconnect_pihole
+
+    adapter = AsyncMock()
+    adapter.connect = AsyncMock(side_effect=PiholeUnavailableError("still down"))
+
+    degraded_ts = time.time() - 120
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=False,
+        degraded_since=degraded_ts,
+    )
+
+    await reconnect_pihole(state)
+
+    assert state.pihole_available is False
+    assert state.degraded_since == degraded_ts
+
+
+@pytest.mark.anyio
+async def test_reconnect_reseeds_groups(tmp_path):
+    from apps.permitato.state import PermitState, reconnect_pihole
+
+    adapter = AsyncMock()
+    adapter.connect = AsyncMock()
+    adapter.get_groups = AsyncMock(return_value=[
+        {"name": "permitato_work", "id": 1},
+        {"name": "permitato_sfw", "id": 2},
+        {"name": "permitato_exceptions", "id": 3},
+    ])
+    adapter.add_domain_rule = AsyncMock()
+    adapter.get_domain_rules = AsyncMock(return_value=[])
+    adapter.update_client = AsyncMock()
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=False,
+        degraded_since=time.time() - 60,
+    )
+    state.exception_store = MagicMock()
+    state.exception_store.list_active.return_value = []
+
+    await reconnect_pihole(state)
+
+    assert state.group_map["permitato_work"] == 1
+    assert state.exception_group_id == 3
+    adapter.add_domain_rule.assert_called()  # deny-lists reseeded
+
+
+@pytest.mark.anyio
+async def test_reconnect_stays_degraded_on_mid_recovery_failure(tmp_path):
+    from apps.permitato.state import PermitState, reconnect_pihole
+
+    adapter = AsyncMock()
+    adapter.connect = AsyncMock()
+    # connect succeeds, but get_groups blows up
+    adapter.get_groups = AsyncMock(side_effect=Exception("transient failure"))
+
+    degraded_ts = time.time() - 60
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=False,
+        degraded_since=degraded_ts,
+    )
+
+    await reconnect_pihole(state)
+
+    assert state.pihole_available is False
+    assert state.degraded_since == degraded_ts
+
+
+@pytest.mark.anyio
+async def test_reconnect_reapplies_mode_to_client(tmp_path):
+    from apps.permitato.state import PermitState, reconnect_pihole
+
+    adapter = AsyncMock()
+    adapter.connect = AsyncMock()
+    adapter.get_groups = AsyncMock(return_value=[
+        {"name": "permitato_work", "id": 1},
+        {"name": "permitato_sfw", "id": 2},
+        {"name": "permitato_exceptions", "id": 3},
+    ])
+    adapter.add_domain_rule = AsyncMock()
+    adapter.get_domain_rules = AsyncMock(return_value=[])
+    adapter.update_client = AsyncMock()
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=False,
+        degraded_since=time.time() - 60,
+        mode="work",
+        client_id="192.168.1.10",
+    )
+    state.exception_store = MagicMock()
+    state.exception_store.list_active.return_value = []
+
+    await reconnect_pihole(state)
+
+    # Mode should have been reapplied to the client
+    adapter.update_client.assert_called_once()
+    call_args = adapter.update_client.call_args
+    assert call_args.args[0] == "192.168.1.10"
+    groups = call_args.args[1]
+    assert 1 in groups  # permitato_work group
+
+
+# ---------------------------------------------------------------------------
+# Exception compensation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compensation_readds_missing_pihole_rules(tmp_path):
+    from apps.permitato.state import PermitState, compensate_exceptions
+    from apps.permitato.exceptions import ExceptionStore
+
+    adapter = AsyncMock()
+    # Pi-hole has no allow rules
+    adapter.get_domain_rules = AsyncMock(return_value=[])
+    adapter.add_domain_rule = AsyncMock()
+
+    store = ExceptionStore(data_dir=tmp_path)
+    exc = store.grant("twitter.com", "DMs", ttl_seconds=3600)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+        exception_group_id=3,
+    )
+
+    await compensate_exceptions(state)
+
+    # Should have re-added the missing allow rule
+    adapter.add_domain_rule.assert_called_once()
+    call_kw = adapter.add_domain_rule.call_args.kwargs
+    assert call_kw["rule_type"] == "allow"
+    assert call_kw["domain"] == exc.regex_pattern
+
+
+@pytest.mark.anyio
+async def test_compensation_removes_orphaned_permitato_rules(tmp_path):
+    from apps.permitato.state import PermitState, compensate_exceptions
+    from apps.permitato.exceptions import ExceptionStore
+
+    adapter = AsyncMock()
+    # Pi-hole has a Permitato-owned orphaned rule
+    adapter.get_domain_rules = AsyncMock(return_value=[
+        {"domain": r"(^|\.)old\.com$", "groups": [3], "comment": "Permitato: old"},
+    ])
+    adapter.delete_domain_rule = AsyncMock()
+
+    store = ExceptionStore(data_dir=tmp_path)
+    # Store is empty — no active exceptions
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+        exception_group_id=3,
+    )
+
+    await compensate_exceptions(state)
+
+    adapter.delete_domain_rule.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_compensation_skips_non_permitato_rules(tmp_path):
+    from apps.permitato.state import PermitState, compensate_exceptions
+    from apps.permitato.exceptions import ExceptionStore
+
+    adapter = AsyncMock()
+    # Pi-hole has rules not owned by Permitato — different group or no comment
+    adapter.get_domain_rules = AsyncMock(return_value=[
+        {"domain": r"(^|\.)manual\.com$", "groups": [99], "comment": "user rule"},
+        {"domain": r"(^|\.)other\.com$", "groups": [3], "comment": "not Permitato"},
+        {"domain": r"(^|\.)bare\.com$", "groups": [3]},
+    ])
+    adapter.delete_domain_rule = AsyncMock()
+    adapter.add_domain_rule = AsyncMock()
+
+    store = ExceptionStore(data_dir=tmp_path)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+        exception_group_id=3,
+    )
+
+    await compensate_exceptions(state)
+
+    # None should be deleted — they're not Permitato-owned
+    adapter.delete_domain_rule.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_compensation_noop_when_in_sync(tmp_path):
+    from apps.permitato.state import PermitState, compensate_exceptions
+    from apps.permitato.exceptions import ExceptionStore
+
+    adapter = AsyncMock()
+
+    store = ExceptionStore(data_dir=tmp_path)
+    exc = store.grant("twitter.com", "DMs", ttl_seconds=3600)
+
+    # Pi-hole has the matching Permitato-owned rule
+    adapter.get_domain_rules = AsyncMock(return_value=[
+        {"domain": exc.regex_pattern, "groups": [3], "comment": "Permitato: DMs"},
+    ])
+    adapter.add_domain_rule = AsyncMock()
+    adapter.delete_domain_rule = AsyncMock()
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+        exception_group_id=3,
+    )
+
+    await compensate_exceptions(state)
+
+    adapter.add_domain_rule.assert_not_called()
+    adapter.delete_domain_rule.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_compensation_noop_without_exception_group(tmp_path):
+    from apps.permitato.state import PermitState, compensate_exceptions
+    from apps.permitato.exceptions import ExceptionStore
+
+    adapter = AsyncMock()
+    store = ExceptionStore(data_dir=tmp_path)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+        exception_group_id=0,  # no exception group
+    )
+
+    await compensate_exceptions(state)
+
+    adapter.get_domain_rules.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Audit rotation
+# ---------------------------------------------------------------------------
+
+
+def test_audit_rotation_keeps_last_n(tmp_path):
+    from apps.permitato.audit import write_audit_entry, rotate_audit_log
+
+    for i in range(100):
+        write_audit_entry(tmp_path, {"event": f"event_{i}"})
+
+    removed = rotate_audit_log(tmp_path, max_lines=30)
+    assert removed == 70
+
+    lines = (tmp_path / "audit.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 30
+    # Most recent entry should be last
+    assert json.loads(lines[-1])["event"] == "event_99"
+    # Oldest kept should be event_70
+    assert json.loads(lines[0])["event"] == "event_70"
+
+
+def test_audit_rotation_noop_under_threshold(tmp_path):
+    from apps.permitato.audit import write_audit_entry, rotate_audit_log
+
+    for i in range(10):
+        write_audit_entry(tmp_path, {"event": f"event_{i}"})
+
+    removed = rotate_audit_log(tmp_path, max_lines=100)
+    assert removed == 0
+
+    lines = (tmp_path / "audit.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 10
+
+
+def test_audit_rotation_leaves_no_tmp_files(tmp_path):
+    from apps.permitato.audit import write_audit_entry, rotate_audit_log
+
+    for i in range(50):
+        write_audit_entry(tmp_path, {"event": f"event_{i}"})
+
+    rotate_audit_log(tmp_path, max_lines=10)
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_audit_rotation_handles_empty_log(tmp_path):
+    from apps.permitato.audit import rotate_audit_log
+
+    removed = rotate_audit_log(tmp_path, max_lines=100)
+    assert removed == 0
+
+
+# ---------------------------------------------------------------------------
+# Domain validation hardening
+# ---------------------------------------------------------------------------
+
+
+def test_domain_rejects_whitespace():
+    from apps.permitato.exceptions import build_domain_regex
+
+    with pytest.raises(ValueError):
+        build_domain_regex("twitter .com")
+
+    with pytest.raises(ValueError):
+        build_domain_regex("twitter.com\n")
+
+
+# ---------------------------------------------------------------------------
+# Degraded status tracking
+# ---------------------------------------------------------------------------
+
+
+def test_state_has_degraded_since_field():
+    from apps.permitato.state import PermitState
+
+    state = PermitState()
+    assert state.degraded_since is None
+
+
+def test_state_degraded_since_tracks_timestamp():
+    from apps.permitato.state import PermitState
+
+    now = time.time()
+    state = PermitState(degraded_since=now)
+    assert state.degraded_since == now
+
+
+# ---------------------------------------------------------------------------
+# Pi-hole adapter: get_domain_rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_adapter_get_domain_rules():
+    from apps.permitato.pihole_adapter import PiholeAdapter
+
+    adapter = PiholeAdapter(base_url="http://pihole.test:8081/api", password="testpw")
+    adapter._sid = "sid1"
+
+    with respx.mock() as router:
+        router.get("http://pihole.test:8081/api/domains/allow/regex").mock(
+            return_value=Response(200, json={
+                "domains": [
+                    {"domain": r"(^|\.)twitter\.com$", "groups": [3]},
+                    {"domain": r"(^|\.)reddit\.com$", "groups": [3]},
+                ],
+            })
+        )
+        result = await adapter.get_domain_rules("allow", "regex")
+
+    assert len(result) == 2
+    assert result[0]["domain"] == r"(^|\.)twitter\.com$"
+    await adapter.disconnect()

--- a/apps/permitato/tests/test_lifecycle.py
+++ b/apps/permitato/tests/test_lifecycle.py
@@ -57,11 +57,14 @@ async def test_on_shutdown_cleans_up(monkeypatch):
         def __await__(self):
             return asyncio.sleep(0).__await__()
 
-    task = _FakeTask()
-    app.state.permit_expiry_task = task
+    expiry_task = _FakeTask()
+    reconnect_task = _FakeTask()
+    app.state.permit_expiry_task = expiry_task
+    app.state.permit_reconnect_task = reconnect_task
     app.state.permit_state = MagicMock()
 
     await lifecycle.on_shutdown(app)
 
-    assert task.cancel_called
+    assert expiry_task.cancel_called
+    assert reconnect_task.cancel_called
     mock_shutdown.assert_awaited_once_with(app.state.permit_state)


### PR DESCRIPTION
## Summary

- Atomic writes for `state.json` and `exceptions.json` via write-tmp + `os.replace` — a crash mid-write can no longer corrupt persisted state
- Pi-hole reconnection loop (60s interval) with automatic group/deny-list reseeding on recovery
- Exception-to-Pi-hole compensation after reconnection — reconciles local exception store with live Pi-hole allow rules (re-adds missing, removes orphaned)
- Audit log rotation via `rotate_audit_log()` — keeps last N entries with atomic rewrite
- Domain validation rejects newlines, carriage returns, and tabs before existing regex check
- `degraded_since` timestamp on `PermitState`, surfaced in `/status` response
- Permitato milestone plan in `permitato-readme.md` with phased ticket ordering

Closes #221

## Test plan

- [x] 17 new hardening tests in `test_hardening.py` (all TDD red-first)
- [x] Updated `test_lifecycle.py` for reconnection task shutdown
- [x] 662 Python tests pass (`uv run python -m pytest tests/unit tests/api apps/permitato/tests -q -n auto`)
- [x] 106 Playwright tests pass (`npx playwright test --reporter=dot --timeout=15000 --workers=75%`)
- [ ] Pi QA: verify degraded/recovered transitions with Pi-hole stopped/restarted