### PR TITLE
feat(permitato): add install and controlled-client onboarding flow

### DIFF
--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -1,5 +1,153 @@
 /* Permitato — scoped styles */
 
+/* Onboarding overlay */
+.permitato-onboarding {
+  position: absolute;
+  inset: 0;
+  z-index: 100;
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.permitato-onboarding[hidden] {
+  display: none;
+}
+
+.permitato-onboarding-card {
+  max-width: 420px;
+  width: 100%;
+  padding: 32px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+}
+
+.permitato-onboarding-card h2 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+}
+
+.permitato-onboarding-desc {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin: 0 0 16px;
+}
+
+.permitato-onboarding-status {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-bottom: 12px;
+}
+
+.permitato-client-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.permitato-client-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  transition: border-color 0.15s, background 0.15s;
+  font-size: 0.9rem;
+}
+
+.permitato-client-list li.this-device {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(34, 197, 94, 0.06);
+}
+
+.client-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.client-label {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.this-device .client-label {
+  color: #22c55e;
+}
+
+.client-sub {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.client-select-btn {
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.client-select-btn:hover {
+  border-color: var(--focus);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.permitato-onboarding-error {
+  color: #ef4444;
+  font-size: 0.85rem;
+  margin-top: 12px;
+}
+
+.permitato-onboarding-error[hidden] {
+  display: none;
+}
+
+/* Recovery banner */
+.permitato-recovery-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  margin: 8px 16px 0;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 10px;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.permitato-recovery-banner[hidden] {
+  display: none;
+}
+
+.permitato-reconfigure-btn {
+  padding: 3px 10px;
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  border-radius: 6px;
+  background: transparent;
+  color: #f59e0b;
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.permitato-reconfigure-btn:hover {
+  background: rgba(245, 158, 11, 0.15);
+}
+
 .permitato-status-bar {
   display: flex;
   align-items: center;

--- a/apps/permitato/assets/permitato.html
+++ b/apps/permitato/assets/permitato.html
@@ -1,3 +1,18 @@
+<div id="permitatoOnboarding" class="permitato-onboarding" hidden>
+  <div class="permitato-onboarding-card">
+    <h2>Set up Permitato</h2>
+    <p class="permitato-onboarding-desc">Select which device's DNS filtering Permitato will control.</p>
+    <div id="permitatoOnboardingStatus" class="permitato-onboarding-status"></div>
+    <ul id="permitatoClientList" class="permitato-client-list"></ul>
+    <div id="permitatoOnboardingError" class="permitato-onboarding-error" hidden></div>
+  </div>
+</div>
+
+<div id="permitatoRecoveryBanner" class="permitato-recovery-banner" hidden>
+  <span id="permitatoRecoveryText"></span>
+  <button id="permitatoReconfigureBtn" class="permitato-reconfigure-btn">Reconfigure</button>
+</div>
+
 <div id="permitatoStatusBar" class="permitato-status-bar">
   <div class="permitato-mode">
     <span class="permitato-mode-label">Mode:</span>

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -4,6 +4,9 @@ let _shell = null;
 let _statusTimer = null;
 let _history = [];
 let _requestInFlight = false;
+let _onboardingVisible = false;
+let _pendingClientSelection = false;
+let _lastClientFetchTs = 0;
 
 const PERMITATO_API = "/app/permitato/api";
 
@@ -28,6 +31,9 @@ export function init(shellApi) {
       }
     });
   }
+
+  const reconfigBtn = document.getElementById("permitatoReconfigureBtn");
+  if (reconfigBtn) reconfigBtn.addEventListener("click", () => _showOnboarding());
 
   _pollStatus();
   _statusTimer = setInterval(_pollStatus, 5000);
@@ -73,6 +79,23 @@ async function _switchMode(mode) {
 }
 
 function _updateStatusBar(data) {
+  // Onboarding: show overlay when no client is selected
+  if (!data.client_id && !_pendingClientSelection) {
+    _showOnboarding();
+    return;
+  }
+  if (data.client_id && _onboardingVisible && !_pendingClientSelection) {
+    _hideOnboarding();
+  }
+
+  // Recovery: show banner when client is invalid
+  const banner = document.getElementById("permitatoRecoveryBanner");
+  if (data.client_id && data.client_valid === false) {
+    _showRecoveryBanner(data.client_id);
+  } else if (banner) {
+    banner.hidden = true;
+  }
+
   const badge = document.getElementById("permitatoModeValue");
   if (badge) {
     const mode = data.mode_display || data.mode || "--";
@@ -201,6 +224,136 @@ function _appendMessage(role, text) {
   container.appendChild(el);
   container.scrollTop = container.scrollHeight;
   return el;
+}
+
+// --- Onboarding ---
+
+async function _showOnboarding() {
+  const overlay = document.getElementById("permitatoOnboarding");
+  if (!overlay) return;
+  overlay.hidden = false;
+  const wasAlreadyVisible = _onboardingVisible;
+  _onboardingVisible = true;
+  // First open: fetch immediately. Already open: refresh every 30s to avoid flicker.
+  const now = Date.now();
+  if (!wasAlreadyVisible || (now - _lastClientFetchTs > 30000 && !_pendingClientSelection)) {
+    await _fetchClients();
+  }
+}
+
+function _hideOnboarding() {
+  const overlay = document.getElementById("permitatoOnboarding");
+  if (overlay) overlay.hidden = true;
+  _onboardingVisible = false;
+  _pendingClientSelection = false;
+}
+
+async function _fetchClients() {
+  const list = document.getElementById("permitatoClientList");
+  const status = document.getElementById("permitatoOnboardingStatus");
+  if (!list) return;
+
+  // Only show "Loading..." on first fetch (avoid flicker on refresh)
+  if (!list.children.length && status) status.textContent = "Loading...";
+
+  try {
+    const resp = await fetch(`${PERMITATO_API}/clients`);
+    if (!resp.ok) {
+      if (status) status.textContent = "Failed to load clients.";
+      return;
+    }
+    const data = await resp.json();
+
+    if (!data.pihole_available) {
+      list.innerHTML = "";
+      if (status) status.textContent = "Pi-hole is not connected. Connect Pi-hole to discover devices.";
+      return;
+    }
+
+    if (data.clients.length === 0) {
+      list.innerHTML = "";
+      if (status) status.textContent = "No devices discovered by Pi-hole yet.";
+      return;
+    }
+
+    // Successful fetch with clients — throttle further refreshes to avoid flicker
+    _lastClientFetchTs = Date.now();
+    if (status) status.textContent = "";
+    list.innerHTML = "";
+
+    for (const c of data.clients) {
+      const li = document.createElement("li");
+      if (c.is_requester) li.classList.add("this-device");
+
+      const info = document.createElement("div");
+      info.className = "client-info";
+
+      const label = document.createElement("span");
+      label.className = "client-label";
+      if (c.is_requester) {
+        label.textContent = "Your device";
+      } else if (c.name) {
+        label.textContent = c.name;
+      } else {
+        label.textContent = c.client;
+      }
+      info.appendChild(label);
+
+      const sub = document.createElement("span");
+      sub.className = "client-sub";
+      sub.textContent = c.is_requester || c.name ? c.client : "";
+      if (sub.textContent) info.appendChild(sub);
+
+      li.appendChild(info);
+
+      const btn = document.createElement("button");
+      btn.className = "client-select-btn";
+      btn.textContent = c.is_requester ? "Select this device" : "Select";
+      btn.addEventListener("click", () => _selectClient(c.client));
+      li.appendChild(btn);
+
+      // Your device goes to top
+      if (c.is_requester) {
+        list.prepend(li);
+      } else {
+        list.appendChild(li);
+      }
+    }
+  } catch {
+    if (status) status.textContent = "Failed to load clients.";
+  }
+}
+
+async function _selectClient(clientId) {
+  _pendingClientSelection = true;
+  const errEl = document.getElementById("permitatoOnboardingError");
+
+  try {
+    const resp = await fetch(`${PERMITATO_API}/client`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ client_id: clientId }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      if (errEl) { errEl.textContent = err.error || "Failed to set client."; errEl.hidden = false; }
+      _pendingClientSelection = false;
+      return;
+    }
+    _hideOnboarding();
+    _pollStatus();
+  } catch {
+    if (errEl) { errEl.textContent = "Connection error."; errEl.hidden = false; }
+    _pendingClientSelection = false;
+  }
+}
+
+function _showRecoveryBanner(clientId) {
+  const banner = document.getElementById("permitatoRecoveryBanner");
+  const text = document.getElementById("permitatoRecoveryText");
+  if (!banner || !text) return;
+  text.textContent = `Your controlled device (${clientId}) is no longer available in Pi-hole.`;
+  banner.hidden = false;
 }
 
 // --- Session persistence (IndexedDB) ---

--- a/apps/permitato/net_resolve.py
+++ b/apps/permitato/net_resolve.py
@@ -1,0 +1,81 @@
+"""Resolve requester IP to Pi-hole client IP via the kernel neighbor table."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_requester_ipv4(requester_ip: str, client_ips: set[str]) -> str | None:
+    """Try to match the HTTP requester's IP to a Pi-hole client IPv4.
+
+    If the requester is already an IPv4 in the client set, return it directly.
+    Otherwise, look up the ARP/NDP neighbor table to map IPv6 → MAC → IPv4.
+    Returns None if no match is found.
+    """
+    if not requester_ip:
+        return None
+
+    # Strip IPv4-mapped IPv6 prefix
+    ip = requester_ip
+    if ip.startswith("::ffff:"):
+        ip = ip[7:]
+
+    # Direct match (requester is already IPv4 and in client list)
+    if ip in client_ips:
+        return ip
+
+    # Not a direct match — try neighbor table resolution
+    mac = _ip_to_mac(ip)
+    if not mac:
+        return None
+
+    return _mac_to_ipv4(mac, client_ips)
+
+
+def _ip_to_mac(ip: str) -> str | None:
+    """Look up a MAC address for an IP via the kernel neighbor table."""
+    try:
+        # Try IPv6 first (most common case: browser connects via IPv6)
+        result = subprocess.run(
+            ["ip", "-6", "neigh", "show"],
+            capture_output=True, text=True, timeout=2,
+        )
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 5 and parts[0] == ip and parts[3] == "lladdr":
+                return parts[4].lower()
+
+        # Try IPv4
+        result = subprocess.run(
+            ["ip", "-4", "neigh", "show"],
+            capture_output=True, text=True, timeout=2,
+        )
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 5 and parts[0] == ip and parts[3] == "lladdr":
+                return parts[4].lower()
+    except Exception:
+        logger.debug("Neighbor table lookup failed for %s", ip, exc_info=True)
+
+    return None
+
+
+def _mac_to_ipv4(mac: str, client_ips: set[str]) -> str | None:
+    """Find the IPv4 address that shares a MAC with the given address."""
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "neigh", "show"],
+            capture_output=True, text=True, timeout=2,
+        )
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 5 and parts[3] == "lladdr" and parts[4].lower() == mac:
+                if parts[0] in client_ips:
+                    return parts[0]
+    except Exception:
+        logger.debug("MAC-to-IPv4 lookup failed for %s", mac, exc_info=True)
+
+    return None

--- a/apps/permitato/permitato-readme.md
+++ b/apps/permitato/permitato-readme.md
@@ -9,10 +9,10 @@ Epic: #219 | Milestone: [Permitato](https://github.com/slomin/potato-os/mileston
 
 These two tickets fix the ground everything else builds on. Sequential — #222 uses the hardened persistence from #221.
 
-| Order | Ticket | Summary | Key files |
-|-------|--------|---------|-----------|
-| 1 | **#221** | Harden Pi-hole recovery, persistence, exception consistency | `state.py`, `exceptions.py`, `audit.py`, `lifecycle.py`, `pihole_adapter.py` |
-| 2 | **#222** | Install and controlled-client onboarding flow | `routes.py`, `state.py`, `assets/*`, new onboarding UI |
+| Order | Ticket | Summary | Status |
+|-------|--------|---------|--------|
+| 1 | **#221** | Harden Pi-hole recovery, persistence, exception consistency | Done (PR #228) |
+| 2 | **#222** | Install and controlled-client onboarding flow | In progress |
 
 **#221 in detail** (first ticket):
 - Atomic writes for `state.json` and `exceptions.json` (write-tmp + `os.replace`)

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -14,7 +14,8 @@ from apps.permitato.exceptions import ExceptionStore, build_domain_regex
 from apps.permitato.intent import parse_llm_response, strip_action_markers
 from apps.permitato.modes import get_mode, MODES
 from apps.permitato.pihole_adapter import PiholeUnavailableError
-from apps.permitato.state import apply_mode_to_client
+from apps.permitato.net_resolve import resolve_requester_ipv4
+from apps.permitato.state import apply_mode_to_client, validate_client
 from apps.permitato.system_prompt import build_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ async def permitato_status(request: Request):
         return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
 
     mode_def = get_mode(state.mode)
+    await validate_client(state)
     return {
         "mode": state.mode,
         "mode_display": mode_def.display_name,
@@ -47,6 +49,7 @@ async def permitato_status(request: Request):
         "pihole_available": state.pihole_available,
         "degraded_since": state.degraded_since,
         "client_id": state.client_id,
+        "client_valid": state.client_valid,
     }
 
 
@@ -104,8 +107,54 @@ async def set_client(request: Request):
     state.client_id = client_id
     state.persist()
     await apply_mode_to_client(state)
+    await validate_client(state, force_refresh=True)
 
-    return {"client_id": client_id, "mode": state.mode}
+    warning = None
+    if state.client_valid is False:
+        warning = "Client not found in Pi-hole's known clients"
+
+    return {
+        "client_id": client_id,
+        "mode": state.mode,
+        "client_valid": state.client_valid,
+        "warning": warning,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /clients
+# ---------------------------------------------------------------------------
+
+
+@router.get("/clients")
+async def list_clients(request: Request):
+    """Discover Pi-hole clients for onboarding."""
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+    if not state.pihole_available or not state.adapter:
+        return {"clients": [], "pihole_available": False}
+
+    try:
+        raw = await state.adapter.get_clients()
+    except PiholeUnavailableError:
+        return {"clients": [], "pihole_available": False}
+
+    requester_ip = request.headers.get("x-real-ip") or (request.client.host if request.client else None)
+    client_ips = {c.get("client", "") for c in raw}
+    resolved_ip = resolve_requester_ipv4(requester_ip, client_ips)
+
+    clients = [
+        {
+            "client": c.get("client", ""),
+            "name": c.get("name", ""),
+            "id": c.get("id"),
+            "selected": c.get("client", "") == state.client_id,
+            "is_requester": c.get("client", "") == resolved_ip,
+        }
+        for c in raw
+    ]
+    return {"clients": clients, "pihole_available": True}
 
 
 # ---------------------------------------------------------------------------

--- a/apps/permitato/state.py
+++ b/apps/permitato/state.py
@@ -34,6 +34,9 @@ class PermitState:
     exception_group_id: int = 0
     pihole_available: bool = False
     degraded_since: float | None = None
+    client_valid: bool | None = None
+    _client_cache_ts: float = 0
+    _cached_clients: list = field(default_factory=list)
     data_dir: Path = field(default_factory=lambda: Path("/opt/potato/data/permitato"))
 
     def persist(self) -> None:
@@ -93,12 +96,44 @@ async def initialize_permitato(
             logger.info("Cleaned up %d expired exceptions on startup", len(revoked))
             state.exception_store.persist()
 
+        await validate_client(state)
+
     except PiholeUnavailableError:
         state.pihole_available = False
         state.degraded_since = time.time()
         logger.warning("Pi-hole unavailable at %s — running in degraded mode", pihole_base_url)
 
     return state
+
+
+async def validate_client(state: PermitState, force_refresh: bool = False) -> bool | None:
+    """Check if the saved client_id exists in Pi-hole. Uses a 30s cache."""
+    if not state.client_id:
+        state.client_valid = None
+        return None
+    if not state.pihole_available or not state.adapter:
+        state.client_valid = None
+        return None
+
+    now = time.time()
+    cache_expired = now - state._client_cache_ts > 30
+    if cache_expired or force_refresh:
+        try:
+            state._cached_clients = await state.adapter.get_clients()
+            state._client_cache_ts = now
+        except PiholeUnavailableError:
+            # Pi-hole went down — enter degraded mode so reconnect loop picks it up
+            state._client_cache_ts = now
+            state.pihole_available = False
+            if state.degraded_since is None:
+                state.degraded_since = now
+            state.client_valid = None
+            logger.warning("Pi-hole became unreachable during client validation")
+            return None
+
+    known_ids = {c.get("client", "") for c in state._cached_clients}
+    state.client_valid = state.client_id in known_ids
+    return state.client_valid
 
 
 async def shutdown_permitato(state: PermitState) -> None:

--- a/apps/permitato/tests/onboarding.spec.js
+++ b/apps/permitato/tests/onboarding.spec.js
@@ -1,0 +1,184 @@
+const { test, expect } = require("@playwright/test");
+const { makeStatusPayload } = require("../../../tests/ui/helpers");
+
+/**
+ * Navigate to the Permitato app tab and wait for it to be loaded.
+ * Mocks the platform /status and /internal/apps so the shell boots.
+ */
+async function openPermitato(page, { statusRoute, permitatoStatusRoute, clientsRoute } = {}) {
+  // Mock platform status so the shell boots
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+
+  // Mock the Permitato-specific status endpoint
+  if (permitatoStatusRoute) {
+    await page.route("**/app/permitato/api/status", permitatoStatusRoute);
+  }
+
+  // Mock the clients discovery endpoint
+  if (clientsRoute) {
+    await page.route("**/app/permitato/api/clients", clientsRoute);
+  }
+
+  await page.goto("/");
+  // Wait for shell to discover apps and render navigation
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+  // Click the Permitato tab
+  await page.locator('button[data-app="permitato"]').click();
+  // Wait for Permitato to load its HTML — either the status bar or the onboarding overlay becomes visible
+  await page.waitForFunction(() => {
+    const bar = document.getElementById("permitatoStatusBar");
+    const onb = document.getElementById("permitatoOnboarding");
+    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+  }, { timeout: 10000 });
+}
+
+const FAKE_PERMITATO_STATUS_NO_CLIENT = {
+  mode: "normal",
+  mode_display: "Normal",
+  mode_description: "No extra restrictions",
+  active_exceptions: 0,
+  exceptions: [],
+  pihole_available: true,
+  degraded_since: null,
+  client_id: "",
+  client_valid: null,
+};
+
+const FAKE_PERMITATO_STATUS_VALID_CLIENT = {
+  ...FAKE_PERMITATO_STATUS_NO_CLIENT,
+  client_id: "192.168.1.106",
+  client_valid: true,
+};
+
+const FAKE_PERMITATO_STATUS_INVALID_CLIENT = {
+  ...FAKE_PERMITATO_STATUS_NO_CLIENT,
+  client_id: "192.168.1.106",
+  client_valid: false,
+};
+
+const FAKE_CLIENTS = {
+  clients: [
+    { client: "192.168.1.106", name: "", id: 1, selected: false, is_requester: true },
+    { client: "192.168.1.200", name: "iPhone", id: 2, selected: false, is_requester: false },
+  ],
+  pihole_available: true,
+};
+
+
+test("shows onboarding overlay when client_id is empty", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_PERMITATO_STATUS_NO_CLIENT) });
+    },
+    clientsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_CLIENTS) });
+    },
+  });
+
+  await expect(page.locator("#permitatoOnboarding")).toBeVisible();
+  await expect(page.locator("#permitatoClientList li")).toHaveCount(2);
+  // Your device should be highlighted and sorted first
+  await expect(page.locator("#permitatoClientList li").first()).toHaveClass(/this-device/);
+  await expect(page.locator(".client-label").first()).toHaveText("Your device");
+  await expect(page.locator(".client-select-btn").first()).toHaveText("Select this device");
+});
+
+
+test("selecting a client hides onboarding and shows normal UI", async ({ page }) => {
+  let statusReturnsClient = false;
+
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      const data = statusReturnsClient
+        ? FAKE_PERMITATO_STATUS_VALID_CLIENT
+        : FAKE_PERMITATO_STATUS_NO_CLIENT;
+      await route.fulfill({ status: 200, body: JSON.stringify(data) });
+    },
+    clientsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_CLIENTS) });
+    },
+  });
+
+  // Mock the POST /client endpoint
+  await page.route("**/app/permitato/api/client", async (route) => {
+    if (route.request().method() === "POST") {
+      statusReturnsClient = true;
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          client_id: "192.168.1.106",
+          mode: "normal",
+          client_valid: true,
+          warning: null,
+        }),
+      });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  // Onboarding should be visible
+  await expect(page.locator("#permitatoOnboarding")).toBeVisible();
+
+  // Click the Select button on the first client
+  await page.locator(".client-select-btn").first().click();
+
+  // Onboarding should hide, status bar should appear
+  await expect(page.locator("#permitatoOnboarding")).toBeHidden({ timeout: 10000 });
+  await expect(page.locator("#permitatoModeValue")).toBeVisible();
+});
+
+
+test("shows recovery banner when client_valid is false", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_PERMITATO_STATUS_INVALID_CLIENT) });
+    },
+  });
+
+  await expect(page.locator("#permitatoRecoveryBanner")).toBeVisible();
+  await expect(page.locator("#permitatoRecoveryText")).toContainText("192.168.1.106");
+});
+
+
+test("reconfigure button opens onboarding overlay", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_PERMITATO_STATUS_INVALID_CLIENT) });
+    },
+    clientsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_CLIENTS) });
+    },
+  });
+
+  await expect(page.locator("#permitatoRecoveryBanner")).toBeVisible();
+  await page.locator("#permitatoReconfigureBtn").click();
+  await expect(page.locator("#permitatoOnboarding")).toBeVisible();
+});
+
+
+test("shows message when Pi-hole unavailable during onboarding", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          ...FAKE_PERMITATO_STATUS_NO_CLIENT,
+          pihole_available: false,
+        }),
+      });
+    },
+    clientsRoute: async (route) => {
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({ clients: [], pihole_available: false }),
+      });
+    },
+  });
+
+  await expect(page.locator("#permitatoOnboarding")).toBeVisible();
+  await expect(page.locator("#permitatoOnboardingStatus")).toContainText("Pi-hole");
+});

--- a/apps/permitato/tests/test_onboarding.py
+++ b/apps/permitato/tests/test_onboarding.py
@@ -1,0 +1,350 @@
+"""Tests for Permitato client validation, discovery, and onboarding."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+FAKE_CLIENTS = [
+    {"client": "192.168.1.106", "name": "", "id": 1, "groups": [0, 3]},
+    {"client": "192.168.1.200", "name": "iPhone", "id": 2, "groups": [0]},
+]
+
+
+# ---------------------------------------------------------------------------
+# validate_client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_validate_client_true_when_exists(tmp_path):
+    from apps.permitato.state import PermitState, validate_client
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.106",
+    )
+
+    result = await validate_client(state)
+
+    assert result is True
+    assert state.client_valid is True
+
+
+@pytest.mark.anyio
+async def test_validate_client_false_when_missing(tmp_path):
+    from apps.permitato.state import PermitState, validate_client
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="10.0.0.99",
+    )
+
+    result = await validate_client(state)
+
+    assert result is False
+    assert state.client_valid is False
+
+
+@pytest.mark.anyio
+async def test_validate_client_none_when_no_client_id(tmp_path):
+    from apps.permitato.state import PermitState, validate_client
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=AsyncMock(),
+        pihole_available=True,
+        client_id="",
+    )
+
+    result = await validate_client(state)
+
+    assert result is None
+    assert state.client_valid is None
+
+
+@pytest.mark.anyio
+async def test_validate_client_none_when_pihole_unavailable(tmp_path):
+    from apps.permitato.state import PermitState, validate_client
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=AsyncMock(),
+        pihole_available=False,
+        client_id="192.168.1.106",
+    )
+
+    result = await validate_client(state)
+
+    assert result is None
+    assert state.client_valid is None
+
+
+@pytest.mark.anyio
+async def test_validate_client_caches_for_30s(tmp_path):
+    from apps.permitato.state import PermitState, validate_client
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.106",
+    )
+
+    await validate_client(state)
+    await validate_client(state)
+
+    # Should only have called get_clients once (cached)
+    adapter.get_clients.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_validate_client_refreshes_after_expiry(tmp_path):
+    from apps.permitato.state import PermitState, validate_client
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.106",
+    )
+
+    await validate_client(state)
+
+    # Expire the cache manually
+    state._client_cache_ts = time.time() - 31
+
+    await validate_client(state)
+
+    assert adapter.get_clients.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_validate_client_force_refresh_bypasses_cache(tmp_path):
+    from apps.permitato.state import PermitState, validate_client
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.106",
+    )
+
+    await validate_client(state)
+    await validate_client(state, force_refresh=True)
+
+    assert adapter.get_clients.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_validate_client_backs_off_on_pihole_failure(tmp_path):
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+    from apps.permitato.state import PermitState, validate_client
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(side_effect=PiholeUnavailableError("down"))
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.106",
+    )
+
+    await validate_client(state)
+    assert state.client_valid is None
+    assert state.pihole_available is False
+    assert state.degraded_since is not None
+
+    # Second call returns early (pihole_available is now False)
+    await validate_client(state)
+    adapter.get_clients.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# resolve_requester_ipv4
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_direct_ipv4_match():
+    from apps.permitato.net_resolve import resolve_requester_ipv4
+
+    result = resolve_requester_ipv4("192.168.1.106", {"192.168.1.106", "10.0.0.1"})
+    assert result == "192.168.1.106"
+
+
+def test_resolve_strips_ipv4_mapped_ipv6():
+    from apps.permitato.net_resolve import resolve_requester_ipv4
+
+    result = resolve_requester_ipv4("::ffff:192.168.1.106", {"192.168.1.106"})
+    assert result == "192.168.1.106"
+
+
+def test_resolve_returns_none_for_unknown():
+    from apps.permitato.net_resolve import resolve_requester_ipv4
+
+    # No neighbor table on macOS/test environment — falls through to None
+    result = resolve_requester_ipv4("2001:db8::1234", {"192.168.1.106"})
+    assert result is None
+
+
+def test_resolve_returns_none_for_empty():
+    from apps.permitato.net_resolve import resolve_requester_ipv4
+
+    assert resolve_requester_ipv4("", {"192.168.1.106"}) is None
+    assert resolve_requester_ipv4(None, {"192.168.1.106"}) is None
+
+
+# ---------------------------------------------------------------------------
+# GET /clients
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_clients_marks_selected(tmp_path):
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import router
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.106",
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/clients")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["clients"]) == 2
+    assert data["pihole_available"] is True
+
+    selected = [c for c in data["clients"] if c["selected"]]
+    assert len(selected) == 1
+    assert selected[0]["client"] == "192.168.1.106"
+
+
+@pytest.mark.anyio
+async def test_get_clients_empty_when_pihole_down(tmp_path):
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import router
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=None,
+        pihole_available=False,
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/clients")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["clients"] == []
+    assert data["pihole_available"] is False
+
+
+# ---------------------------------------------------------------------------
+# POST /client validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_post_client_warns_when_unknown(tmp_path):
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import router
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+    adapter.update_client = AsyncMock()
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+    )
+    state.exception_store = MagicMock()
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/client", json={"client_id": "10.0.0.99"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["client_id"] == "10.0.0.99"
+    assert data["warning"] is not None
+
+
+@pytest.mark.anyio
+async def test_post_client_no_warning_when_known(tmp_path):
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import router
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    adapter = AsyncMock()
+    adapter.get_clients = AsyncMock(return_value=FAKE_CLIENTS)
+    adapter.update_client = AsyncMock()
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+    )
+    state.exception_store = MagicMock()
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/client", json={"client_id": "192.168.1.106"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["client_id"] == "192.168.1.106"
+    assert data["client_valid"] is True
+    assert data.get("warning") is None

--- a/tests/ui/settings.spec.js
+++ b/tests/ui/settings.spec.js
@@ -63,6 +63,12 @@ test("seed mode defaults to random, toggles deterministic, persists, and control
   await saveModelSettings(page);
   await closeSettingsModal(page);
 
+  // Wait for status poll to propagate the saved generation_mode change
+  await page.waitForResponse(
+    (resp) => resp.url().includes("/status") && resp.status() === 200,
+    { timeout: 10000 },
+  );
+
   await promptField.fill("Seed random request after toggle.");
   const randomRequestAfterTogglePromise = page.waitForRequest("**/v1/chat/completions");
   await promptField.press("Enter");


### PR DESCRIPTION
## Summary

- **Client validation**: `validate_client()` checks saved `client_id` against Pi-hole's client list with 30s cache and backoff on failure
- **GET /clients**: Discovery endpoint wrapping `adapter.get_clients()`, marks current selection, detects requester's device via kernel neighbor table (IPv6 → MAC → IPv4)
- **Status extension**: `GET /status` includes `client_valid` (true/false/null); `POST /client` returns `client_valid` and `warning`, uses `force_refresh` to bypass stale cache
- **Onboarding overlay**: Full-area overlay when `client_id` is empty — "Your device" highlighted in green and sorted to top with "Select this device" button, other clients show IP with "Select"
- **Recovery banner**: Amber banner with "Reconfigure" button when `client_valid` is false
- **Flicker fix**: Client list refresh throttled to 30s while onboarding is visible, list stays visible during fetch
- **Device detection**: Resolves HTTP requester to Pi-hole client via ARP/NDP neighbor table — graceful fallback to IP-only on non-Linux or missing entries

Closes #222

## Test plan

- [x] 16 backend tests in `test_onboarding.py` (validation, caching, backoff, force-refresh, GET /clients, POST /client, net resolve)
- [x] 5 Playwright tests in `onboarding.spec.js` (overlay, selection with "Your device", recovery, reconfigure, Pi-hole unavailable)
- [x] 682 Python tests pass
- [x] 111 Playwright tests pass
- [x] Pi QA: onboarding shows "Your device" correctly, selection completes setup, no flicker