### PR TITLE
feat(permitato): add active exceptions panel with TTL countdown and revoke

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -102,6 +102,8 @@ All feature tickets are implemented TDD-first:
    - implementation commit,
    - docs/runbook updates commit.
 
+**Which tests drive TDD:** Unit tests (pytest) and API tests drive the red-green-refactor cycle — they're fast, isolated, and give sub-second feedback. Playwright/UI tests are for end-to-end integration verification only — keep them minimal (critical happy paths, not exhaustive coverage). For pure frontend tickets with no backend changes, build the implementation first and add a small number of Playwright smoke tests after.
+
 ## Local Dev Environment Rule
 
 For all local development work, always use `uv`.

--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -241,6 +241,25 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 2px 8px;
+  margin: -2px 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.permitato-exceptions:hover {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.permitato-exceptions[aria-expanded="true"] {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .permitato-exception-count {
@@ -249,6 +268,110 @@
 
 .permitato-exception-label {
   color: var(--text-muted);
+}
+
+/* Exceptions panel */
+.permitato-exceptions-panel {
+  margin: 0 16px;
+  padding: 10px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.permitato-exceptions-panel[hidden] {
+  display: none;
+}
+
+.permitato-exceptions-degraded {
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #f59e0b;
+}
+
+.permitato-exceptions-degraded[hidden] {
+  display: none;
+}
+
+.permitato-exceptions-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.permitato-exceptions-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.exc-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.exc-domain {
+  font-weight: 500;
+}
+
+.exc-reason {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.exc-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.exc-ttl {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  min-width: 60px;
+  text-align: right;
+}
+
+.exc-revoke-btn {
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.exc-revoke-btn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.permitato-exceptions-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 8px;
 }
 
 .permitato-pihole-status {

--- a/apps/permitato/assets/permitato.html
+++ b/apps/permitato/assets/permitato.html
@@ -18,10 +18,10 @@
     <span class="permitato-mode-label">Mode:</span>
     <span id="permitatoModeValue" class="permitato-mode-badge">--</span>
   </div>
-  <div class="permitato-exceptions">
+  <button id="permitatoExceptionsToggle" class="permitato-exceptions" type="button">
     <span id="permitatoExceptionCount" class="permitato-exception-count">0</span>
     <span class="permitato-exception-label">active exceptions</span>
-  </div>
+  </button>
   <div class="permitato-mode-toggle">
     <button class="permitato-mode-btn" data-mode="normal">Normal</button>
     <button class="permitato-mode-btn" data-mode="work">Work</button>
@@ -32,6 +32,14 @@
     <span id="permitatoPiholeLabel">Checking...</span>
   </div>
 </div>
+
+<section id="permitatoExceptionsPanel" class="permitato-exceptions-panel" hidden>
+  <div id="permitatoExceptionsDegraded" class="permitato-exceptions-degraded" hidden>
+    Pi-hole is unavailable — revoke may not take effect.
+  </div>
+  <ul id="permitatoExceptionsList" class="permitato-exceptions-list"></ul>
+  <div id="permitatoExceptionsEmpty" class="permitato-exceptions-empty">No active exceptions</div>
+</section>
 
 <section id="permitatoMessages" class="permitato-messages"></section>
 

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -7,6 +7,10 @@ let _requestInFlight = false;
 let _onboardingVisible = false;
 let _pendingClientSelection = false;
 let _lastClientFetchTs = 0;
+let _panelOpen = false;
+let _ttlTimer = null;
+let _latestExceptions = [];
+let _latestPiholeAvailable = true;
 
 const PERMITATO_API = "/app/permitato/api";
 
@@ -35,12 +39,16 @@ export function init(shellApi) {
   const reconfigBtn = document.getElementById("permitatoReconfigureBtn");
   if (reconfigBtn) reconfigBtn.addEventListener("click", () => _showOnboarding());
 
+  const excToggle = document.getElementById("permitatoExceptionsToggle");
+  if (excToggle) excToggle.addEventListener("click", _toggleExceptionsPanel);
+
   _pollStatus();
   _statusTimer = setInterval(_pollStatus, 5000);
   _loadSession();
 }
 
 export function destroy() {
+  _stopTtlTimer();
   if (_statusTimer) {
     clearInterval(_statusTimer);
     _statusTimer = null;
@@ -110,6 +118,11 @@ function _updateStatusBar(data) {
 
   const count = document.getElementById("permitatoExceptionCount");
   if (count) count.textContent = String(data.active_exceptions || 0);
+
+  // Store exception data for the panel
+  _latestExceptions = data.exceptions || [];
+  _latestPiholeAvailable = data.pihole_available !== false;
+  if (_panelOpen) _renderExceptions();
 
   const dot = document.getElementById("permitatoPiholeDot");
   const label = document.getElementById("permitatoPiholeLabel");
@@ -224,6 +237,112 @@ function _appendMessage(role, text) {
   container.appendChild(el);
   container.scrollTop = container.scrollHeight;
   return el;
+}
+
+// --- Exceptions panel ---
+
+function _toggleExceptionsPanel() {
+  _panelOpen = !_panelOpen;
+  const panel = document.getElementById("permitatoExceptionsPanel");
+  const toggle = document.getElementById("permitatoExceptionsToggle");
+  if (panel) panel.hidden = !_panelOpen;
+  if (toggle) toggle.setAttribute("aria-expanded", String(_panelOpen));
+  if (_panelOpen) {
+    _renderExceptions();
+    _startTtlTimer();
+  } else {
+    _stopTtlTimer();
+  }
+}
+
+function _renderExceptions() {
+  const list = document.getElementById("permitatoExceptionsList");
+  const empty = document.getElementById("permitatoExceptionsEmpty");
+  const degraded = document.getElementById("permitatoExceptionsDegraded");
+  if (!list) return;
+
+  if (degraded) degraded.hidden = _latestPiholeAvailable;
+
+  if (_latestExceptions.length === 0) {
+    list.innerHTML = "";
+    if (empty) empty.hidden = false;
+    return;
+  }
+  if (empty) empty.hidden = true;
+  list.innerHTML = "";
+
+  for (const exc of _latestExceptions) {
+    const li = document.createElement("li");
+
+    const info = document.createElement("div");
+    info.className = "exc-info";
+    const domain = document.createElement("span");
+    domain.className = "exc-domain";
+    domain.textContent = exc.domain;
+    info.appendChild(domain);
+    if (exc.reason) {
+      const reason = document.createElement("span");
+      reason.className = "exc-reason";
+      reason.textContent = exc.reason;
+      info.appendChild(reason);
+    }
+    li.appendChild(info);
+
+    const right = document.createElement("div");
+    right.className = "exc-right";
+
+    const ttl = document.createElement("span");
+    ttl.className = "exc-ttl";
+    ttl.setAttribute("data-expires-at", String(exc.expires_at));
+    ttl.textContent = _formatTtl(exc.expires_at);
+    right.appendChild(ttl);
+
+    const btn = document.createElement("button");
+    btn.className = "exc-revoke-btn";
+    btn.textContent = "Revoke";
+    btn.addEventListener("click", () => _revokeException(exc.id));
+    right.appendChild(btn);
+
+    li.appendChild(right);
+    list.appendChild(li);
+  }
+}
+
+function _formatTtl(expiresAt) {
+  const remaining = Math.max(0, Math.floor(expiresAt - Date.now() / 1000));
+  if (remaining <= 0) return "expired";
+  const h = Math.floor(remaining / 3600);
+  const m = Math.floor((remaining % 3600) / 60);
+  const s = remaining % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m ${String(s).padStart(2, "0")}s`;
+}
+
+function _startTtlTimer() {
+  _stopTtlTimer();
+  _ttlTimer = setInterval(_tickTtl, 1000);
+}
+
+function _stopTtlTimer() {
+  if (_ttlTimer) {
+    clearInterval(_ttlTimer);
+    _ttlTimer = null;
+  }
+}
+
+function _tickTtl() {
+  document.querySelectorAll(".exc-ttl[data-expires-at]").forEach(el => {
+    el.textContent = _formatTtl(Number(el.getAttribute("data-expires-at")));
+  });
+}
+
+async function _revokeException(id) {
+  try {
+    const resp = await fetch(`${PERMITATO_API}/exceptions/${id}`, { method: "DELETE" });
+    if (resp.ok) _pollStatus();
+  } catch {
+    // silent — next poll will update state
+  }
 }
 
 // --- Onboarding ---

--- a/apps/permitato/tests/exceptions-panel.spec.js
+++ b/apps/permitato/tests/exceptions-panel.spec.js
@@ -1,0 +1,114 @@
+const { test, expect } = require("@playwright/test");
+const { makeStatusPayload } = require("../../../tests/ui/helpers");
+
+async function openPermitato(page, { permitatoStatusRoute } = {}) {
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+  if (permitatoStatusRoute) {
+    await page.route("**/app/permitato/api/status", permitatoStatusRoute);
+  }
+  await page.goto("/");
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+  await page.locator('button[data-app="permitato"]').click();
+  await page.waitForFunction(() => {
+    const bar = document.getElementById("permitatoStatusBar");
+    const onb = document.getElementById("permitatoOnboarding");
+    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+  }, { timeout: 10000 });
+}
+
+const NOW = Math.floor(Date.now() / 1000);
+
+const STATUS_WITH_EXCEPTIONS = {
+  mode: "work",
+  mode_display: "Work",
+  mode_description: "Social media blocked",
+  active_exceptions: 2,
+  exceptions: [
+    { id: "exc-1", domain: "twitter.com", reason: "check DMs", granted_at: NOW - 600, expires_at: NOW + 2400, ttl_seconds: 3600 },
+    { id: "exc-2", domain: "reddit.com", reason: "research", granted_at: NOW - 300, expires_at: NOW + 1500, ttl_seconds: 1800 },
+  ],
+  pihole_available: true,
+  degraded_since: null,
+  client_id: "192.168.1.100",
+  client_valid: true,
+};
+
+const STATUS_EMPTY = {
+  ...STATUS_WITH_EXCEPTIONS,
+  active_exceptions: 0,
+  exceptions: [],
+};
+
+
+test("clicking exception count toggles panel open and closed", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(STATUS_WITH_EXCEPTIONS) });
+    },
+  });
+
+  // Panel hidden by default
+  await expect(page.locator("#permitatoExceptionsPanel")).toBeHidden();
+
+  // Click count to open
+  await page.locator("#permitatoExceptionsToggle").click();
+  await expect(page.locator("#permitatoExceptionsPanel")).toBeVisible();
+  await expect(page.locator("#permitatoExceptionsList li")).toHaveCount(2);
+
+  // Click again to close
+  await page.locator("#permitatoExceptionsToggle").click();
+  await expect(page.locator("#permitatoExceptionsPanel")).toBeHidden();
+});
+
+
+test("exception items show domain, reason, TTL, and revoke button", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(STATUS_WITH_EXCEPTIONS) });
+    },
+  });
+
+  await page.locator("#permitatoExceptionsToggle").click();
+
+  const firstItem = page.locator("#permitatoExceptionsList li").first();
+  await expect(firstItem.locator(".exc-domain")).toHaveText("twitter.com");
+  await expect(firstItem.locator(".exc-reason")).toHaveText("check DMs");
+  await expect(firstItem.locator(".exc-ttl")).toContainText(/\d+m/);
+  await expect(firstItem.locator(".exc-revoke-btn")).toBeVisible();
+});
+
+
+test("revoke calls DELETE and refreshes the panel", async ({ page }) => {
+  let revoked = false;
+
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      const data = revoked
+        ? { ...STATUS_WITH_EXCEPTIONS, active_exceptions: 1, exceptions: [STATUS_WITH_EXCEPTIONS.exceptions[1]] }
+        : STATUS_WITH_EXCEPTIONS;
+      await route.fulfill({ status: 200, body: JSON.stringify(data) });
+    },
+  });
+
+  await page.route("**/app/permitato/api/exceptions/exc-1", async (route) => {
+    if (route.request().method() === "DELETE") {
+      revoked = true;
+      await route.fulfill({ status: 200, body: JSON.stringify({ revoked: true }) });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.locator("#permitatoExceptionsToggle").click();
+  await expect(page.locator("#permitatoExceptionsList li")).toHaveCount(2);
+
+  // Click revoke on first item
+  await page.locator(".exc-revoke-btn").first().click();
+
+  // Should update to 1 exception after the re-poll
+  await expect(page.locator("#permitatoExceptionsList li")).toHaveCount(1, { timeout: 10000 });
+  await expect(page.locator("#permitatoExceptionCount")).toHaveText("1");
+});


### PR DESCRIPTION
## Summary

- **Collapsible exceptions panel** unfolds from the status bar when clicking the exception count
- Each exception shows **domain**, **reason**, **live TTL countdown** (1s tick), and a **Revoke button**
- Revoke calls `DELETE /exceptions/{id}` and re-polls status to refresh both panel and count
- **Empty state**: "No active exceptions" message when panel is open with no exceptions
- **Degraded state**: Warning banner remains visible, and revoke stays available so local removal can persist during Pi-hole outages
- TTL timer only runs while panel is open (no background work when collapsed)
- Updated WORKFLOW.md: unit tests drive TDD, Playwright is minimal e2e verification only

Closes #223

## Test plan

- [x] 3 Playwright smoke tests (toggle, rendering with domain/reason/TTL, revoke flow)
- [x] 682 Python tests pass
- [x] 114 Playwright tests pass
- [x] Pi QA: granted 2 exceptions, panel shows TTL countdown, revoke works live
