### PR TITLE
feat(permitato): add scheduled modes and manual override behavior

### DIFF
--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -374,6 +374,306 @@
   padding: 8px;
 }
 
+/* Schedule indicator */
+.permitato-schedule-indicator {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.permitato-schedule-indicator[hidden] {
+  display: none;
+}
+
+/* Schedule toggle */
+.permitato-schedule-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 2px 8px;
+  margin: -2px 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text-muted);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.permitato-schedule-toggle:hover {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.permitato-schedule-toggle[aria-expanded="true"] {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* Schedule panel */
+.permitato-schedule-panel {
+  margin: 0 16px;
+  padding: 10px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.permitato-schedule-panel[hidden] {
+  display: none;
+}
+
+.permitato-schedule-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.permitato-schedule-header h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.permitato-add-rule-btn {
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.permitato-add-rule-btn:hover {
+  border-color: var(--focus);
+  color: var(--text);
+}
+
+.permitato-schedule-next {
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.permitato-schedule-next[hidden] {
+  display: none;
+}
+
+.permitato-schedule-rules {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.permitato-schedule-rules li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.sched-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.sched-mode {
+  font-weight: 600;
+  font-size: 0.8rem;
+  padding: 1px 8px;
+  border-radius: 10px;
+}
+
+.sched-mode[data-mode="work"] {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.sched-mode[data-mode="sfw"] {
+  background: #f59e0b;
+  color: #fff;
+}
+
+.sched-mode[data-mode="normal"] {
+  background: var(--border);
+  color: var(--text);
+}
+
+.sched-days {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.sched-time {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8rem;
+}
+
+.sched-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.sched-disabled {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-style: italic;
+}
+
+.sched-delete-btn {
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.sched-delete-btn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.permitato-schedule-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 8px;
+}
+
+/* Add rule form */
+.permitato-add-rule-form {
+  margin-top: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.permitato-add-rule-form[hidden] {
+  display: none;
+}
+
+.permitato-rule-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.permitato-rule-row > label:first-child {
+  width: 44px;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.permitato-rule-row select,
+.permitato-rule-row input[type="time"] {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+.permitato-day-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.permitato-day-picker label {
+  font-size: 0.8rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.permitato-time-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.permitato-time-picker span {
+  color: var(--text-muted);
+}
+
+.permitato-rule-error {
+  color: #ef4444;
+  font-size: 0.8rem;
+}
+
+.permitato-rule-error[hidden] {
+  display: none;
+}
+
+.permitato-add-rule-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.permitato-save-rule-btn {
+  padding: 4px 14px;
+  border: 1px solid #3b82f6;
+  border-radius: 6px;
+  background: #3b82f6;
+  color: #fff;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.permitato-save-rule-btn:hover {
+  opacity: 0.85;
+}
+
+.permitato-cancel-rule-btn {
+  padding: 4px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.permitato-cancel-rule-btn:hover {
+  border-color: var(--text);
+  color: var(--text);
+}
+
 .permitato-pihole-status {
   display: flex;
   align-items: center;

--- a/apps/permitato/assets/permitato.html
+++ b/apps/permitato/assets/permitato.html
@@ -17,6 +17,7 @@
   <div class="permitato-mode">
     <span class="permitato-mode-label">Mode:</span>
     <span id="permitatoModeValue" class="permitato-mode-badge">--</span>
+    <span id="permitatoScheduleIndicator" class="permitato-schedule-indicator" hidden></span>
   </div>
   <button id="permitatoExceptionsToggle" class="permitato-exceptions" type="button">
     <span id="permitatoExceptionCount" class="permitato-exception-count">0</span>
@@ -27,6 +28,9 @@
     <button class="permitato-mode-btn" data-mode="work">Work</button>
     <button class="permitato-mode-btn" data-mode="sfw">SFW</button>
   </div>
+  <button id="permitatoScheduleToggle" class="permitato-schedule-toggle" type="button">
+    <span id="permitatoScheduleLabel">Schedule</span>
+  </button>
   <div id="permitatoPiholeStatus" class="permitato-pihole-status">
     <span id="permitatoPiholeDot" class="permitato-pihole-dot"></span>
     <span id="permitatoPiholeLabel">Checking...</span>
@@ -39,6 +43,51 @@
   </div>
   <ul id="permitatoExceptionsList" class="permitato-exceptions-list"></ul>
   <div id="permitatoExceptionsEmpty" class="permitato-exceptions-empty">No active exceptions</div>
+</section>
+
+<section id="permitatoSchedulePanel" class="permitato-schedule-panel" hidden>
+  <div class="permitato-schedule-header">
+    <h3>Weekly Schedule</h3>
+    <button id="permitatoAddRuleBtn" class="permitato-add-rule-btn">+ Add Rule</button>
+  </div>
+  <div id="permitatoScheduleNext" class="permitato-schedule-next" hidden></div>
+  <ul id="permitatoScheduleRules" class="permitato-schedule-rules"></ul>
+  <div id="permitatoScheduleEmpty" class="permitato-schedule-empty">No schedule rules configured</div>
+  <div id="permitatoAddRuleForm" class="permitato-add-rule-form" hidden>
+    <div class="permitato-rule-row">
+      <label>Mode</label>
+      <select id="permitatoRuleMode">
+        <option value="work">Work</option>
+        <option value="sfw">SFW</option>
+        <option value="normal">Normal</option>
+      </select>
+    </div>
+    <div class="permitato-rule-row">
+      <label>Days</label>
+      <div class="permitato-day-picker" id="permitatoDayPicker">
+        <label><input type="checkbox" value="0"> Mon</label>
+        <label><input type="checkbox" value="1"> Tue</label>
+        <label><input type="checkbox" value="2"> Wed</label>
+        <label><input type="checkbox" value="3"> Thu</label>
+        <label><input type="checkbox" value="4"> Fri</label>
+        <label><input type="checkbox" value="5"> Sat</label>
+        <label><input type="checkbox" value="6"> Sun</label>
+      </div>
+    </div>
+    <div class="permitato-rule-row">
+      <label>Time</label>
+      <div class="permitato-time-picker">
+        <input type="time" id="permitatoRuleStart" value="09:00">
+        <span>to</span>
+        <input type="time" id="permitatoRuleEnd" value="17:00">
+      </div>
+    </div>
+    <div id="permitatoRuleError" class="permitato-rule-error" hidden></div>
+    <div class="permitato-add-rule-actions">
+      <button id="permitatoSaveRuleBtn" class="permitato-save-rule-btn">Save</button>
+      <button id="permitatoCancelRuleBtn" class="permitato-cancel-rule-btn">Cancel</button>
+    </div>
+  </div>
 </section>
 
 <section id="permitatoMessages" class="permitato-messages"></section>

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -8,6 +8,7 @@ let _onboardingVisible = false;
 let _pendingClientSelection = false;
 let _lastClientFetchTs = 0;
 let _panelOpen = false;
+let _schedulePanelOpen = false;
 let _ttlTimer = null;
 let _latestExceptions = [];
 let _latestPiholeAvailable = true;
@@ -41,6 +42,18 @@ export function init(shellApi) {
 
   const excToggle = document.getElementById("permitatoExceptionsToggle");
   if (excToggle) excToggle.addEventListener("click", _toggleExceptionsPanel);
+
+  const schedToggle = document.getElementById("permitatoScheduleToggle");
+  if (schedToggle) schedToggle.addEventListener("click", _toggleSchedulePanel);
+
+  const addRuleBtn = document.getElementById("permitatoAddRuleBtn");
+  if (addRuleBtn) addRuleBtn.addEventListener("click", _showAddRuleForm);
+
+  const saveRuleBtn = document.getElementById("permitatoSaveRuleBtn");
+  if (saveRuleBtn) saveRuleBtn.addEventListener("click", _saveScheduleRule);
+
+  const cancelRuleBtn = document.getElementById("permitatoCancelRuleBtn");
+  if (cancelRuleBtn) cancelRuleBtn.addEventListener("click", _hideAddRuleForm);
 
   _pollStatus();
   _statusTimer = setInterval(_pollStatus, 5000);
@@ -109,6 +122,20 @@ function _updateStatusBar(data) {
     const mode = data.mode_display || data.mode || "--";
     badge.textContent = mode;
     badge.setAttribute("data-mode", data.mode || "");
+  }
+
+  // Schedule/override indicator
+  const indicator = document.getElementById("permitatoScheduleIndicator");
+  if (indicator) {
+    if (data.override_active) {
+      indicator.textContent = "(override)";
+      indicator.hidden = false;
+    } else if (data.schedule_active) {
+      indicator.textContent = "(scheduled)";
+      indicator.hidden = false;
+    } else {
+      indicator.hidden = true;
+    }
   }
 
   // Highlight active mode button
@@ -342,6 +369,160 @@ async function _revokeException(id) {
     if (resp.ok) _pollStatus();
   } catch {
     // silent — next poll will update state
+  }
+}
+
+// --- Schedule panel ---
+
+const _DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function _toggleSchedulePanel() {
+  _schedulePanelOpen = !_schedulePanelOpen;
+  const panel = document.getElementById("permitatoSchedulePanel");
+  const toggle = document.getElementById("permitatoScheduleToggle");
+  if (panel) panel.hidden = !_schedulePanelOpen;
+  if (toggle) toggle.setAttribute("aria-expanded", String(_schedulePanelOpen));
+  if (_schedulePanelOpen) _fetchSchedule();
+}
+
+async function _fetchSchedule() {
+  try {
+    const resp = await fetch(`${PERMITATO_API}/schedule`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    _renderScheduleRules(data.rules || []);
+    _renderNextTransition(data.next_transition);
+  } catch {
+    // silent
+  }
+}
+
+function _renderScheduleRules(rules) {
+  const list = document.getElementById("permitatoScheduleRules");
+  const empty = document.getElementById("permitatoScheduleEmpty");
+  if (!list) return;
+
+  if (rules.length === 0) {
+    list.innerHTML = "";
+    if (empty) empty.hidden = false;
+    return;
+  }
+  if (empty) empty.hidden = true;
+  list.innerHTML = "";
+
+  for (const rule of rules) {
+    const li = document.createElement("li");
+
+    const info = document.createElement("div");
+    info.className = "sched-info";
+
+    const mode = document.createElement("span");
+    mode.className = "sched-mode";
+    mode.textContent = rule.mode.charAt(0).toUpperCase() + rule.mode.slice(1);
+    mode.setAttribute("data-mode", rule.mode);
+    info.appendChild(mode);
+
+    const days = document.createElement("span");
+    days.className = "sched-days";
+    days.textContent = rule.days.map(d => _DAY_NAMES[d]).join(", ");
+    info.appendChild(days);
+
+    const time = document.createElement("span");
+    time.className = "sched-time";
+    time.textContent = `${rule.start_time} – ${rule.end_time}`;
+    info.appendChild(time);
+
+    li.appendChild(info);
+
+    const right = document.createElement("div");
+    right.className = "sched-right";
+
+    if (!rule.enabled) {
+      const dis = document.createElement("span");
+      dis.className = "sched-disabled";
+      dis.textContent = "disabled";
+      right.appendChild(dis);
+    }
+
+    const btn = document.createElement("button");
+    btn.className = "sched-delete-btn";
+    btn.textContent = "Delete";
+    btn.addEventListener("click", () => _deleteScheduleRule(rule.id));
+    right.appendChild(btn);
+
+    li.appendChild(right);
+    list.appendChild(li);
+  }
+}
+
+function _renderNextTransition(next) {
+  const el = document.getElementById("permitatoScheduleNext");
+  if (!el) return;
+  if (!next) {
+    el.hidden = true;
+    return;
+  }
+  const dayName = _DAY_NAMES[next.day];
+  el.textContent = `Next: ${next.mode.charAt(0).toUpperCase() + next.mode.slice(1)} at ${dayName} ${next.time}`;
+  el.hidden = false;
+}
+
+function _showAddRuleForm() {
+  const form = document.getElementById("permitatoAddRuleForm");
+  const errEl = document.getElementById("permitatoRuleError");
+  if (form) form.hidden = false;
+  if (errEl) errEl.hidden = true;
+}
+
+function _hideAddRuleForm() {
+  const form = document.getElementById("permitatoAddRuleForm");
+  if (form) form.hidden = true;
+}
+
+async function _saveScheduleRule() {
+  const mode = document.getElementById("permitatoRuleMode")?.value;
+  const startTime = document.getElementById("permitatoRuleStart")?.value;
+  const endTime = document.getElementById("permitatoRuleEnd")?.value;
+  const errEl = document.getElementById("permitatoRuleError");
+
+  const days = [];
+  document.querySelectorAll("#permitatoDayPicker input:checked").forEach(cb => {
+    days.push(Number(cb.value));
+  });
+
+  if (days.length === 0) {
+    if (errEl) { errEl.textContent = "Select at least one day."; errEl.hidden = false; }
+    return;
+  }
+
+  try {
+    const resp = await fetch(`${PERMITATO_API}/schedule`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode, days, start_time: startTime, end_time: endTime }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      if (errEl) { errEl.textContent = err.error || "Failed to save rule."; errEl.hidden = false; }
+      return;
+    }
+    _hideAddRuleForm();
+    _fetchSchedule();
+    _pollStatus();
+  } catch {
+    if (errEl) { errEl.textContent = "Connection error."; errEl.hidden = false; }
+  }
+}
+
+async function _deleteScheduleRule(id) {
+  try {
+    const resp = await fetch(`${PERMITATO_API}/schedule/${id}`, { method: "DELETE" });
+    if (resp.ok) {
+      _fetchSchedule();
+      _pollStatus();
+    }
+  } catch {
+    // silent
   }
 }
 

--- a/apps/permitato/lifecycle.py
+++ b/apps/permitato/lifecycle.py
@@ -6,7 +6,12 @@ import asyncio
 import logging
 from pathlib import Path
 
-from apps.permitato.state import initialize_permitato, shutdown_permitato, reconnect_pihole
+from datetime import datetime
+
+from apps.permitato.state import (
+    PermitState, apply_mode_to_client, apply_startup_schedule,
+    initialize_permitato, shutdown_permitato, reconnect_pihole,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +33,14 @@ async def on_startup(app, app_dir: Path, data_dir: Path) -> None:
         pihole_password=pihole_pw,
     )
 
+    # Initialize schedule store and apply schedule on startup
+    from apps.permitato.schedule import ScheduleStore
+
+    state = app.state.permit_state
+    state.schedule_store = ScheduleStore(data_dir=permit_data_dir)
+    state.schedule_store.load()
+    await apply_startup_schedule(state)
+
     app.state.permit_expiry_task = asyncio.create_task(
         _exception_expiry_loop(app),
         name="permitato-expiry",
@@ -36,11 +49,15 @@ async def on_startup(app, app_dir: Path, data_dir: Path) -> None:
         _pihole_reconnection_loop(app),
         name="permitato-reconnect",
     )
+    app.state.permit_schedule_task = asyncio.create_task(
+        _schedule_check_loop(app),
+        name="permitato-schedule",
+    )
 
 
 async def on_shutdown(app) -> None:
     """Shutdown Permitato: cancel background tasks, disconnect adapter."""
-    for attr in ("permit_expiry_task", "permit_reconnect_task"):
+    for attr in ("permit_expiry_task", "permit_reconnect_task", "permit_schedule_task"):
         task = getattr(app.state, attr, None)
         if task is not None:
             task.cancel()
@@ -92,3 +109,51 @@ async def _pihole_reconnection_loop(app) -> None:
             await reconnect_pihole(state)
             if was_degraded and state.pihole_available:
                 write_audit_entry(state.data_dir, {"event": "pihole_recovered"})
+
+
+async def _schedule_check_loop(app) -> None:
+    """Background task: evaluate schedule and apply mode transitions every 60s."""
+    while True:
+        await asyncio.sleep(60)
+        state = getattr(app.state, "permit_state", None)
+        if state:
+            await _apply_schedule_tick(state)
+
+
+async def _apply_schedule_tick(
+    state: PermitState, now: datetime | None = None,
+) -> None:
+    """Single schedule evaluation tick — used by the loop and testable directly."""
+    from apps.permitato.audit import write_audit_entry
+
+    if not state.schedule_store:
+        return
+
+    scheduled_mode = state.schedule_store.evaluate(now)
+
+    # Override clearing: if the schedule has moved to a different window, clear
+    if state.override_mode is not None:
+        if scheduled_mode != state.override_scheduled_mode:
+            old_override = state.override_mode
+            state.override_mode = None
+            state.override_scheduled_mode = None
+            state.persist()
+            write_audit_entry(state.data_dir, {
+                "event": "override_cleared",
+                "old_override_mode": old_override,
+                "new_scheduled_mode": scheduled_mode,
+            })
+        else:
+            return  # override still valid, skip
+
+    effective = scheduled_mode or "normal"
+    if effective != state.mode:
+        old_mode = state.mode
+        state.mode = effective
+        state.persist()
+        await apply_mode_to_client(state)
+        write_audit_entry(state.data_dir, {
+            "event": "scheduled_mode_switch",
+            "from_mode": old_mode,
+            "to_mode": effective,
+        })

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 
 import httpx
 from fastapi import APIRouter, Request
@@ -15,7 +16,8 @@ from apps.permitato.intent import parse_llm_response, strip_action_markers
 from apps.permitato.modes import get_mode, MODES
 from apps.permitato.pihole_adapter import PiholeUnavailableError
 from apps.permitato.net_resolve import resolve_requester_ipv4
-from apps.permitato.state import apply_mode_to_client, validate_client
+from apps.permitato.lifecycle import _apply_schedule_tick
+from apps.permitato.state import PermitState, apply_mode_to_client, validate_client
 from apps.permitato.system_prompt import build_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -25,6 +27,26 @@ router = APIRouter()
 
 def _get_state(request: Request):
     return getattr(request.app.state, "permit_state", None)
+
+
+def _schedule_now() -> datetime:
+    """Return current local time. Extracted for test patching."""
+    return datetime.now()
+
+
+def _record_override(
+    state: PermitState, new_mode: str, now: datetime | None = None,
+) -> None:
+    """Set or clear override state based on whether new_mode deviates from schedule."""
+    scheduled_mode = None
+    if state.schedule_store:
+        scheduled_mode = state.schedule_store.evaluate(now)
+    if scheduled_mode is not None and new_mode != scheduled_mode:
+        state.override_mode = new_mode
+        state.override_scheduled_mode = scheduled_mode
+    else:
+        state.override_mode = None
+        state.override_scheduled_mode = None
 
 
 # ---------------------------------------------------------------------------
@@ -40,6 +62,10 @@ async def permitato_status(request: Request):
 
     mode_def = get_mode(state.mode)
     await validate_client(state)
+
+    now = _schedule_now()
+    scheduled_mode = state.schedule_store.evaluate(now) if state.schedule_store else None
+
     return {
         "mode": state.mode,
         "mode_display": mode_def.display_name,
@@ -50,6 +76,10 @@ async def permitato_status(request: Request):
         "degraded_since": state.degraded_since,
         "client_id": state.client_id,
         "client_valid": state.client_valid,
+        "schedule_active": scheduled_mode is not None,
+        "scheduled_mode": scheduled_mode,
+        "override_active": state.override_mode is not None,
+        "override_mode": state.override_mode,
     }
 
 
@@ -75,6 +105,7 @@ async def switch_mode(request: Request):
 
     old_mode = state.mode
     state.mode = mode_name
+    _record_override(state, mode_name)
     state.persist()
     await apply_mode_to_client(state)
 
@@ -82,6 +113,7 @@ async def switch_mode(request: Request):
         "event": "mode_switch",
         "from_mode": old_mode,
         "to_mode": mode_name,
+        "override": state.override_mode is not None,
     })
 
     return {"mode": mode_name, "mode_display": mode_def.display_name}
@@ -254,6 +286,127 @@ async def revoke_exception(request: Request, exception_id: str):
 
 
 # ---------------------------------------------------------------------------
+# GET /schedule
+# ---------------------------------------------------------------------------
+
+
+@router.get("/schedule")
+async def get_schedule(request: Request):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+
+    store = state.schedule_store
+    now = _schedule_now()
+    scheduled_mode = store.evaluate(now) if store else None
+    next_trans = store.next_transition(now) if store else None
+
+    return {
+        "rules": store.list_rules() if store else [],
+        "scheduled_mode": scheduled_mode,
+        "next_transition": next_trans,
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /schedule
+# ---------------------------------------------------------------------------
+
+
+@router.post("/schedule")
+async def create_schedule_rule(request: Request):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+    if not state.schedule_store:
+        return JSONResponse(status_code=503, content={"error": "Schedule not available"})
+
+    body = await request.json()
+    try:
+        rule = state.schedule_store.add_rule(
+            mode=body.get("mode", ""),
+            days=body.get("days", []),
+            start_time=body.get("start_time", ""),
+            end_time=body.get("end_time", ""),
+        )
+    except (ValueError, TypeError) as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+
+    state.schedule_store.persist()
+    write_audit_entry(state.data_dir, {
+        "event": "schedule_rule_created",
+        "rule_id": rule.id,
+        "mode": rule.mode,
+        "days": rule.days,
+        "start_time": rule.start_time,
+        "end_time": rule.end_time,
+    })
+
+    await _apply_schedule_tick(state, _schedule_now())
+    return {"rule": rule.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# PUT /schedule/{rule_id}
+# ---------------------------------------------------------------------------
+
+
+@router.put("/schedule/{rule_id}")
+async def update_schedule_rule(request: Request, rule_id: str):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+    if not state.schedule_store:
+        return JSONResponse(status_code=503, content={"error": "Schedule not available"})
+
+    body = await request.json()
+    try:
+        rule = state.schedule_store.update_rule(rule_id, **body)
+    except KeyError:
+        return JSONResponse(status_code=404, content={"error": f"No rule with id: {rule_id}"})
+    except (ValueError, TypeError) as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+
+    state.schedule_store.persist()
+    write_audit_entry(state.data_dir, {
+        "event": "schedule_rule_updated",
+        "rule_id": rule.id,
+    })
+
+    await _apply_schedule_tick(state, _schedule_now())
+    return {"rule": rule.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# DELETE /schedule/{rule_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/schedule/{rule_id}")
+async def delete_schedule_rule(request: Request, rule_id: str):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+    if not state.schedule_store:
+        return JSONResponse(status_code=503, content={"error": "Schedule not available"})
+
+    try:
+        rule = state.schedule_store.remove_rule(rule_id)
+    except KeyError:
+        return JSONResponse(status_code=404, content={"error": f"No rule with id: {rule_id}"})
+
+    state.schedule_store.persist()
+    write_audit_entry(state.data_dir, {
+        "event": "schedule_rule_deleted",
+        "rule_id": rule.id,
+        "mode": rule.mode,
+    })
+
+    await _apply_schedule_tick(state, _schedule_now())
+    return {"deleted": True}
+
+
+# ---------------------------------------------------------------------------
 # POST /chat
 # ---------------------------------------------------------------------------
 
@@ -270,11 +423,21 @@ async def permitato_chat(request: Request):
 
     # Build system prompt with current state
     mode_def = get_mode(state.mode)
+
+    schedule_status = "No schedule configured"
+    if state.schedule_store:
+        scheduled = state.schedule_store.evaluate()
+        if scheduled is not None and state.override_mode is not None:
+            schedule_status = f"Manually overridden from scheduled {scheduled} mode"
+        elif scheduled is not None:
+            schedule_status = f"Scheduled ({scheduled} mode active)"
+
     system_prompt = build_system_prompt(
         current_mode=mode_def.display_name,
         mode_description=mode_def.description,
         exception_count=state.exception_store.active_count() if state.exception_store else 0,
         active_exceptions=state.exception_store.list_active() if state.exception_store else [],
+        schedule_status=schedule_status,
     )
 
     # Build messages array for LLM
@@ -357,12 +520,14 @@ async def _execute_action(state, intent, user_message: str) -> dict:
 
         old_mode = state.mode
         state.mode = mode_name
+        _record_override(state, mode_name)
         state.persist()
         await apply_mode_to_client(state)
         write_audit_entry(state.data_dir, {
             "event": "mode_switch",
             "from_mode": old_mode,
             "to_mode": mode_name,
+            "override": state.override_mode is not None,
             "user_message": user_message,
         })
         return {"type": "mode_switched", "mode": mode_name, "display": mode_def.display_name}

--- a/apps/permitato/schedule.py
+++ b/apps/permitato/schedule.py
@@ -1,0 +1,204 @@
+"""Permitato schedule — day/time rules for automatic mode switching."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, time, timedelta
+from pathlib import Path
+
+from apps.permitato.modes import MODES
+
+logger = logging.getLogger(__name__)
+
+_TIME_RE = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+def _parse_time(s: str) -> time:
+    """Parse HH:MM into a time object, raising ValueError on bad format."""
+    if not _TIME_RE.match(s):
+        raise ValueError(f"Invalid time format: {s!r} (expected HH:MM, 24h)")
+    h, m = s.split(":")
+    return time(int(h), int(m))
+
+
+@dataclass
+class ScheduleRule:
+    id: str
+    mode: str
+    days: list[int]
+    start_time: str
+    end_time: str
+    enabled: bool = True
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "mode": self.mode,
+            "days": self.days,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "enabled": self.enabled,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ScheduleRule:
+        return cls(**{k: data[k] for k in (
+            "id", "mode", "days", "start_time", "end_time", "enabled",
+        )})
+
+
+@dataclass
+class ScheduleStore:
+    data_dir: Path | None
+    _rules: dict[str, ScheduleRule] = field(default_factory=dict)
+
+    def add_rule(
+        self, mode: str, days: list[int], start_time: str, end_time: str,
+    ) -> ScheduleRule:
+        """Create and store a new schedule rule with validation."""
+        if mode not in MODES:
+            raise ValueError(f"Invalid mode: {mode!r}. Valid: {list(MODES)}")
+        if not days:
+            raise ValueError("days must be a non-empty list")
+        for d in days:
+            if d < 0 or d > 6:
+                raise ValueError(f"Invalid day: {d} (must be 0=Mon..6=Sun)")
+
+        start = _parse_time(start_time)
+        end = _parse_time(end_time)
+        if end <= start:
+            raise ValueError(f"end_time ({end_time}) must be after start_time ({start_time})")
+
+        rule = ScheduleRule(
+            id=str(uuid.uuid4()),
+            mode=mode,
+            days=sorted(set(days)),
+            start_time=start_time,
+            end_time=end_time,
+        )
+        self._rules[rule.id] = rule
+        return rule
+
+    def remove_rule(self, rule_id: str) -> ScheduleRule:
+        if rule_id not in self._rules:
+            raise KeyError(f"No rule with id: {rule_id}")
+        return self._rules.pop(rule_id)
+
+    def update_rule(self, rule_id: str, **kwargs) -> ScheduleRule:
+        if rule_id not in self._rules:
+            raise KeyError(f"No rule with id: {rule_id}")
+
+        rule = self._rules[rule_id]
+
+        mode = kwargs.get("mode", rule.mode)
+        if mode not in MODES:
+            raise ValueError(f"Invalid mode: {mode!r}")
+
+        days = kwargs.get("days", rule.days)
+        if not days:
+            raise ValueError("days must be a non-empty list")
+        for d in days:
+            if d < 0 or d > 6:
+                raise ValueError(f"Invalid day: {d}")
+
+        start_time = kwargs.get("start_time", rule.start_time)
+        end_time = kwargs.get("end_time", rule.end_time)
+        start = _parse_time(start_time)
+        end = _parse_time(end_time)
+        if end <= start:
+            raise ValueError(f"end_time ({end_time}) must be after start_time ({start_time})")
+
+        enabled = kwargs.get("enabled", rule.enabled)
+
+        rule.mode = mode
+        rule.days = sorted(set(days))
+        rule.start_time = start_time
+        rule.end_time = end_time
+        rule.enabled = enabled
+        return rule
+
+    def list_rules(self) -> list[dict]:
+        return [r.to_dict() for r in self._rules.values()]
+
+    def evaluate(self, now: datetime | None = None) -> str | None:
+        """Return the mode for the current time, or None if no rule matches.
+
+        Iterates all enabled rules; if multiple match, the last-added wins.
+        """
+        if now is None:
+            now = datetime.now()
+
+        weekday = now.weekday()
+        current_time = now.time()
+        result = None
+
+        for rule in self._rules.values():
+            if not rule.enabled:
+                continue
+            if weekday not in rule.days:
+                continue
+            start = _parse_time(rule.start_time)
+            end = _parse_time(rule.end_time)
+            if start <= current_time < end:
+                result = rule.mode
+
+        return result
+
+    def next_transition(self, now: datetime | None = None) -> dict | None:
+        """Find the next point where the effective mode changes.
+
+        Scans forward minute-by-minute (up to 7 days) to find where
+        evaluate() returns a different result than it does right now.
+        """
+        if not self._rules:
+            return None
+        if now is None:
+            now = datetime.now()
+
+        current_mode = self.evaluate(now)
+        # Scan forward in 1-minute steps, up to 7 days
+        check = now + timedelta(minutes=1)
+        limit = now + timedelta(days=7)
+
+        while check <= limit:
+            candidate = self.evaluate(check)
+            if candidate != current_mode:
+                return {
+                    "time": check.strftime("%H:%M"),
+                    "day": check.weekday(),
+                    "mode": candidate or "normal",
+                    "at": check.isoformat(),
+                }
+            check += timedelta(minutes=1)
+
+        return None
+
+    def persist(self) -> None:
+        if self.data_dir is None:
+            return
+        from apps.permitato.state import atomic_write
+
+        path = self.data_dir / "schedule.json"
+        data = {
+            "version": 1,
+            "rules": {rid: r.to_dict() for rid, r in self._rules.items()},
+        }
+        atomic_write(path, json.dumps(data, indent=2))
+
+    def load(self) -> None:
+        if self.data_dir is None:
+            return
+        path = self.data_dir / "schedule.json"
+        if not path.exists():
+            return
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            for rid, rdata in data.get("rules", {}).items():
+                self._rules[rid] = ScheduleRule.from_dict(rdata)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            logger.warning("Failed to load schedule from %s, starting fresh", path)
+            self._rules.clear()

--- a/apps/permitato/state.py
+++ b/apps/permitato/state.py
@@ -9,9 +9,12 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from datetime import datetime
+
 from apps.permitato.exceptions import ExceptionStore
 from apps.permitato.modes import MODES, get_mode, WORK_DENY_DOMAINS, SFW_DENY_DOMAINS
 from apps.permitato.pihole_adapter import PiholeAdapter, PiholeUnavailableError
+from apps.permitato.schedule import ScheduleStore
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +32,9 @@ class PermitState:
     mode: str = "normal"
     adapter: PiholeAdapter | None = None
     exception_store: ExceptionStore | None = None
+    schedule_store: ScheduleStore | None = None
+    override_mode: str | None = None
+    override_scheduled_mode: str | None = None
     client_id: str = ""
     group_map: dict = field(default_factory=dict)
     exception_group_id: int = 0
@@ -42,9 +48,11 @@ class PermitState:
     def persist(self) -> None:
         path = self.data_dir / "state.json"
         atomic_write(path, json.dumps({
-            "version": 1,
+            "version": 2,
             "mode": self.mode,
             "client_id": self.client_id,
+            "override_mode": self.override_mode,
+            "override_scheduled_mode": self.override_scheduled_mode,
         }, indent=2))
 
     def load(self) -> None:
@@ -55,8 +63,20 @@ class PermitState:
             data = json.loads(path.read_text(encoding="utf-8"))
             self.mode = data.get("mode", "normal")
             self.client_id = data.get("client_id", "")
+            self.override_mode = data.get("override_mode")
+            self.override_scheduled_mode = data.get("override_scheduled_mode")
         except (json.JSONDecodeError, KeyError):
             logger.warning("Failed to load state from %s", path)
+
+    def effective_mode(self, now: datetime | None = None) -> str:
+        """Return the mode that should actually be applied."""
+        if self.override_mode is not None:
+            return self.override_mode
+        if self.schedule_store:
+            scheduled = self.schedule_store.evaluate(now)
+            if scheduled is not None:
+                return scheduled
+        return "normal"
 
 
 async def initialize_permitato(
@@ -291,3 +311,29 @@ async def compensate_exceptions(state: PermitState) -> None:
                 logger.info("Compensation: removed orphaned allow rule %s", rule["domain"])
             except Exception:
                 logger.warning("Compensation: failed to remove orphaned rule %s", rule["domain"])
+
+
+async def apply_startup_schedule(state: PermitState, now: datetime | None = None) -> None:
+    """Evaluate schedule on startup, clear stale overrides, and sync Pi-hole."""
+    if not state.schedule_store:
+        return
+
+    scheduled_mode = state.schedule_store.evaluate(now)
+
+    # Clear override if the schedule has moved past the overridden window
+    if state.override_mode is not None:
+        if scheduled_mode != state.override_scheduled_mode:
+            logger.info(
+                "Clearing stale override (was %s for %s, schedule now %s)",
+                state.override_mode, state.override_scheduled_mode, scheduled_mode,
+            )
+            state.override_mode = None
+            state.override_scheduled_mode = None
+            state.persist()
+
+    effective = state.effective_mode(now)
+    if effective != state.mode:
+        logger.info("Startup schedule: switching %s → %s", state.mode, effective)
+        state.mode = effective
+        state.persist()
+        await apply_mode_to_client(state)

--- a/apps/permitato/system_prompt.py
+++ b/apps/permitato/system_prompt.py
@@ -11,6 +11,7 @@ You are not a rigid gatekeeper. You are a thoughtful friend who asks "do you rea
 
 ## Current State
 Mode: {current_mode} ({mode_description})
+Schedule: {schedule_status}
 Active exceptions: {exception_count}
 {exception_details}
 
@@ -49,6 +50,7 @@ def build_system_prompt(
     mode_description: str,
     exception_count: int,
     active_exceptions: list[dict],
+    schedule_status: str = "No schedule configured",
 ) -> str:
     """Build the system prompt with current state injected."""
     if active_exceptions:
@@ -64,4 +66,5 @@ def build_system_prompt(
         mode_description=mode_description,
         exception_count=exception_count,
         exception_details=details,
+        schedule_status=schedule_status,
     )

--- a/apps/permitato/tests/schedule-panel.spec.js
+++ b/apps/permitato/tests/schedule-panel.spec.js
@@ -1,0 +1,122 @@
+const { test, expect } = require("@playwright/test");
+const { makeStatusPayload } = require("../../../tests/ui/helpers");
+
+async function openPermitato(page, { permitatoStatusRoute, scheduleRoute } = {}) {
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+  if (permitatoStatusRoute) {
+    await page.route("**/app/permitato/api/status", permitatoStatusRoute);
+  }
+  if (scheduleRoute) {
+    await page.route("**/app/permitato/api/schedule", scheduleRoute);
+  }
+  await page.goto("/");
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+  await page.locator('button[data-app="permitato"]').click();
+  await page.waitForFunction(() => {
+    const bar = document.getElementById("permitatoStatusBar");
+    const onb = document.getElementById("permitatoOnboarding");
+    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+  }, { timeout: 10000 });
+}
+
+const STATUS_SCHEDULED = {
+  mode: "work",
+  mode_display: "Work",
+  mode_description: "Social media blocked",
+  active_exceptions: 0,
+  exceptions: [],
+  pihole_available: true,
+  degraded_since: null,
+  client_id: "192.168.1.100",
+  client_valid: true,
+  schedule_active: true,
+  scheduled_mode: "work",
+  override_active: false,
+  override_mode: null,
+};
+
+const STATUS_OVERRIDDEN = {
+  ...STATUS_SCHEDULED,
+  mode: "normal",
+  mode_display: "Normal",
+  override_active: true,
+  override_mode: "normal",
+};
+
+const STATUS_NO_SCHEDULE = {
+  ...STATUS_SCHEDULED,
+  schedule_active: false,
+  scheduled_mode: null,
+};
+
+const SCHEDULE_WITH_RULES = {
+  rules: [
+    { id: "r1", mode: "work", days: [0, 1, 2, 3, 4], start_time: "09:00", end_time: "17:00", enabled: true },
+    { id: "r2", mode: "sfw", days: [5, 6], start_time: "22:00", end_time: "23:00", enabled: true },
+  ],
+  scheduled_mode: "work",
+  next_transition: { time: "17:00", day: 0, mode: "normal" },
+};
+
+
+test("schedule toggle opens and closes panel", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(STATUS_SCHEDULED) });
+    },
+    scheduleRoute: async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({ status: 200, body: JSON.stringify(SCHEDULE_WITH_RULES) });
+      } else {
+        await route.fallback();
+      }
+    },
+  });
+
+  await expect(page.locator("#permitatoSchedulePanel")).toBeHidden();
+
+  await page.locator("#permitatoScheduleToggle").click();
+  await expect(page.locator("#permitatoSchedulePanel")).toBeVisible();
+  await expect(page.locator(".permitato-schedule-rules li")).toHaveCount(2);
+
+  await page.locator("#permitatoScheduleToggle").click();
+  await expect(page.locator("#permitatoSchedulePanel")).toBeHidden();
+});
+
+
+test("schedule indicator shows scheduled when schedule is active", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(STATUS_SCHEDULED) });
+    },
+  });
+
+  await expect(page.locator("#permitatoScheduleIndicator")).toBeVisible();
+  await expect(page.locator("#permitatoScheduleIndicator")).toHaveText("(scheduled)");
+});
+
+
+test("schedule indicator shows override when overridden", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(STATUS_OVERRIDDEN) });
+    },
+  });
+
+  await expect(page.locator("#permitatoScheduleIndicator")).toBeVisible();
+  await expect(page.locator("#permitatoScheduleIndicator")).toHaveText("(override)");
+});
+
+
+test("schedule indicator hidden when no schedule", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(STATUS_NO_SCHEDULE) });
+    },
+  });
+
+  await expect(page.locator("#permitatoScheduleIndicator")).toBeHidden();
+});

--- a/apps/permitato/tests/test_lifecycle.py
+++ b/apps/permitato/tests/test_lifecycle.py
@@ -28,7 +28,9 @@ async def test_on_startup_initializes_state(tmp_path, monkeypatch):
 
     fake_state = MagicMock()
     mock_init = AsyncMock(return_value=fake_state)
+    mock_startup_sched = AsyncMock()
     monkeypatch.setattr(lifecycle, "initialize_permitato", mock_init)
+    monkeypatch.setattr(lifecycle, "apply_startup_schedule", mock_startup_sched)
     monkeypatch.setattr(asyncio, "create_task", lambda coro, **kw: (coro.close(), MagicMock())[1])
 
     app = MagicMock()
@@ -59,12 +61,15 @@ async def test_on_shutdown_cleans_up(monkeypatch):
 
     expiry_task = _FakeTask()
     reconnect_task = _FakeTask()
+    schedule_task = _FakeTask()
     app.state.permit_expiry_task = expiry_task
     app.state.permit_reconnect_task = reconnect_task
+    app.state.permit_schedule_task = schedule_task
     app.state.permit_state = MagicMock()
 
     await lifecycle.on_shutdown(app)
 
     assert expiry_task.cancel_called
     assert reconnect_task.cancel_called
+    assert schedule_task.cancel_called
     mock_shutdown.assert_awaited_once_with(app.state.permit_state)

--- a/apps/permitato/tests/test_schedule.py
+++ b/apps/permitato/tests/test_schedule.py
@@ -1,0 +1,946 @@
+"""Tests for Permitato schedule — day/time rules, evaluation, override, persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# ScheduleRule serialization
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_rule_roundtrip():
+    from apps.permitato.schedule import ScheduleRule
+
+    rule = ScheduleRule(
+        id="r1", mode="work", days=[0, 1, 2, 3, 4],
+        start_time="09:00", end_time="17:00",
+    )
+    restored = ScheduleRule.from_dict(rule.to_dict())
+    assert restored.id == rule.id
+    assert restored.mode == rule.mode
+    assert restored.days == rule.days
+    assert restored.start_time == rule.start_time
+    assert restored.end_time == rule.end_time
+    assert restored.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# add_rule validation
+# ---------------------------------------------------------------------------
+
+
+def test_add_rule_creates_with_uuid(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    rule = store.add_rule("work", [0, 1, 2, 3, 4], "09:00", "17:00")
+    assert rule.id
+    assert rule.mode == "work"
+    assert len(store.list_rules()) == 1
+
+
+def test_add_rule_rejects_invalid_mode(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="mode"):
+        store.add_rule("invalid", [0], "09:00", "17:00")
+
+
+def test_add_rule_rejects_empty_days(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="days"):
+        store.add_rule("work", [], "09:00", "17:00")
+
+
+def test_add_rule_rejects_invalid_day(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="day"):
+        store.add_rule("work", [7], "09:00", "17:00")
+    with pytest.raises(ValueError, match="day"):
+        store.add_rule("work", [-1], "09:00", "17:00")
+
+
+def test_add_rule_rejects_bad_time_format(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="time"):
+        store.add_rule("work", [0], "9:00", "17:00")
+    with pytest.raises(ValueError, match="time"):
+        store.add_rule("work", [0], "09:00", "25:00")
+
+
+def test_add_rule_rejects_end_before_start(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="end_time.*start_time"):
+        store.add_rule("work", [0], "17:00", "09:00")
+
+
+def test_add_rule_rejects_equal_start_end(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="end_time.*start_time"):
+        store.add_rule("work", [0], "09:00", "09:00")
+
+
+# ---------------------------------------------------------------------------
+# remove_rule / update_rule
+# ---------------------------------------------------------------------------
+
+
+def test_remove_rule(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    rule = store.add_rule("work", [0], "09:00", "17:00")
+    removed = store.remove_rule(rule.id)
+    assert removed.id == rule.id
+    assert len(store.list_rules()) == 0
+
+
+def test_remove_rule_unknown_id(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(KeyError):
+        store.remove_rule("nonexistent")
+
+
+def test_update_rule(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    rule = store.add_rule("work", [0], "09:00", "17:00")
+    updated = store.update_rule(rule.id, mode="sfw", start_time="10:00")
+    assert updated.mode == "sfw"
+    assert updated.start_time == "10:00"
+    assert updated.end_time == "17:00"  # unchanged
+
+
+def test_update_rule_unknown_id(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    with pytest.raises(KeyError):
+        store.update_rule("nonexistent", mode="sfw")
+
+
+# ---------------------------------------------------------------------------
+# evaluate()
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_inside_window():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0, 1, 2, 3, 4], "09:00", "17:00")
+    # Monday 10:00
+    now = datetime(2026, 3, 30, 10, 0)  # 2026-03-30 is a Monday
+    assert store.evaluate(now) == "work"
+
+
+def test_evaluate_outside_window():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0, 1, 2, 3, 4], "09:00", "17:00")
+    # Monday 18:00
+    now = datetime(2026, 3, 30, 18, 0)
+    assert store.evaluate(now) is None
+
+
+def test_evaluate_wrong_day():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")  # Monday only
+    # Tuesday 10:00
+    now = datetime(2026, 3, 31, 10, 0)
+    assert store.evaluate(now) is None
+
+
+def test_evaluate_at_start_boundary():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+    # Exactly 09:00
+    now = datetime(2026, 3, 30, 9, 0)
+    assert store.evaluate(now) == "work"
+
+
+def test_evaluate_at_end_boundary():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+    # Exactly 17:00 — outside the window (end is exclusive)
+    now = datetime(2026, 3, 30, 17, 0)
+    assert store.evaluate(now) is None
+
+
+def test_evaluate_disabled_rule_ignored():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    rule = store.add_rule("work", [0], "09:00", "17:00")
+    store.update_rule(rule.id, enabled=False)
+    now = datetime(2026, 3, 30, 10, 0)
+    assert store.evaluate(now) is None
+
+
+def test_evaluate_empty_store():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    assert store.evaluate(datetime(2026, 3, 30, 10, 0)) is None
+
+
+def test_evaluate_overlapping_rules_last_wins():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+    store.add_rule("sfw", [0], "08:00", "18:00")
+    now = datetime(2026, 3, 30, 10, 0)
+    assert store.evaluate(now) == "sfw"
+
+
+def test_evaluate_multiple_non_overlapping():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0, 1, 2, 3, 4], "09:00", "17:00")
+    store.add_rule("sfw", [0, 1, 2, 3, 4, 5, 6], "22:00", "23:59")
+    # Monday 10:00 → work
+    assert store.evaluate(datetime(2026, 3, 30, 10, 0)) == "work"
+    # Monday 22:30 → sfw
+    assert store.evaluate(datetime(2026, 3, 30, 22, 30)) == "sfw"
+    # Monday 20:00 → none
+    assert store.evaluate(datetime(2026, 3, 30, 20, 0)) is None
+
+
+# ---------------------------------------------------------------------------
+# next_transition()
+# ---------------------------------------------------------------------------
+
+
+def test_next_transition_upcoming():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+    # Monday 07:00 → next transition is "work" at 09:00
+    now = datetime(2026, 3, 30, 7, 0)
+    nxt = store.next_transition(now)
+    assert nxt is not None
+    assert nxt["mode"] == "work"
+    assert nxt["time"] == "09:00"
+
+
+def test_next_transition_is_end_of_window():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+    # Monday 10:00 (inside window) → next transition is end at 17:00
+    now = datetime(2026, 3, 30, 10, 0)
+    nxt = store.next_transition(now)
+    assert nxt is not None
+    assert nxt["time"] == "17:00"
+    assert nxt["mode"] == "normal"  # what it transitions TO
+
+
+def test_next_transition_empty_schedule():
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=None)
+    assert store.next_transition(datetime(2026, 3, 30, 10, 0)) is None
+
+
+# ---------------------------------------------------------------------------
+# persist / load
+# ---------------------------------------------------------------------------
+
+
+def test_persist_and_load_roundtrip(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    store.add_rule("work", [0, 1, 2, 3, 4], "09:00", "17:00")
+    store.add_rule("sfw", [5, 6], "22:00", "23:00")
+    store.persist()
+
+    store2 = ScheduleStore(data_dir=tmp_path)
+    store2.load()
+    assert len(store2.list_rules()) == 2
+
+
+def test_load_missing_file(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    store = ScheduleStore(data_dir=tmp_path)
+    store.load()
+    assert len(store.list_rules()) == 0
+
+
+def test_load_corrupt_json(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+
+    (tmp_path / "schedule.json").write_text("not json!!!")
+    store = ScheduleStore(data_dir=tmp_path)
+    store.load()
+    assert len(store.list_rules()) == 0
+
+
+# ---------------------------------------------------------------------------
+# PermitState override fields and effective_mode
+# ---------------------------------------------------------------------------
+
+
+def test_state_persist_loads_override_fields(tmp_path):
+    from unittest.mock import AsyncMock
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.mode = "normal"
+    state.override_mode = "normal"
+    state.override_scheduled_mode = "work"
+    state.persist()
+
+    state2 = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state2.load()
+    assert state2.override_mode == "normal"
+    assert state2.override_scheduled_mode == "work"
+
+
+def test_state_load_v1_no_override(tmp_path):
+    """Loading a version-1 state.json (pre-schedule) sets override fields to None."""
+    import json
+    (tmp_path / "state.json").write_text(json.dumps({
+        "version": 1, "mode": "work", "client_id": "192.168.1.5",
+    }))
+
+    from apps.permitato.state import PermitState
+    state = PermitState(data_dir=tmp_path)
+    state.load()
+    assert state.mode == "work"
+    assert state.override_mode is None
+    assert state.override_scheduled_mode is None
+
+
+def test_effective_mode_override_wins(tmp_path):
+    from unittest.mock import MagicMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0, 1, 2, 3, 4], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path)
+    state.schedule_store = store
+    state.override_mode = "normal"
+    # Even though schedule says "work", override takes precedence
+    now = datetime(2026, 3, 30, 10, 0)
+    assert state.effective_mode(now) == "normal"
+
+
+def test_effective_mode_schedule_when_no_override(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0, 1, 2, 3, 4], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path)
+    state.schedule_store = store
+    now = datetime(2026, 3, 30, 10, 0)
+    assert state.effective_mode(now) == "work"
+
+
+def test_effective_mode_normal_when_nothing_matches(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    state = PermitState(data_dir=tmp_path)
+    state.schedule_store = store
+    assert state.effective_mode(datetime(2026, 3, 30, 10, 0)) == "normal"
+
+
+def test_effective_mode_normal_when_no_store(tmp_path):
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path)
+    assert state.effective_mode() == "normal"
+
+
+# ---------------------------------------------------------------------------
+# Schedule check loop behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_schedule_loop_applies_scheduled_mode(tmp_path):
+    """When schedule says 'work' and current mode is 'normal', loop switches."""
+    from unittest.mock import AsyncMock, patch
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    state.mode = "normal"
+    state.pihole_available = True
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    now = datetime(2026, 3, 30, 10, 0)
+    await _apply_schedule_tick(state, now)
+
+    assert state.mode == "work"
+
+
+@pytest.mark.anyio
+async def test_schedule_loop_skips_when_override_in_same_window(tmp_path):
+    """Override stays active while we're still in the same scheduled window."""
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    state.mode = "normal"
+    state.override_mode = "normal"
+    state.override_scheduled_mode = "work"
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    now = datetime(2026, 3, 30, 10, 0)  # still inside work window
+    await _apply_schedule_tick(state, now)
+
+    assert state.mode == "normal"  # override held
+    assert state.override_mode == "normal"
+
+
+@pytest.mark.anyio
+async def test_schedule_loop_clears_override_on_transition(tmp_path):
+    """Override clears when schedule transitions to a different window."""
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    state.mode = "normal"
+    state.override_mode = "normal"
+    state.override_scheduled_mode = "work"
+    state.pihole_available = True
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    now = datetime(2026, 3, 30, 18, 0)  # outside work window
+    await _apply_schedule_tick(state, now)
+
+    assert state.override_mode is None
+    assert state.override_scheduled_mode is None
+    # Effective mode is "normal" (no schedule match → fallback)
+    assert state.mode == "normal"
+
+
+@pytest.mark.anyio
+async def test_schedule_loop_noop_when_mode_matches(tmp_path):
+    """No Pi-hole call when scheduled mode already matches current mode."""
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    adapter = AsyncMock()
+    state = PermitState(data_dir=tmp_path, adapter=adapter)
+    state.schedule_store = store
+    state.mode = "work"
+    state.pihole_available = True
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    now = datetime(2026, 3, 30, 10, 0)
+    await _apply_schedule_tick(state, now)
+
+    assert state.mode == "work"
+    adapter.update_client.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_schedule_loop_noop_without_store(tmp_path):
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path)
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    await _apply_schedule_tick(state, datetime(2026, 3, 30, 10, 0))
+    assert state.mode == "normal"
+
+
+# ---------------------------------------------------------------------------
+# Startup schedule evaluation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_startup_clears_stale_override(tmp_path):
+    """On startup, override is cleared if schedule has moved past its window."""
+    import json
+
+    # Simulate persisted state with override for a 'work' window
+    (tmp_path / "state.json").write_text(json.dumps({
+        "version": 2, "mode": "normal", "client_id": "",
+        "override_mode": "normal", "override_scheduled_mode": "work",
+    }))
+    # Schedule: work Mon 09:00-17:00
+    (tmp_path / "schedule.json").write_text(json.dumps({
+        "version": 1,
+        "rules": {"r1": {
+            "id": "r1", "mode": "work", "days": [0],
+            "start_time": "09:00", "end_time": "17:00", "enabled": True,
+        }},
+    }))
+
+    from apps.permitato.state import PermitState
+    from apps.permitato.schedule import ScheduleStore
+
+    state = PermitState(data_dir=tmp_path)
+    state.load()
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+    state.schedule_store.load()
+
+    # Simulate boot at 18:00 Mon — outside the work window
+    from apps.permitato.state import apply_startup_schedule
+    await apply_startup_schedule(state, now=datetime(2026, 3, 30, 18, 0))
+
+    assert state.override_mode is None
+    assert state.override_scheduled_mode is None
+
+    # Verify the clear was persisted to disk (not just in memory)
+    saved = json.loads((tmp_path / "state.json").read_text())
+    assert saved["override_mode"] is None
+    assert saved["override_scheduled_mode"] is None
+
+
+@pytest.mark.anyio
+async def test_startup_preserves_valid_override(tmp_path):
+    """On startup, override stays if still within the same scheduled window."""
+    import json
+
+    (tmp_path / "state.json").write_text(json.dumps({
+        "version": 2, "mode": "normal", "client_id": "",
+        "override_mode": "normal", "override_scheduled_mode": "work",
+    }))
+    (tmp_path / "schedule.json").write_text(json.dumps({
+        "version": 1,
+        "rules": {"r1": {
+            "id": "r1", "mode": "work", "days": [0],
+            "start_time": "09:00", "end_time": "17:00", "enabled": True,
+        }},
+    }))
+
+    from apps.permitato.state import PermitState
+    from apps.permitato.schedule import ScheduleStore
+
+    state = PermitState(data_dir=tmp_path)
+    state.load()
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+    state.schedule_store.load()
+
+    # Boot at 10:00 Mon — still inside work window
+    from apps.permitato.state import apply_startup_schedule
+    await apply_startup_schedule(state, now=datetime(2026, 3, 30, 10, 0))
+
+    assert state.override_mode == "normal"
+    assert state.mode == "normal"  # override held
+
+
+# ---------------------------------------------------------------------------
+# P1: Startup must apply mode to Pi-hole client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_startup_schedule_applies_to_pihole(tmp_path):
+    """apply_startup_schedule must call apply_mode_to_client when mode changes."""
+    import json
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState, apply_startup_schedule
+
+    # Persisted state says "normal", but schedule says "work" right now
+    (tmp_path / "state.json").write_text(json.dumps({
+        "version": 2, "mode": "normal", "client_id": "192.168.1.5",
+        "override_mode": None, "override_scheduled_mode": None,
+    }))
+    (tmp_path / "schedule.json").write_text(json.dumps({
+        "version": 1,
+        "rules": {"r1": {
+            "id": "r1", "mode": "work", "days": [0],
+            "start_time": "09:00", "end_time": "17:00", "enabled": True,
+        }},
+    }))
+
+    adapter = AsyncMock()
+    state = PermitState(data_dir=tmp_path, adapter=adapter)
+    state.load()
+    state.pihole_available = True
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+    state.schedule_store.load()
+
+    now = datetime(2026, 3, 30, 10, 0)  # Monday 10:00, inside work window
+    await apply_startup_schedule(state, now=now)
+
+    assert state.mode == "work"
+    adapter.update_client.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# P1: Override clear must persist even when effective mode stays same
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_schedule_tick_persists_override_clear_same_mode(tmp_path):
+    """When override clears but effective mode matches state.mode, still persist."""
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    # User overrode to "normal" during work window, then work window ended
+    state.mode = "normal"
+    state.override_mode = "normal"
+    state.override_scheduled_mode = "work"
+    state.pihole_available = True
+    state.persist()
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    now = datetime(2026, 3, 30, 18, 0)  # outside work window — override should clear
+    await _apply_schedule_tick(state, now)
+
+    assert state.override_mode is None
+
+    # Verify the clear was persisted (reload from disk)
+    import json
+    saved = json.loads((tmp_path / "state.json").read_text())
+    assert saved["override_mode"] is None
+    assert saved["override_scheduled_mode"] is None
+
+
+# ---------------------------------------------------------------------------
+# P2: Schedule edits re-evaluate immediately
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_post_schedule_applies_immediately(tmp_path):
+    """Creating a rule whose window includes now must apply the mode right away."""
+    from unittest.mock import AsyncMock, patch
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    state = PermitState(data_dir=tmp_path, adapter=adapter)
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+    state.mode = "normal"
+    state.client_id = "192.168.1.5"
+    state.pihole_available = True
+
+    from apps.permitato import routes
+    now = datetime(2026, 3, 30, 10, 0)  # Monday 10:00
+    with patch.object(routes, "_schedule_now", return_value=now):
+        result = await _call_post_schedule(state, {
+            "mode": "work", "days": [0, 1, 2, 3, 4],
+            "start_time": "09:00", "end_time": "17:00",
+        })
+
+    assert result["rule"]["mode"] == "work"
+    assert state.mode == "work"
+    adapter.update_client.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_delete_schedule_applies_immediately(tmp_path):
+    """Deleting the active rule must revert mode right away."""
+    from unittest.mock import AsyncMock, patch
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    state = PermitState(data_dir=tmp_path, adapter=adapter)
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+    rule = state.schedule_store.add_rule("work", [0], "09:00", "17:00")
+    state.mode = "work"
+    state.pihole_available = True
+
+    from apps.permitato import routes
+    now = datetime(2026, 3, 30, 10, 0)
+    with patch.object(routes, "_schedule_now", return_value=now):
+        result = await _call_delete_schedule(state, rule.id)
+
+    assert result["deleted"] is True
+    assert state.mode == "normal"  # reverted because no rules match
+
+
+# ---------------------------------------------------------------------------
+# Override recording on POST /mode
+# ---------------------------------------------------------------------------
+
+
+def test_record_override_sets_when_deviating(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import _record_override
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path)
+    state.schedule_store = store
+
+    _record_override(state, "normal", now=datetime(2026, 3, 30, 10, 0))
+    assert state.override_mode == "normal"
+    assert state.override_scheduled_mode == "work"
+
+
+def test_record_override_clears_when_matching(tmp_path):
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import _record_override
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path)
+    state.schedule_store = store
+    state.override_mode = "normal"
+    state.override_scheduled_mode = "work"
+
+    # User switches back to "work" — matches schedule, clear override
+    _record_override(state, "work", now=datetime(2026, 3, 30, 10, 0))
+    assert state.override_mode is None
+    assert state.override_scheduled_mode is None
+
+
+def test_record_override_noop_when_no_schedule(tmp_path):
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import _record_override
+
+    state = PermitState(data_dir=tmp_path)
+    _record_override(state, "work")
+    assert state.override_mode is None
+
+
+# ---------------------------------------------------------------------------
+# Schedule CRUD API routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_schedule_empty(tmp_path):
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+    from apps.permitato.routes import get_schedule
+    from starlette.testclient import TestClient
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+
+    result = await _call_get_schedule(state)
+    assert result["rules"] == []
+    assert result["scheduled_mode"] is None
+
+
+@pytest.mark.anyio
+async def test_post_schedule_creates_rule(tmp_path):
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+
+    result = await _call_post_schedule(state, {
+        "mode": "work", "days": [0, 1, 2, 3, 4],
+        "start_time": "09:00", "end_time": "17:00",
+    })
+    assert "rule" in result
+    assert result["rule"]["mode"] == "work"
+    assert len(state.schedule_store.list_rules()) == 1
+
+
+@pytest.mark.anyio
+async def test_post_schedule_rejects_invalid(tmp_path):
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+
+    result, status = await _call_post_schedule(
+        state, {"mode": "invalid", "days": [0], "start_time": "09:00", "end_time": "17:00"},
+        return_status=True,
+    )
+    assert status == 400
+
+
+@pytest.mark.anyio
+async def test_delete_schedule_removes_rule(tmp_path):
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+    rule = state.schedule_store.add_rule("work", [0], "09:00", "17:00")
+
+    result = await _call_delete_schedule(state, rule.id)
+    assert result["deleted"] is True
+    assert len(state.schedule_store.list_rules()) == 0
+
+
+@pytest.mark.anyio
+async def test_delete_schedule_unknown_id(tmp_path):
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+
+    result, status = await _call_delete_schedule(state, "nonexistent", return_status=True)
+    assert status == 404
+
+
+@pytest.mark.anyio
+async def test_get_status_includes_schedule_fields(tmp_path):
+    from unittest.mock import AsyncMock, MagicMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    state.pihole_available = True
+    state.exception_store = MagicMock()
+    state.exception_store.active_count.return_value = 0
+    state.exception_store.list_active.return_value = []
+
+    result = await _call_get_status(state, now=datetime(2026, 3, 30, 10, 0))
+    assert result["schedule_active"] is True
+    assert result["scheduled_mode"] == "work"
+    assert result["override_active"] is False
+    assert result["override_mode"] is None
+
+
+@pytest.mark.anyio
+async def test_get_status_override_fields(tmp_path):
+    from unittest.mock import AsyncMock, MagicMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+    store.add_rule("work", [0], "09:00", "17:00")
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    state.override_mode = "normal"
+    state.override_scheduled_mode = "work"
+    state.pihole_available = True
+    state.exception_store = MagicMock()
+    state.exception_store.active_count.return_value = 0
+    state.exception_store.list_active.return_value = []
+
+    result = await _call_get_status(state, now=datetime(2026, 3, 30, 10, 0))
+    assert result["override_active"] is True
+    assert result["override_mode"] == "normal"
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — direct function calls with mock state
+# ---------------------------------------------------------------------------
+
+
+async def _call_get_schedule(state):
+    """Call the get_schedule route handler directly."""
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.app.state.permit_state = state
+
+    from apps.permitato.routes import get_schedule
+    return await get_schedule(request)
+
+
+async def _call_post_schedule(state, body, return_status=False):
+    from unittest.mock import AsyncMock, MagicMock
+    request = MagicMock()
+    request.app.state.permit_state = state
+    request.json = AsyncMock(return_value=body)
+
+    from apps.permitato.routes import create_schedule_rule
+    result = await create_schedule_rule(request)
+    if return_status:
+        if hasattr(result, "status_code"):
+            import json
+            return json.loads(result.body.decode()), result.status_code
+        return result, 200
+    return result
+
+
+async def _call_delete_schedule(state, rule_id, return_status=False):
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.app.state.permit_state = state
+
+    from apps.permitato.routes import delete_schedule_rule
+    result = await delete_schedule_rule(request, rule_id)
+    if return_status:
+        if hasattr(result, "status_code"):
+            import json
+            return json.loads(result.body.decode()), result.status_code
+        return result, 200
+    return result
+
+
+async def _call_get_status(state, now=None):
+    from unittest.mock import AsyncMock, MagicMock, patch
+    request = MagicMock()
+    request.app.state.permit_state = state
+
+    from apps.permitato import routes
+    if now:
+        with patch.object(routes, "_schedule_now", return_value=now):
+            return await routes.permitato_status(request)
+    return await routes.permitato_status(request)


### PR DESCRIPTION
## Summary

- Add weekly schedule model with day-of-week + time-window rules for automatic mode switching
- Schedule check loop evaluates every 60s and applies mode transitions against Pi-hole
- Manual override lasts until next scheduled transition, then clears automatically
- Schedule CRUD API (GET/POST/PUT/DELETE `/schedule`)
- Status API extended with `schedule_active`, `scheduled_mode`, `override_active`, `override_mode`
- Schedule editor UI panel with rule creation, day picker, time inputs, delete controls
- Mode badge shows `(scheduled)` or `(override)` indicator
- System prompt includes schedule context for LLM awareness
- All state persists across restarts — schedule in `schedule.json`, overrides in `state.json`

Closes #220
Refs #219

## Test evidence

**Python (50 schedule tests + full suite):**
```
uv run python -m pytest tests/unit tests/api apps/permitato/tests -q -n auto
732 passed in 10.34s
```

**Playwright (4 schedule tests + full suite):**
```
npx playwright test --reporter=dot --timeout=15000 --workers=75%
118 passed (29.5s)
```

## Test plan

- [x] Schedule model: rule CRUD, validation, evaluate(), next_transition(), persist/load
- [x] Override state: persist/load, effective_mode() precedence, backward compat with v1 state
- [x] Schedule loop: applies mode, skips during override, clears on transition, noop when matching
- [x] Startup: evaluates immediately, clears stale overrides, preserves valid overrides
- [x] Override recording: set when deviating from schedule, clear when matching
- [x] Schedule CRUD routes: create, delete, validation errors, 404 handling
- [x] Status API: schedule/override fields present
- [x] UI: panel toggle, rule rendering, schedule/override indicators
- [ ] Pi QA: deploy, create schedule, verify timed transition, verify override clear