### PR TITLE
feat(permitato): add attention stats and streaks from audit history

### DIFF
--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -766,3 +766,101 @@
   color: var(--text-muted);
   font-size: 0.8rem;
 }
+
+/* Stats toggle */
+.permitato-stats-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 2px 8px;
+  margin: -2px 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text-muted);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.permitato-stats-toggle:hover {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.permitato-stats-toggle[aria-expanded="true"] {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* Stats panel */
+.permitato-stats-panel {
+  margin: 0 16px;
+  padding: 10px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+}
+
+.permitato-stats-panel[hidden] {
+  display: none;
+}
+
+.permitato-stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.permitato-stats-grid[hidden] {
+  display: none;
+}
+
+.permitato-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.stat-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-value.streak-active {
+  color: #22c55e;
+}
+
+.stat-label {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin-top: 2px;
+}
+
+.permitato-top-domains {
+  font-size: 0.8rem;
+  padding: 8px 0 0;
+}
+
+.top-domains-label {
+  color: var(--text-muted);
+}
+
+.permitato-stats-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 12px 0;
+}
+
+.permitato-stats-footer {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  text-align: center;
+  padding-top: 6px;
+}

--- a/apps/permitato/assets/permitato.html
+++ b/apps/permitato/assets/permitato.html
@@ -31,6 +31,7 @@
   <button id="permitatoScheduleToggle" class="permitato-schedule-toggle" type="button">
     <span id="permitatoScheduleLabel">Schedule</span>
   </button>
+  <button id="permitatoStatsToggle" class="permitato-stats-toggle" type="button">Stats</button>
   <div id="permitatoPiholeStatus" class="permitato-pihole-status">
     <span id="permitatoPiholeDot" class="permitato-pihole-dot"></span>
     <span id="permitatoPiholeLabel">Checking...</span>
@@ -87,6 +88,35 @@
       <button id="permitatoSaveRuleBtn" class="permitato-save-rule-btn">Save</button>
       <button id="permitatoCancelRuleBtn" class="permitato-cancel-rule-btn">Cancel</button>
     </div>
+  </div>
+</section>
+
+<section id="permitatoStatsPanel" class="permitato-stats-panel" hidden>
+  <div class="permitato-stats-grid" id="permitatoStatsGrid">
+    <div class="permitato-stat">
+      <span class="stat-value" id="permitatoStreakValue">--</span>
+      <span class="stat-label">day focus streak</span>
+    </div>
+    <div class="permitato-stat">
+      <span class="stat-value" id="permitatoTodayValue">--</span>
+      <span class="stat-label" id="permitatoTodayLabel">requests today</span>
+    </div>
+    <div class="permitato-stat">
+      <span class="stat-value" id="permitatoDenyRateValue">--</span>
+      <span class="stat-label">requests denied</span>
+    </div>
+    <div class="permitato-stat">
+      <span class="stat-value" id="permitatoModeDurationValue">--</span>
+      <span class="stat-label" id="permitatoModeDurationLabel">in current mode</span>
+    </div>
+  </div>
+  <div id="permitatoTopDomains" class="permitato-top-domains" hidden>
+    <span class="top-domains-label">Top distractions: </span>
+    <span id="permitatoTopDomainsList" class="top-domains-list"></span>
+  </div>
+  <div id="permitatoStatsEmpty" class="permitato-stats-empty" hidden>No activity recorded yet</div>
+  <div id="permitatoStatsFooter" class="permitato-stats-footer" hidden>
+    Based on last <span id="permitatoDataSpan">0</span> days
   </div>
 </section>
 

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -9,6 +9,7 @@ let _pendingClientSelection = false;
 let _lastClientFetchTs = 0;
 let _panelOpen = false;
 let _schedulePanelOpen = false;
+let _statsPanelOpen = false;
 let _ttlTimer = null;
 let _latestExceptions = [];
 let _latestPiholeAvailable = true;
@@ -46,6 +47,9 @@ export function init(shellApi) {
   const schedToggle = document.getElementById("permitatoScheduleToggle");
   if (schedToggle) schedToggle.addEventListener("click", _toggleSchedulePanel);
 
+  const statsToggle = document.getElementById("permitatoStatsToggle");
+  if (statsToggle) statsToggle.addEventListener("click", _toggleStatsPanel);
+
   const addRuleBtn = document.getElementById("permitatoAddRuleBtn");
   if (addRuleBtn) addRuleBtn.addEventListener("click", _showAddRuleForm);
 
@@ -76,6 +80,7 @@ async function _pollStatus() {
     if (!resp.ok) return;
     const data = await resp.json();
     _updateStatusBar(data);
+    if (_statsPanelOpen) _fetchStats();
   } catch {
     _updateStatusBar({ pihole_available: false, mode: "unknown", active_exceptions: 0 });
   }
@@ -708,4 +713,118 @@ async function _loadSession() {
   } catch {
     // silent
   }
+}
+
+
+// ---------------------------------------------------------------------------
+// Stats panel
+// ---------------------------------------------------------------------------
+
+function _toggleStatsPanel() {
+  _statsPanelOpen = !_statsPanelOpen;
+  const panel = document.getElementById("permitatoStatsPanel");
+  const toggle = document.getElementById("permitatoStatsToggle");
+  if (panel) panel.hidden = !_statsPanelOpen;
+  if (toggle) toggle.setAttribute("aria-expanded", String(_statsPanelOpen));
+  if (_statsPanelOpen) _fetchStats();
+}
+
+async function _fetchStats() {
+  try {
+    const resp = await fetch(`${PERMITATO_API}/stats`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    _renderStats(data);
+  } catch {
+    // silent
+  }
+}
+
+function _renderStats(data) {
+  const empty = document.getElementById("permitatoStatsEmpty");
+  const grid = document.getElementById("permitatoStatsGrid");
+  const domainsEl = document.getElementById("permitatoTopDomains");
+  const footer = document.getElementById("permitatoStatsFooter");
+
+  const hasData = data.data_span_days > 0 ||
+    data.requests_today.granted > 0 ||
+    data.requests_today.denied > 0 ||
+    data.top_domains.length > 0 ||
+    data.deny_rate.total > 0;
+
+  if (!hasData) {
+    if (empty) empty.hidden = false;
+    if (grid) grid.hidden = true;
+    if (domainsEl) domainsEl.hidden = true;
+    if (footer) footer.hidden = true;
+    return;
+  }
+
+  if (empty) empty.hidden = true;
+  if (grid) grid.hidden = false;
+
+  // Streak
+  const streakVal = document.getElementById("permitatoStreakValue");
+  if (streakVal) {
+    streakVal.textContent = String(data.focus_streak_days);
+    streakVal.classList.toggle("streak-active", data.focus_streak_days > 0);
+  }
+
+  // Today
+  const todayVal = document.getElementById("permitatoTodayValue");
+  const todayLabel = document.getElementById("permitatoTodayLabel");
+  const total = data.requests_today.granted + data.requests_today.denied;
+  if (todayVal) todayVal.textContent = String(total);
+  if (todayLabel) {
+    if (total === 0) todayLabel.textContent = "requests today";
+    else todayLabel.textContent = `today (${data.requests_today.denied} denied)`;
+  }
+
+  // Deny rate
+  const denyVal = document.getElementById("permitatoDenyRateValue");
+  if (denyVal) {
+    denyVal.textContent = data.deny_rate.rate !== null
+      ? Math.round(data.deny_rate.rate * 100) + "%"
+      : "--";
+  }
+
+  // Mode duration
+  const modeVal = document.getElementById("permitatoModeDurationValue");
+  if (modeVal) {
+    modeVal.textContent = data.mode_duration_seconds !== null
+      ? _formatDuration(data.mode_duration_seconds)
+      : "--";
+  }
+
+  // Top domains
+  if (domainsEl) {
+    const list = document.getElementById("permitatoTopDomainsList");
+    if (data.top_domains.length > 0) {
+      domainsEl.hidden = false;
+      if (list) {
+        list.textContent = data.top_domains
+          .map(d => `${d.domain} (${d.count})`)
+          .join(", ");
+      }
+    } else {
+      domainsEl.hidden = true;
+    }
+  }
+
+  // Footer
+  if (footer) {
+    const span = document.getElementById("permitatoDataSpan");
+    if (span) span.textContent = String(data.data_span_days);
+    footer.hidden = data.data_span_days < 1;
+  }
+}
+
+function _formatDuration(seconds) {
+  if (seconds < 60) return "<1m";
+  const m = Math.floor(seconds / 60);
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  if (h === 0) return `${m}m`;
+  if (rm === 0) return `${h}h`;
+  return `${h}h ${rm}m`;
 }

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from apps.permitato.audit import build_recent_context, read_audit_log, write_audit_entry
 from apps.permitato.exceptions import ExceptionStore, build_domain_regex
 from apps.permitato.intent import parse_llm_response, strip_action_markers
+from apps.permitato.stats import compute_stats
 from apps.permitato.modes import get_mode, MODES
 from apps.permitato.pihole_adapter import PiholeUnavailableError
 from apps.permitato.net_resolve import resolve_requester_ipv4
@@ -81,6 +82,20 @@ async def permitato_status(request: Request):
         "override_active": state.override_mode is not None,
         "override_mode": state.override_mode,
     }
+
+
+# ---------------------------------------------------------------------------
+# GET /stats
+# ---------------------------------------------------------------------------
+
+
+@router.get("/stats")
+async def permitato_stats(request: Request):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+    entries = read_audit_log(state.data_dir, limit=5000)
+    return compute_stats(entries, current_mode=state.mode)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/permitato/state.py
+++ b/apps/permitato/state.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from datetime import datetime
 
+from apps.permitato.audit import write_audit_entry
 from apps.permitato.exceptions import ExceptionStore
 from apps.permitato.modes import MODES, get_mode, WORK_DENY_DOMAINS, SFW_DENY_DOMAINS
 from apps.permitato.pihole_adapter import PiholeAdapter, PiholeUnavailableError
@@ -333,7 +334,13 @@ async def apply_startup_schedule(state: PermitState, now: datetime | None = None
 
     effective = state.effective_mode(now)
     if effective != state.mode:
-        logger.info("Startup schedule: switching %s → %s", state.mode, effective)
+        old_mode = state.mode
+        logger.info("Startup schedule: switching %s → %s", old_mode, effective)
         state.mode = effective
         state.persist()
+        write_audit_entry(state.data_dir, {
+            "event": "scheduled_mode_switch",
+            "from_mode": old_mode,
+            "to_mode": effective,
+        })
         await apply_mode_to_client(state)

--- a/apps/permitato/stats.py
+++ b/apps/permitato/stats.py
@@ -1,0 +1,122 @@
+"""Permitato attention stats — lightweight focus metrics from audit history."""
+
+from __future__ import annotations
+
+import time
+from collections import Counter
+from datetime import date, datetime
+
+
+_DECISION_EVENTS = frozenset({"exception_granted", "exception_denied"})
+_MODE_EVENTS = frozenset({"mode_switch", "scheduled_mode_switch"})
+
+
+def _calendar_date(ts: float) -> date:
+    """Convert a unix timestamp to a local calendar date."""
+    return datetime.fromtimestamp(ts).date()
+
+
+def compute_focus_streak(entries: list[dict], now: float) -> int:
+    """Consecutive calendar days ending today with no exception_granted events.
+
+    Days with only denials or no activity count as focused.
+    Returns 0 when there are no entries (no data = no meaningful streak).
+    """
+    if not entries:
+        return 0
+
+    grant_dates: set[date] = set()
+    earliest = _calendar_date(entries[0]["ts"])
+    for e in entries:
+        if e.get("event") == "exception_granted":
+            grant_dates.add(_calendar_date(e["ts"]))
+
+    today = _calendar_date(now)
+    streak = 0
+    d = today
+    while d not in grant_dates and d >= earliest:
+        streak += 1
+        d = date.fromordinal(d.toordinal() - 1)
+    return streak
+
+
+def compute_requests_today(entries: list[dict], now: float) -> dict:
+    """Count granted and denied exceptions for today's calendar date."""
+    today = _calendar_date(now)
+    granted = 0
+    denied = 0
+    for e in entries:
+        if _calendar_date(e["ts"]) != today:
+            continue
+        event = e.get("event")
+        if event == "exception_granted":
+            granted += 1
+        elif event == "exception_denied":
+            denied += 1
+    return {"granted": granted, "denied": denied}
+
+
+def compute_top_domains(
+    entries: list[dict], max_domains: int = 3
+) -> list[dict]:
+    """Top N domains by combined grant+deny count."""
+    counts: Counter[str] = Counter()
+    for e in entries:
+        if e.get("event") in _DECISION_EVENTS:
+            domain = e.get("domain")
+            if domain:
+                counts[domain] += 1
+    return [
+        {"domain": domain, "count": count}
+        for domain, count in counts.most_common(max_domains)
+    ]
+
+
+def compute_mode_duration(
+    entries: list[dict], current_mode: str, now: float
+) -> float | None:
+    """Seconds since the most recent switch into *current_mode*. None if not found."""
+    for e in reversed(entries):
+        if e.get("event") in _MODE_EVENTS and e.get("to_mode") == current_mode:
+            return now - e["ts"]
+    return None
+
+
+def compute_deny_rate(entries: list[dict]) -> dict:
+    """Deny rate across all decisions. Rate is None when total < 5."""
+    denied = 0
+    total = 0
+    for e in entries:
+        if e.get("event") in _DECISION_EVENTS:
+            total += 1
+            if e["event"] == "exception_denied":
+                denied += 1
+    rate = denied / total if total >= 5 else None
+    return {"rate": rate, "total": total, "denied": denied}
+
+
+def compute_data_span_days(entries: list[dict]) -> int:
+    """Calendar days between oldest and newest entry."""
+    if len(entries) < 2:
+        return 0
+    oldest = _calendar_date(entries[0]["ts"])
+    newest = _calendar_date(entries[-1]["ts"])
+    return (newest - oldest).days
+
+
+def compute_stats(
+    entries: list[dict],
+    current_mode: str,
+    now: float | None = None,
+) -> dict:
+    """Aggregate all stats into a single dict for the API response."""
+    if now is None:
+        now = time.time()
+    return {
+        "focus_streak_days": compute_focus_streak(entries, now),
+        "requests_today": compute_requests_today(entries, now),
+        "top_domains": compute_top_domains(entries),
+        "mode_duration_seconds": compute_mode_duration(entries, current_mode, now),
+        "deny_rate": compute_deny_rate(entries),
+        "data_span_days": compute_data_span_days(entries),
+    }

--- a/apps/permitato/tests/stats-panel.spec.js
+++ b/apps/permitato/tests/stats-panel.spec.js
@@ -1,0 +1,160 @@
+const { test, expect } = require("@playwright/test");
+const { makeStatusPayload } = require("../../../tests/ui/helpers");
+
+async function openPermitato(page, { permitatoStatusRoute, statsRoute } = {}) {
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+  if (permitatoStatusRoute) {
+    await page.route("**/app/permitato/api/status", permitatoStatusRoute);
+  }
+  if (statsRoute) {
+    await page.route("**/app/permitato/api/stats", statsRoute);
+  }
+  await page.goto("/");
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+  await page.locator('button[data-app="permitato"]').click();
+  await page.waitForFunction(() => {
+    const bar = document.getElementById("permitatoStatusBar");
+    const onb = document.getElementById("permitatoOnboarding");
+    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+  }, { timeout: 10000 });
+}
+
+const FAKE_STATUS = {
+  mode: "work",
+  mode_display: "Work",
+  mode_description: "Social media blocked",
+  active_exceptions: 0,
+  exceptions: [],
+  pihole_available: true,
+  degraded_since: null,
+  client_id: "192.168.1.100",
+  client_valid: true,
+  schedule_active: false,
+  scheduled_mode: null,
+  override_active: false,
+  override_mode: null,
+};
+
+const FAKE_STATS = {
+  focus_streak_days: 5,
+  requests_today: { granted: 1, denied: 2 },
+  top_domains: [
+    { domain: "twitter.com", count: 8 },
+    { domain: "reddit.com", count: 5 },
+    { domain: "youtube.com", count: 2 },
+  ],
+  mode_duration_seconds: 8100,
+  deny_rate: { rate: 0.6, total: 15, denied: 9 },
+  data_span_days: 20,
+};
+
+const EMPTY_STATS = {
+  focus_streak_days: 0,
+  requests_today: { granted: 0, denied: 0 },
+  top_domains: [],
+  mode_duration_seconds: null,
+  deny_rate: { rate: null, total: 0, denied: 0 },
+  data_span_days: 0,
+};
+
+
+test("stats toggle opens and closes panel", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS) });
+    },
+    statsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATS) });
+    },
+  });
+
+  const panel = page.locator("#permitatoStatsPanel");
+  const toggle = page.locator("#permitatoStatsToggle");
+
+  await expect(panel).toBeHidden();
+  await toggle.click();
+  await expect(panel).toBeVisible();
+  await toggle.click();
+  await expect(panel).toBeHidden();
+});
+
+
+test("stats panel shows all metrics with data", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS) });
+    },
+    statsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATS) });
+    },
+  });
+
+  await page.locator("#permitatoStatsToggle").click();
+  const panel = page.locator("#permitatoStatsPanel");
+  await expect(panel).toBeVisible();
+
+  await expect(page.locator("#permitatoStreakValue")).toHaveText("5");
+  await expect(page.locator("#permitatoTodayValue")).toHaveText("3");
+  await expect(page.locator("#permitatoDenyRateValue")).toHaveText("60%");
+  await expect(page.locator("#permitatoModeDurationValue")).toHaveText("2h 15m");
+  await expect(page.locator("#permitatoTopDomainsList")).toContainText("twitter.com");
+  await expect(page.locator("#permitatoDataSpan")).toHaveText("20");
+});
+
+
+test("stats panel shows empty state when no data", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS) });
+    },
+    statsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(EMPTY_STATS) });
+    },
+  });
+
+  await page.locator("#permitatoStatsToggle").click();
+  await expect(page.locator("#permitatoStatsEmpty")).toBeVisible();
+  await expect(page.locator("#permitatoStatsGrid")).toBeHidden();
+});
+
+
+test("single-day past activity is not treated as empty", async ({ page }) => {
+  const singleDayStats = {
+    ...EMPTY_STATS,
+    top_domains: [{ domain: "twitter.com", count: 2 }],
+    deny_rate: { rate: null, total: 2, denied: 1 },
+    // data_span_days is 0 (all on one day) and requests_today is 0
+  };
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS) });
+    },
+    statsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(singleDayStats) });
+    },
+  });
+
+  await page.locator("#permitatoStatsToggle").click();
+  await expect(page.locator("#permitatoStatsGrid")).toBeVisible();
+  await expect(page.locator("#permitatoStatsEmpty")).toBeHidden();
+  await expect(page.locator("#permitatoTopDomainsList")).toContainText("twitter.com");
+});
+
+
+test("streak value gets green highlight when positive", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS) });
+    },
+    statsRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATS) });
+    },
+  });
+
+  await page.locator("#permitatoStatsToggle").click();
+  const streakEl = page.locator("#permitatoStreakValue");
+  await expect(streakEl).toHaveClass(/streak-active/);
+});

--- a/apps/permitato/tests/test_schedule.py
+++ b/apps/permitato/tests/test_schedule.py
@@ -617,6 +617,14 @@ async def test_startup_schedule_applies_to_pihole(tmp_path):
     assert state.mode == "work"
     adapter.update_client.assert_called_once()
 
+    # Startup mode correction must write an audit entry so stats can anchor to it
+    from apps.permitato.audit import read_audit_log
+    entries = read_audit_log(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["event"] == "scheduled_mode_switch"
+    assert entries[0]["from_mode"] == "normal"
+    assert entries[0]["to_mode"] == "work"
+
 
 # ---------------------------------------------------------------------------
 # P1: Override clear must persist even when effective mode stays same

--- a/apps/permitato/tests/test_stats.py
+++ b/apps/permitato/tests/test_stats.py
@@ -1,0 +1,375 @@
+"""Tests for Permitato attention stats and streaks."""
+
+from __future__ import annotations
+
+import pytest
+
+NOW = 1_700_000_000.0
+DAY = 86400
+
+
+def _entry(event: str, ago: int, **extra) -> dict:
+    """Build an audit entry *ago* seconds before NOW."""
+    return {"ts": NOW - ago, "event": event, **extra}
+
+
+# ---------------------------------------------------------------------------
+# Focus streak
+# ---------------------------------------------------------------------------
+
+
+def test_streak_empty_returns_zero():
+    from apps.permitato.stats import compute_focus_streak
+
+    assert compute_focus_streak([], now=NOW) == 0
+
+
+def test_streak_grant_today_returns_zero():
+    from apps.permitato.stats import compute_focus_streak
+
+    entries = [
+        _entry("exception_granted", 3600, domain="twitter.com"),
+    ]
+    assert compute_focus_streak(entries, now=NOW) == 0
+
+
+def test_streak_no_grants_today():
+    """Grant 2 days ago, denial today → streak = 2 (today + yesterday)."""
+    from apps.permitato.stats import compute_focus_streak
+
+    entries = [
+        _entry("exception_granted", 2 * DAY, domain="twitter.com"),
+        _entry("exception_denied", 3600, domain="reddit.com"),
+    ]
+    # Grant breaks the streak on day -2; today and yesterday are clean
+    assert compute_focus_streak(entries, now=NOW) == 2
+
+
+def test_streak_gap_days_count():
+    """Grant 4 days ago, nothing since → streak covers 4 clean days."""
+    from apps.permitato.stats import compute_focus_streak
+
+    entries = [
+        _entry("exception_granted", 4 * DAY, domain="twitter.com"),
+    ]
+    # Grant on day -4; days -3, -2, -1, today are all clean
+    assert compute_focus_streak(entries, now=NOW) == 4
+
+
+def test_streak_only_denials_count_as_focus():
+    """Denials today + yesterday, grant 2 days ago → streak = 2."""
+    from apps.permitato.stats import compute_focus_streak
+
+    entries = [
+        _entry("exception_granted", 2 * DAY, domain="twitter.com"),
+        _entry("exception_denied", DAY + 3600, domain="reddit.com"),
+        _entry("exception_denied", 3600, domain="reddit.com"),
+    ]
+    # Grant on day -2; yesterday (denial) and today (denial) are clean
+    assert compute_focus_streak(entries, now=NOW) == 2
+
+
+# ---------------------------------------------------------------------------
+# Requests today
+# ---------------------------------------------------------------------------
+
+
+def test_today_mixed():
+    from apps.permitato.stats import compute_requests_today
+
+    entries = [
+        _entry("exception_granted", 5 * DAY, domain="old.com"),
+        _entry("exception_granted", 3600, domain="a.com"),
+        _entry("exception_granted", 1800, domain="b.com"),
+        _entry("exception_denied", 900, domain="c.com"),
+    ]
+    result = compute_requests_today(entries, now=NOW)
+    assert result == {"granted": 2, "denied": 1}
+
+
+def test_today_empty():
+    from apps.permitato.stats import compute_requests_today
+
+    assert compute_requests_today([], now=NOW) == {"granted": 0, "denied": 0}
+
+
+def test_today_ignores_other_events():
+    from apps.permitato.stats import compute_requests_today
+
+    entries = [
+        _entry("mode_switch", 3600, from_mode="normal", to_mode="work"),
+        _entry("exception_expired", 1800, domain="x.com"),
+    ]
+    assert compute_requests_today(entries, now=NOW) == {"granted": 0, "denied": 0}
+
+
+# ---------------------------------------------------------------------------
+# Top domains
+# ---------------------------------------------------------------------------
+
+
+def test_top_domains_ranked():
+    from apps.permitato.stats import compute_top_domains
+
+    entries = [
+        *[_entry("exception_granted", i * 60, domain="twitter.com") for i in range(5)],
+        *[_entry("exception_denied", i * 60, domain="reddit.com") for i in range(3)],
+        _entry("exception_granted", 10, domain="youtube.com"),
+    ]
+    result = compute_top_domains(entries)
+    assert len(result) == 3
+    assert result[0]["domain"] == "twitter.com"
+    assert result[0]["count"] == 5
+    assert result[1]["domain"] == "reddit.com"
+    assert result[1]["count"] == 3
+    assert result[2]["domain"] == "youtube.com"
+
+
+def test_top_domains_max_three():
+    from apps.permitato.stats import compute_top_domains
+
+    entries = [
+        _entry("exception_granted", i * 60, domain=f"d{i}.com") for i in range(5)
+    ]
+    assert len(compute_top_domains(entries)) == 3
+
+
+def test_top_domains_empty():
+    from apps.permitato.stats import compute_top_domains
+
+    assert compute_top_domains([]) == []
+
+
+def test_top_domains_counts_grants_and_denials():
+    from apps.permitato.stats import compute_top_domains
+
+    entries = [
+        _entry("exception_granted", 300, domain="x.com"),
+        _entry("exception_granted", 200, domain="x.com"),
+        _entry("exception_denied", 100, domain="x.com"),
+        _entry("exception_denied", 50, domain="x.com"),
+        _entry("exception_denied", 30, domain="x.com"),
+    ]
+    result = compute_top_domains(entries)
+    assert result[0] == {"domain": "x.com", "count": 5}
+
+
+# ---------------------------------------------------------------------------
+# Mode duration
+# ---------------------------------------------------------------------------
+
+
+def test_duration_from_recent_switch():
+    from apps.permitato.stats import compute_mode_duration
+
+    entries = [
+        _entry("mode_switch", 3600, from_mode="normal", to_mode="work"),
+    ]
+    assert compute_mode_duration(entries, "work", now=NOW) == pytest.approx(3600.0)
+
+
+def test_duration_none_when_no_switch():
+    from apps.permitato.stats import compute_mode_duration
+
+    assert compute_mode_duration([], "normal", now=NOW) is None
+
+
+def test_duration_uses_most_recent():
+    from apps.permitato.stats import compute_mode_duration
+
+    entries = [
+        _entry("mode_switch", 7200, from_mode="normal", to_mode="sfw"),
+        _entry("mode_switch", 3600, from_mode="sfw", to_mode="work"),
+    ]
+    assert compute_mode_duration(entries, "work", now=NOW) == pytest.approx(3600.0)
+
+
+def test_duration_handles_scheduled():
+    from apps.permitato.stats import compute_mode_duration
+
+    entries = [
+        _entry("scheduled_mode_switch", 1800, from_mode="normal", to_mode="work"),
+    ]
+    assert compute_mode_duration(entries, "work", now=NOW) == pytest.approx(1800.0)
+
+
+def test_duration_anchors_to_matching_mode():
+    """Duration anchors to the most recent switch into current_mode."""
+    from apps.permitato.stats import compute_mode_duration
+
+    entries = [
+        _entry("mode_switch", 7200, from_mode="normal", to_mode="work"),
+        _entry("mode_switch", 3600, from_mode="work", to_mode="sfw"),
+    ]
+    # Current mode is "sfw" — anchors to the sfw switch at 3600s ago
+    assert compute_mode_duration(entries, "sfw", now=NOW) == pytest.approx(3600.0)
+    # Current mode is "work" — anchors to the work switch at 7200s ago
+    assert compute_mode_duration(entries, "work", now=NOW) == pytest.approx(7200.0)
+
+
+# ---------------------------------------------------------------------------
+# Deny rate
+# ---------------------------------------------------------------------------
+
+
+def test_deny_rate_sufficient():
+    from apps.permitato.stats import compute_deny_rate
+
+    entries = [
+        *[_entry("exception_denied", i * 60, domain="x.com") for i in range(6)],
+        *[_entry("exception_granted", i * 60, domain="y.com") for i in range(4)],
+    ]
+    result = compute_deny_rate(entries)
+    assert result["rate"] == pytest.approx(0.6)
+    assert result["total"] == 10
+    assert result["denied"] == 6
+
+
+def test_deny_rate_insufficient():
+    from apps.permitato.stats import compute_deny_rate
+
+    entries = [
+        _entry("exception_denied", 300, domain="x.com"),
+        _entry("exception_granted", 200, domain="y.com"),
+        _entry("exception_denied", 100, domain="z.com"),
+    ]
+    result = compute_deny_rate(entries)
+    assert result["rate"] is None
+    assert result["total"] == 3
+
+
+def test_deny_rate_empty():
+    from apps.permitato.stats import compute_deny_rate
+
+    assert compute_deny_rate([]) == {"rate": None, "total": 0, "denied": 0}
+
+
+# ---------------------------------------------------------------------------
+# Data span
+# ---------------------------------------------------------------------------
+
+
+def test_span_multiple_days():
+    from apps.permitato.stats import compute_data_span_days
+
+    entries = [
+        _entry("mode_switch", 20 * DAY, from_mode="normal", to_mode="work"),
+        _entry("mode_switch", 0, from_mode="work", to_mode="normal"),
+    ]
+    assert compute_data_span_days(entries) == 20
+
+
+def test_span_empty():
+    from apps.permitato.stats import compute_data_span_days
+
+    assert compute_data_span_days([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# compute_stats integration
+# ---------------------------------------------------------------------------
+
+
+def test_compute_stats_all_fields():
+    from apps.permitato.stats import compute_stats
+
+    entries = [
+        _entry("mode_switch", 2 * DAY, from_mode="normal", to_mode="work"),
+        _entry("exception_denied", DAY + 3600, domain="twitter.com"),
+        _entry("exception_granted", DAY + 1800, domain="reddit.com"),
+        _entry("mode_switch", 3600, from_mode="work", to_mode="normal"),
+        _entry("exception_denied", 1800, domain="twitter.com"),
+    ]
+    result = compute_stats(entries, current_mode="normal", now=NOW)
+    assert "focus_streak_days" in result
+    assert "requests_today" in result
+    assert "top_domains" in result
+    assert "mode_duration_seconds" in result
+    assert "deny_rate" in result
+    assert "data_span_days" in result
+    assert isinstance(result["requests_today"], dict)
+    assert isinstance(result["top_domains"], list)
+
+
+def test_compute_stats_empty():
+    from apps.permitato.stats import compute_stats
+
+    result = compute_stats([], current_mode="normal", now=NOW)
+    assert result["focus_streak_days"] == 0
+    assert result["requests_today"] == {"granted": 0, "denied": 0}
+    assert result["top_domains"] == []
+    assert result["mode_duration_seconds"] is None
+    assert result["deny_rate"] == {"rate": None, "total": 0, "denied": 0}
+    assert result["data_span_days"] == 0
+
+
+# ---------------------------------------------------------------------------
+# API endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stats_endpoint_returns_payload(tmp_path):
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from apps.permitato.audit import write_audit_entry
+    from apps.permitato.routes import router
+    from apps.permitato.state import PermitState
+
+    write_audit_entry(tmp_path, {"event": "exception_denied", "domain": "twitter.com", "reason": "no"})
+    write_audit_entry(tmp_path, {"event": "exception_granted", "domain": "reddit.com", "reason": "ok", "ttl_seconds": 3600, "exception_id": "e1"})
+
+    state = PermitState(data_dir=tmp_path, mode="work")
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/stats")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "focus_streak_days" in data
+    assert "requests_today" in data
+    assert "top_domains" in data
+    assert "deny_rate" in data
+    assert data["data_span_days"] >= 0
+
+
+@pytest.mark.anyio
+async def test_stats_endpoint_empty(tmp_path):
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from apps.permitato.routes import router
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path, mode="normal")
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/stats")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["focus_streak_days"] == 0
+    assert data["top_domains"] == []
+
+
+@pytest.mark.anyio
+async def test_stats_endpoint_503_when_not_initialized():
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/stats")
+
+    assert resp.status_code == 503


### PR DESCRIPTION
## Summary

- Adds a pure-function `stats.py` module computing five focus metrics from audit history: focus streak (consecutive grant-free days), requests today, top distraction domains, mode duration, and deny rate
- Adds `GET /stats` endpoint reading up to 5000 audit entries
- Adds a collapsible stats panel to the Permitato UI with a 2x2 metric grid, top distractions row, empty state, and data span footer
- Focus streak value highlights green when active

## Test evidence

**New tests (30):**
```
apps/permitato/tests/test_stats.py — 23 unit + 3 API tests
apps/permitato/tests/stats-panel.spec.js — 4 Playwright tests
```

**Full suite:**
```
pytest: 599 passed in 9.87s
playwright: 122 passed (30.3s)
```

## Pi QA

Pending — will verify stats panel against real audit history on device.

Closes #225