### PR TITLE
feat(permitato): support user-defined domain lists per mode

### DIFF
--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -864,3 +864,226 @@
   text-align: center;
   padding-top: 6px;
 }
+
+/* Custom Lists toggle */
+.permitato-custom-list-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 2px 8px;
+  margin: -2px 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text-muted);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.permitato-custom-list-toggle:hover {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.permitato-custom-list-toggle[aria-expanded="true"] {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* Custom Lists panel */
+.permitato-custom-list-panel {
+  margin: 0 16px;
+  padding: 10px 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.permitato-custom-list-panel[hidden] {
+  display: none;
+}
+
+.permitato-custom-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.permitato-custom-list-header h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.permitato-add-custom-btn {
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.permitato-add-custom-btn:hover {
+  border-color: var(--focus);
+  color: var(--text);
+}
+
+.permitato-custom-list-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.permitato-custom-tab {
+  padding: 3px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.permitato-custom-tab.active {
+  border-color: var(--focus);
+  color: var(--text);
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.permitato-custom-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.permitato-custom-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.custom-domain-name {
+  font-weight: 500;
+}
+
+.custom-domain-remove-btn {
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.custom-domain-remove-btn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.08);
+}
+
+.permitato-custom-list-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 8px;
+}
+
+.permitato-add-custom-form {
+  margin-top: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.permitato-add-custom-form[hidden] {
+  display: none;
+}
+
+.permitato-custom-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.permitato-custom-row > label:first-child {
+  width: 50px;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.permitato-custom-row select,
+.permitato-custom-row input[type="text"] {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+.permitato-custom-error {
+  color: #ef4444;
+  font-size: 0.8rem;
+}
+
+.permitato-custom-error[hidden] {
+  display: none;
+}
+
+.permitato-add-custom-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.permitato-save-custom-btn {
+  padding: 4px 14px;
+  border: 1px solid #3b82f6;
+  border-radius: 6px;
+  background: #3b82f6;
+  color: #fff;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.permitato-save-custom-btn:hover {
+  opacity: 0.85;
+}
+
+.permitato-cancel-custom-btn {
+  padding: 4px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.permitato-cancel-custom-btn:hover {
+  border-color: var(--text);
+  color: var(--text);
+}

--- a/apps/permitato/assets/permitato.html
+++ b/apps/permitato/assets/permitato.html
@@ -32,6 +32,7 @@
     <span id="permitatoScheduleLabel">Schedule</span>
   </button>
   <button id="permitatoStatsToggle" class="permitato-stats-toggle" type="button">Stats</button>
+  <button id="permitatoCustomListToggle" class="permitato-custom-list-toggle" type="button">Custom Lists</button>
   <div id="permitatoPiholeStatus" class="permitato-pihole-status">
     <span id="permitatoPiholeDot" class="permitato-pihole-dot"></span>
     <span id="permitatoPiholeLabel">Checking...</span>
@@ -117,6 +118,37 @@
   <div id="permitatoStatsEmpty" class="permitato-stats-empty" hidden>No activity recorded yet</div>
   <div id="permitatoStatsFooter" class="permitato-stats-footer" hidden>
     Based on last <span id="permitatoDataSpan">0</span> days
+  </div>
+</section>
+
+<section id="permitatoCustomListPanel" class="permitato-custom-list-panel" hidden>
+  <div class="permitato-custom-list-header">
+    <h3>Custom Blocked Domains</h3>
+    <button id="permitatoAddCustomBtn" class="permitato-add-custom-btn">+ Add Domain</button>
+  </div>
+  <div id="permitatoCustomListTabs" class="permitato-custom-list-tabs">
+    <button class="permitato-custom-tab active" data-tab="work">Work</button>
+    <button class="permitato-custom-tab" data-tab="sfw">SFW</button>
+  </div>
+  <ul id="permitatoCustomList" class="permitato-custom-list"></ul>
+  <div id="permitatoCustomListEmpty" class="permitato-custom-list-empty">No custom domains</div>
+  <div id="permitatoAddCustomForm" class="permitato-add-custom-form" hidden>
+    <div class="permitato-custom-row">
+      <label>Mode</label>
+      <select id="permitatoCustomMode">
+        <option value="work">Work</option>
+        <option value="sfw">SFW</option>
+      </select>
+    </div>
+    <div class="permitato-custom-row">
+      <label>Domain</label>
+      <input type="text" id="permitatoCustomDomain" placeholder="example.com">
+    </div>
+    <div id="permitatoCustomError" class="permitato-custom-error" hidden></div>
+    <div class="permitato-add-custom-actions">
+      <button id="permitatoSaveCustomBtn" class="permitato-save-custom-btn">Save</button>
+      <button id="permitatoCancelCustomBtn" class="permitato-cancel-custom-btn">Cancel</button>
+    </div>
   </div>
 </section>
 

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -10,6 +10,9 @@ let _lastClientFetchTs = 0;
 let _panelOpen = false;
 let _schedulePanelOpen = false;
 let _statsPanelOpen = false;
+let _customListPanelOpen = false;
+let _customListTab = "work";
+let _latestCustomDomains = [];
 let _ttlTimer = null;
 let _latestExceptions = [];
 let _latestPiholeAvailable = true;
@@ -58,6 +61,22 @@ export function init(shellApi) {
 
   const cancelRuleBtn = document.getElementById("permitatoCancelRuleBtn");
   if (cancelRuleBtn) cancelRuleBtn.addEventListener("click", _hideAddRuleForm);
+
+  const customToggle = document.getElementById("permitatoCustomListToggle");
+  if (customToggle) customToggle.addEventListener("click", _toggleCustomListPanel);
+
+  const addCustomBtn = document.getElementById("permitatoAddCustomBtn");
+  if (addCustomBtn) addCustomBtn.addEventListener("click", _showAddCustomForm);
+
+  const saveCustomBtn = document.getElementById("permitatoSaveCustomBtn");
+  if (saveCustomBtn) saveCustomBtn.addEventListener("click", _saveCustomDomain);
+
+  const cancelCustomBtn = document.getElementById("permitatoCancelCustomBtn");
+  if (cancelCustomBtn) cancelCustomBtn.addEventListener("click", _hideAddCustomForm);
+
+  document.querySelectorAll(".permitato-custom-tab").forEach(tab => {
+    tab.addEventListener("click", () => _switchCustomTab(tab.dataset.tab));
+  });
 
   _pollStatus();
   _statusTimer = setInterval(_pollStatus, 5000);
@@ -526,6 +545,124 @@ async function _deleteScheduleRule(id) {
       _fetchSchedule();
       _pollStatus();
     }
+  } catch {
+    // silent
+  }
+}
+
+// --- Custom Lists ---
+
+function _toggleCustomListPanel() {
+  _customListPanelOpen = !_customListPanelOpen;
+  const panel = document.getElementById("permitatoCustomListPanel");
+  const toggle = document.getElementById("permitatoCustomListToggle");
+  if (panel) panel.hidden = !_customListPanelOpen;
+  if (toggle) toggle.setAttribute("aria-expanded", String(_customListPanelOpen));
+  if (_customListPanelOpen) _fetchCustomDomains();
+}
+
+async function _fetchCustomDomains() {
+  try {
+    const resp = await fetch(`${PERMITATO_API}/custom-domains`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    _latestCustomDomains = data.entries || [];
+    _renderCustomDomains();
+  } catch {
+    // silent
+  }
+}
+
+function _renderCustomDomains() {
+  const list = document.getElementById("permitatoCustomList");
+  const empty = document.getElementById("permitatoCustomListEmpty");
+  if (!list) return;
+
+  const filtered = _latestCustomDomains.filter(e => e.mode === _customListTab);
+
+  if (filtered.length === 0) {
+    list.innerHTML = "";
+    if (empty) empty.hidden = false;
+    return;
+  }
+  if (empty) empty.hidden = true;
+  list.innerHTML = "";
+
+  for (const entry of filtered) {
+    const li = document.createElement("li");
+
+    const domain = document.createElement("span");
+    domain.className = "custom-domain-name";
+    domain.textContent = entry.domain;
+    li.appendChild(domain);
+
+    const btn = document.createElement("button");
+    btn.className = "custom-domain-remove-btn";
+    btn.textContent = "Remove";
+    btn.addEventListener("click", () => _deleteCustomDomain(entry.id));
+    li.appendChild(btn);
+
+    list.appendChild(li);
+  }
+}
+
+function _switchCustomTab(tab) {
+  _customListTab = tab;
+  document.querySelectorAll(".permitato-custom-tab").forEach(el => {
+    el.classList.toggle("active", el.dataset.tab === tab);
+  });
+  _renderCustomDomains();
+}
+
+function _showAddCustomForm() {
+  const form = document.getElementById("permitatoAddCustomForm");
+  const errEl = document.getElementById("permitatoCustomError");
+  const modeSelect = document.getElementById("permitatoCustomMode");
+  if (form) form.hidden = false;
+  if (errEl) errEl.hidden = true;
+  if (modeSelect) modeSelect.value = _customListTab;
+}
+
+function _hideAddCustomForm() {
+  const form = document.getElementById("permitatoAddCustomForm");
+  const domainInput = document.getElementById("permitatoCustomDomain");
+  if (form) form.hidden = true;
+  if (domainInput) domainInput.value = "";
+}
+
+async function _saveCustomDomain() {
+  const mode = document.getElementById("permitatoCustomMode")?.value;
+  const domainInput = document.getElementById("permitatoCustomDomain");
+  const domain = domainInput?.value?.trim();
+  const errEl = document.getElementById("permitatoCustomError");
+
+  if (!domain) {
+    if (errEl) { errEl.textContent = "Enter a domain."; errEl.hidden = false; }
+    return;
+  }
+
+  try {
+    const resp = await fetch(`${PERMITATO_API}/custom-domains`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode, domain }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      if (errEl) { errEl.textContent = err.error || "Failed to add domain."; errEl.hidden = false; }
+      return;
+    }
+    _hideAddCustomForm();
+    _fetchCustomDomains();
+  } catch {
+    if (errEl) { errEl.textContent = "Connection error."; errEl.hidden = false; }
+  }
+}
+
+async function _deleteCustomDomain(id) {
+  try {
+    const resp = await fetch(`${PERMITATO_API}/custom-domains/${id}`, { method: "DELETE" });
+    if (resp.ok) _fetchCustomDomains();
   } catch {
     // silent
   }

--- a/apps/permitato/audit.py
+++ b/apps/permitato/audit.py
@@ -41,6 +41,8 @@ _CONTEXT_EVENTS = frozenset({
     "exception_denied",
     "exception_expired",
     "exception_revoked",
+    "custom_domain_added",
+    "custom_domain_removed",
 })
 
 
@@ -83,6 +85,14 @@ def _format_entry(entry: dict, now: float) -> str:
         return f"- {ago}: unblock for {entry.get('domain', '?')} expired"
     if event == "exception_revoked":
         return f"- {ago}: unblock for {entry.get('domain', '?')} revoked"
+    if event == "custom_domain_added":
+        domain = entry.get("domain", "?")
+        mode = entry.get("mode", "?")
+        return f"- {ago}: added custom block {domain} to {mode}"
+    if event == "custom_domain_removed":
+        domain = entry.get("domain", "?")
+        mode = entry.get("mode", "?")
+        return f"- {ago}: removed custom block {domain} from {mode}"
     return f"- {ago}: {event}"
 
 

--- a/apps/permitato/custom_lists.py
+++ b/apps/permitato/custom_lists.py
@@ -1,0 +1,110 @@
+"""Permitato custom domain lists — user-defined blocklists per mode."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from apps.permitato.exceptions import build_domain_regex
+
+logger = logging.getLogger(__name__)
+
+_VALID_MODES = frozenset({"work", "sfw"})
+
+
+@dataclass
+class CustomDomainEntry:
+    id: str
+    mode: str
+    domain: str
+    regex_pattern: str
+    created_at: float
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "mode": self.mode,
+            "domain": self.domain,
+            "regex_pattern": self.regex_pattern,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> CustomDomainEntry:
+        return cls(**{k: data[k] for k in (
+            "id", "mode", "domain", "regex_pattern", "created_at",
+        )})
+
+
+@dataclass
+class CustomListStore:
+    data_dir: Path
+    _entries: dict[str, CustomDomainEntry] = field(default_factory=dict)
+
+    def add(self, mode: str, domain: str) -> CustomDomainEntry:
+        """Add a custom domain to a mode's blocklist."""
+        if mode not in _VALID_MODES:
+            raise ValueError(
+                f"Invalid mode: {mode!r}. Custom lists only apply to: {sorted(_VALID_MODES)}"
+            )
+        domain = domain.strip().lower()
+        regex_pattern = build_domain_regex(domain)
+
+        for entry in self._entries.values():
+            if entry.domain == domain:
+                raise ValueError(
+                    f"{domain!r} already exists in {entry.mode} custom list"
+                )
+
+        entry = CustomDomainEntry(
+            id=str(uuid.uuid4()),
+            mode=mode,
+            domain=domain,
+            regex_pattern=regex_pattern,
+            created_at=time.time(),
+        )
+        self._entries[entry.id] = entry
+        return entry
+
+    def remove(self, entry_id: str) -> CustomDomainEntry:
+        """Remove a custom domain entry by ID."""
+        if entry_id not in self._entries:
+            raise KeyError(f"No custom domain entry with id: {entry_id}")
+        return self._entries.pop(entry_id)
+
+    def list_entries(self, mode: str | None = None) -> list[dict]:
+        """List all entries, optionally filtered by mode."""
+        entries = self._entries.values()
+        if mode is not None:
+            entries = [e for e in entries if e.mode == mode]
+        return [e.to_dict() for e in entries]
+
+    def entries_for_mode(self, mode: str) -> list[CustomDomainEntry]:
+        """Return CustomDomainEntry objects for a given mode."""
+        return [e for e in self._entries.values() if e.mode == mode]
+
+    def persist(self) -> None:
+        from apps.permitato.state import atomic_write
+
+        path = self.data_dir / "custom_lists.json"
+        data = {
+            "version": 1,
+            "entries": {eid: e.to_dict() for eid, e in self._entries.items()},
+        }
+        atomic_write(path, json.dumps(data, indent=2))
+
+    def load(self) -> None:
+        path = self.data_dir / "custom_lists.json"
+        if not path.exists():
+            return
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            for eid, entry_data in data.get("entries", {}).items():
+                self._entries[eid] = CustomDomainEntry.from_dict(entry_data)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            logger.warning("Failed to load custom lists from %s, starting fresh", path)
+            self._entries.clear()

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from apps.permitato.audit import build_recent_context, read_audit_log, write_audit_entry
+from apps.permitato.custom_lists import CustomListStore
 from apps.permitato.exceptions import ExceptionStore, build_domain_regex
 from apps.permitato.intent import parse_llm_response, strip_action_markers
 from apps.permitato.stats import compute_stats
@@ -81,6 +82,7 @@ async def permitato_status(request: Request):
         "scheduled_mode": scheduled_mode,
         "override_active": state.override_mode is not None,
         "override_mode": state.override_mode,
+        "custom_domain_count": len(state.custom_list_store.list_entries()) if state.custom_list_store else 0,
     }
 
 
@@ -418,6 +420,116 @@ async def delete_schedule_rule(request: Request, rule_id: str):
     })
 
     await _apply_schedule_tick(state, _schedule_now())
+    return {"deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# GET /custom-domains
+# ---------------------------------------------------------------------------
+
+
+@router.get("/custom-domains")
+async def get_custom_domains(request: Request):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+
+    mode = request.query_params.get("mode")
+    store = state.custom_list_store
+    entries = store.list_entries(mode=mode) if store else []
+    return {"entries": entries}
+
+
+# ---------------------------------------------------------------------------
+# POST /custom-domains
+# ---------------------------------------------------------------------------
+
+
+@router.post("/custom-domains")
+async def add_custom_domain(request: Request):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+    if not state.custom_list_store:
+        return JSONResponse(status_code=503, content={"error": "Custom lists not available"})
+
+    body = await request.json()
+    mode = body.get("mode", "").strip().lower()
+    domain = body.get("domain", "").strip()
+
+    try:
+        entry = state.custom_list_store.add(mode, domain)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+
+    # Push deny rule to Pi-hole
+    if state.pihole_available and state.adapter:
+        gid = state.group_map.get(f"permitato_{mode}")
+        if gid is not None:
+            try:
+                await state.adapter.add_domain_rule(
+                    domain=entry.regex_pattern,
+                    rule_type="deny",
+                    kind="regex",
+                    groups=[gid],
+                    comment=f"Permitato-custom: {entry.domain}",
+                )
+            except PiholeUnavailableError:
+                state.pihole_available = False
+                logger.warning("Failed to add Pi-hole deny rule for %s", domain)
+
+    state.custom_list_store.persist()
+    write_audit_entry(state.data_dir, {
+        "event": "custom_domain_added",
+        "domain": entry.domain,
+        "mode": mode,
+        "entry_id": entry.id,
+    })
+
+    return {"entry": entry.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# DELETE /custom-domains/{entry_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/custom-domains/{entry_id}")
+async def delete_custom_domain(request: Request, entry_id: str):
+    state = _get_state(request)
+    if state is None:
+        return JSONResponse(status_code=503, content={"error": "Permitato not initialized"})
+    if not state.custom_list_store:
+        return JSONResponse(status_code=503, content={"error": "Custom lists not available"})
+
+    store = state.custom_list_store
+    if entry_id not in {e["id"] for e in store.list_entries()}:
+        return JSONResponse(status_code=404, content={"error": f"No custom domain with id: {entry_id}"})
+
+    # Try Pi-hole delete first — only remove locally if it succeeds or Pi-hole
+    # is already known to be unavailable (compensation handles cleanup on reconnect).
+    if state.pihole_available and state.adapter:
+        entry_data = next(e for e in store.list_entries() if e["id"] == entry_id)
+        try:
+            await state.adapter.delete_domain_rule(entry_data["regex_pattern"], "deny", "regex")
+        except PiholeUnavailableError:
+            state.pihole_available = False
+            state.degraded_since = state.degraded_since or __import__("time").time()
+            logger.warning("Pi-hole became unreachable removing deny rule for %s", entry_data["domain"])
+            return JSONResponse(status_code=503, content={"error": "Pi-hole became unreachable — retry later"})
+        except Exception:
+            logger.warning("Failed to remove Pi-hole deny rule for %s", entry_data["domain"])
+            return JSONResponse(status_code=502, content={"error": "Failed to remove Pi-hole rule — retry later"})
+
+    entry = store.remove(entry_id)
+    store.persist()
+    write_audit_entry(state.data_dir, {
+        "event": "custom_domain_removed",
+        "domain": entry.domain,
+        "mode": entry.mode,
+        "entry_id": entry_id,
+    })
+
     return {"deleted": True}
 
 

--- a/apps/permitato/state.py
+++ b/apps/permitato/state.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from datetime import datetime
 
 from apps.permitato.audit import write_audit_entry
+from apps.permitato.custom_lists import CustomListStore
 from apps.permitato.exceptions import ExceptionStore
 from apps.permitato.modes import MODES, get_mode, WORK_DENY_DOMAINS, SFW_DENY_DOMAINS
 from apps.permitato.pihole_adapter import PiholeAdapter, PiholeUnavailableError
@@ -33,6 +34,7 @@ class PermitState:
     mode: str = "normal"
     adapter: PiholeAdapter | None = None
     exception_store: ExceptionStore | None = None
+    custom_list_store: CustomListStore | None = None
     schedule_store: ScheduleStore | None = None
     override_mode: str | None = None
     override_scheduled_mode: str | None = None
@@ -92,6 +94,9 @@ async def initialize_permitato(
     state.exception_store = ExceptionStore(data_dir=data_dir)
     state.exception_store.load()
 
+    state.custom_list_store = CustomListStore(data_dir=data_dir)
+    state.custom_list_store.load()
+
     state.adapter = PiholeAdapter(base_url=pihole_base_url, password=pihole_password)
     try:
         await state.adapter.connect()
@@ -105,6 +110,7 @@ async def initialize_permitato(
 
         # Seed deny-list domains (idempotent — duplicates are ignored by Pi-hole)
         await _seed_domain_lists(state.adapter, state.group_map)
+        await _seed_custom_lists(state.adapter, state.group_map, state.custom_list_store)
 
         # Revoke Pi-hole rules for exceptions that expired while we were down
         for exc in state.exception_store.get_expired():
@@ -161,6 +167,8 @@ async def shutdown_permitato(state: PermitState) -> None:
     """Clean shutdown: persist state and disconnect."""
     if state.exception_store:
         state.exception_store.persist()
+    if state.custom_list_store:
+        state.custom_list_store.persist()
     state.persist()
     if state.adapter:
         await state.adapter.disconnect()
@@ -215,6 +223,29 @@ async def _seed_domain_lists(adapter: PiholeAdapter, group_map: dict[str, int]) 
                 pass
 
 
+async def _seed_custom_lists(
+    adapter: PiholeAdapter, group_map: dict[str, int], store: CustomListStore | None,
+) -> None:
+    """Seed user-defined custom deny-list entries into Pi-hole (idempotent)."""
+    if not store:
+        return
+    for mode_name in ("work", "sfw"):
+        gid = group_map.get(f"permitato_{mode_name}")
+        if gid is None:
+            continue
+        for entry in store.entries_for_mode(mode_name):
+            try:
+                await adapter.add_domain_rule(
+                    domain=entry.regex_pattern,
+                    rule_type="deny",
+                    kind="regex",
+                    groups=[gid],
+                    comment=f"Permitato-custom: {entry.domain}",
+                )
+            except Exception:
+                pass  # duplicate or transient — skip silently
+
+
 async def apply_mode_to_client(state: PermitState) -> None:
     """Apply the current mode to the controlled client in Pi-hole."""
     if not state.pihole_available or not state.adapter or not state.client_id:
@@ -254,7 +285,9 @@ async def reconnect_pihole(state: PermitState) -> None:
         state.group_map = await _ensure_groups(state.adapter)
         state.exception_group_id = state.group_map.get("permitato_exceptions", 0)
         await _seed_domain_lists(state.adapter, state.group_map)
+        await _seed_custom_lists(state.adapter, state.group_map, state.custom_list_store)
         await compensate_exceptions(state)
+        await compensate_custom_lists(state)
     except Exception:
         logger.warning("Pi-hole connected but recovery failed — staying degraded", exc_info=True)
         return
@@ -312,6 +345,54 @@ async def compensate_exceptions(state: PermitState) -> None:
                 logger.info("Compensation: removed orphaned allow rule %s", rule["domain"])
             except Exception:
                 logger.warning("Compensation: failed to remove orphaned rule %s", rule["domain"])
+
+
+async def compensate_custom_lists(state: PermitState) -> None:
+    """Reconcile local custom list store with Pi-hole deny rules."""
+    if not state.adapter or not state.custom_list_store:
+        return
+
+    # Fetch all deny regex rules from Pi-hole
+    all_rules = await state.adapter.get_domain_rules("deny", "regex")
+
+    # Filter to Permitato-custom-owned rules only
+    pihole_custom = [
+        r for r in all_rules
+        if r.get("comment", "").startswith("Permitato-custom:")
+    ]
+    pihole_domains = {r["domain"] for r in pihole_custom}
+
+    # What we expect
+    local_entries = state.custom_list_store.list_entries()
+    local_patterns = {e["regex_pattern"] for e in local_entries}
+
+    # Re-add missing
+    for entry in local_entries:
+        if entry["regex_pattern"] not in pihole_domains:
+            mode_name = entry["mode"]
+            gid = state.group_map.get(f"permitato_{mode_name}")
+            if gid is None:
+                continue
+            try:
+                await state.adapter.add_domain_rule(
+                    domain=entry["regex_pattern"],
+                    rule_type="deny",
+                    kind="regex",
+                    groups=[gid],
+                    comment=f"Permitato-custom: {entry['domain']}",
+                )
+                logger.info("Compensation: re-added missing custom rule for %s", entry["domain"])
+            except Exception:
+                logger.warning("Compensation: failed to re-add custom rule for %s", entry["domain"])
+
+    # Remove orphaned custom rules
+    for rule in pihole_custom:
+        if rule["domain"] not in local_patterns:
+            try:
+                await state.adapter.delete_domain_rule(rule["domain"], "deny", "regex")
+                logger.info("Compensation: removed orphaned custom rule %s", rule["domain"])
+            except Exception:
+                logger.warning("Compensation: failed to remove orphaned custom rule %s", rule["domain"])
 
 
 async def apply_startup_schedule(state: PermitState, now: datetime | None = None) -> None:

--- a/apps/permitato/tests/custom-list-panel.spec.js
+++ b/apps/permitato/tests/custom-list-panel.spec.js
@@ -1,0 +1,136 @@
+const { test, expect } = require("@playwright/test");
+const { makeStatusPayload } = require("../../../tests/ui/helpers");
+
+async function openPermitato(page, { permitatoStatusRoute, customDomainsRoute } = {}) {
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+  if (permitatoStatusRoute) {
+    await page.route("**/app/permitato/api/status", permitatoStatusRoute);
+  }
+  if (customDomainsRoute) {
+    await page.route("**/app/permitato/api/custom-domains", customDomainsRoute);
+  }
+  await page.goto("/");
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+  await page.locator('button[data-app="permitato"]').click();
+  await page.waitForFunction(() => {
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
+  }, { timeout: 10000 });
+}
+
+const BASE_STATUS = {
+  mode: "work",
+  mode_display: "Work",
+  mode_description: "Social media blocked",
+  active_exceptions: 0,
+  exceptions: [],
+  pihole_available: true,
+  degraded_since: null,
+  client_id: "192.168.1.100",
+  client_valid: true,
+  schedule_active: false,
+  scheduled_mode: null,
+  override_active: false,
+  override_mode: null,
+  custom_domain_count: 2,
+};
+
+const CUSTOM_DOMAINS = {
+  entries: [
+    { id: "cd-1", mode: "work", domain: "example.com", regex_pattern: "(^|\\.)example\\.com$", created_at: 1700000000 },
+    { id: "cd-2", mode: "sfw", domain: "adult-site.com", regex_pattern: "(^|\\.)adult-site\\.com$", created_at: 1700000100 },
+  ],
+};
+
+
+test("custom list toggle opens and closes panel", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(BASE_STATUS) });
+    },
+    customDomainsRoute: async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({ status: 200, body: JSON.stringify(CUSTOM_DOMAINS) });
+      } else {
+        await route.fallback();
+      }
+    },
+  });
+
+  await expect(page.locator("#permitatoCustomListPanel")).toBeHidden();
+
+  await page.locator("#permitatoCustomListToggle").click();
+  await expect(page.locator("#permitatoCustomListPanel")).toBeVisible();
+
+  await page.locator("#permitatoCustomListToggle").click();
+  await expect(page.locator("#permitatoCustomListPanel")).toBeHidden();
+});
+
+
+test("panel shows domains filtered by active tab", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(BASE_STATUS) });
+    },
+    customDomainsRoute: async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({ status: 200, body: JSON.stringify(CUSTOM_DOMAINS) });
+      } else {
+        await route.fallback();
+      }
+    },
+  });
+
+  await page.locator("#permitatoCustomListToggle").click();
+  await expect(page.locator("#permitatoCustomListPanel")).toBeVisible();
+
+  // Default tab is Work — should show example.com
+  await expect(page.locator("#permitatoCustomList li")).toHaveCount(1);
+  await expect(page.locator(".custom-domain-name").first()).toHaveText("example.com");
+
+  // Switch to SFW tab
+  await page.locator('.permitato-custom-tab[data-tab="sfw"]').click();
+  await expect(page.locator("#permitatoCustomList li")).toHaveCount(1);
+  await expect(page.locator(".custom-domain-name").first()).toHaveText("adult-site.com");
+});
+
+
+test("removing a domain calls DELETE and refreshes list", async ({ page }) => {
+  let removed = false;
+
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(BASE_STATUS) });
+    },
+    customDomainsRoute: async (route) => {
+      if (route.request().method() === "GET") {
+        const data = removed
+          ? { entries: [CUSTOM_DOMAINS.entries[1]] }
+          : CUSTOM_DOMAINS;
+        await route.fulfill({ status: 200, body: JSON.stringify(data) });
+      } else {
+        await route.fallback();
+      }
+    },
+  });
+
+  await page.route("**/app/permitato/api/custom-domains/cd-1", async (route) => {
+    if (route.request().method() === "DELETE") {
+      removed = true;
+      await route.fulfill({ status: 200, body: JSON.stringify({ deleted: true }) });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  await page.locator("#permitatoCustomListToggle").click();
+  await expect(page.locator("#permitatoCustomList li")).toHaveCount(1);
+
+  await page.locator(".custom-domain-remove-btn").first().click();
+
+  // After remove, Work tab should be empty
+  await expect(page.locator("#permitatoCustomListEmpty")).toBeVisible({ timeout: 10000 });
+});

--- a/apps/permitato/tests/exceptions-panel.spec.js
+++ b/apps/permitato/tests/exceptions-panel.spec.js
@@ -13,9 +13,8 @@ async function openPermitato(page, { permitatoStatusRoute } = {}) {
   await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
   await page.locator('button[data-app="permitato"]').click();
   await page.waitForFunction(() => {
-    const bar = document.getElementById("permitatoStatusBar");
-    const onb = document.getElementById("permitatoOnboarding");
-    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
   }, { timeout: 10000 });
 }
 

--- a/apps/permitato/tests/onboarding.spec.js
+++ b/apps/permitato/tests/onboarding.spec.js
@@ -29,9 +29,11 @@ async function openPermitato(page, { statusRoute, permitatoStatusRoute, clientsR
   await page.locator('button[data-app="permitato"]').click();
   // Wait for Permitato to load its HTML — either the status bar or the onboarding overlay becomes visible
   await page.waitForFunction(() => {
-    const bar = document.getElementById("permitatoStatusBar");
+    const badge = document.getElementById("permitatoModeValue");
     const onb = document.getElementById("permitatoOnboarding");
-    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+    // Wait until either the mode badge is updated (poll completed with client)
+    // or the onboarding overlay is shown (poll completed without client)
+    return (badge && badge.textContent !== "--" && badge.textContent !== "") || (onb && !onb.hidden);
   }, { timeout: 10000 });
 }
 

--- a/apps/permitato/tests/schedule-panel.spec.js
+++ b/apps/permitato/tests/schedule-panel.spec.js
@@ -16,9 +16,8 @@ async function openPermitato(page, { permitatoStatusRoute, scheduleRoute } = {})
   await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
   await page.locator('button[data-app="permitato"]').click();
   await page.waitForFunction(() => {
-    const bar = document.getElementById("permitatoStatusBar");
-    const onb = document.getElementById("permitatoOnboarding");
-    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
   }, { timeout: 10000 });
 }
 

--- a/apps/permitato/tests/stats-panel.spec.js
+++ b/apps/permitato/tests/stats-panel.spec.js
@@ -16,9 +16,8 @@ async function openPermitato(page, { permitatoStatusRoute, statsRoute } = {}) {
   await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
   await page.locator('button[data-app="permitato"]').click();
   await page.waitForFunction(() => {
-    const bar = document.getElementById("permitatoStatusBar");
-    const onb = document.getElementById("permitatoOnboarding");
-    return (bar && bar.offsetParent !== null) || (onb && !onb.hidden);
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
   }, { timeout: 10000 });
 }
 

--- a/apps/permitato/tests/test_audit_context.py
+++ b/apps/permitato/tests/test_audit_context.py
@@ -292,3 +292,27 @@ def test_full_pipeline_write_read_build(tmp_path):
     )
     assert "Recent Activity" in prompt
     assert "twitter.com" in prompt
+
+
+def test_custom_domain_added_formats_correctly():
+    from apps.permitato.audit import build_recent_context
+
+    entries = [
+        _entry("custom_domain_added", 300, domain="facebook.com", mode="work"),
+    ]
+    result = build_recent_context(entries, now=NOW)
+    assert "custom block" in result.lower()
+    assert "facebook.com" in result
+    assert "work" in result
+
+
+def test_custom_domain_removed_formats_correctly():
+    from apps.permitato.audit import build_recent_context
+
+    entries = [
+        _entry("custom_domain_removed", 600, domain="facebook.com", mode="work"),
+    ]
+    result = build_recent_context(entries, now=NOW)
+    assert "removed" in result.lower()
+    assert "facebook.com" in result
+    assert "work" in result

--- a/apps/permitato/tests/test_custom_lists.py
+++ b/apps/permitato/tests/test_custom_lists.py
@@ -1,0 +1,378 @@
+"""Tests for Permitato custom domain lists — per-mode user-defined blocklists."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_add_creates_entry_with_valid_domain(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+    from apps.permitato.exceptions import build_domain_regex
+
+    store = CustomListStore(data_dir=tmp_path)
+    entry = store.add("work", "example.com")
+
+    assert entry.mode == "work"
+    assert entry.domain == "example.com"
+    assert entry.regex_pattern == build_domain_regex("example.com")
+    assert entry.id
+    assert entry.created_at > 0
+
+
+def test_add_normalises_domain(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    entry = store.add("work", "  Example.COM  ")
+
+    assert entry.domain == "example.com"
+
+
+def test_add_rejects_normal_mode(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="normal"):
+        store.add("normal", "example.com")
+
+
+def test_add_rejects_unknown_mode(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    with pytest.raises(ValueError, match="bogus"):
+        store.add("bogus", "example.com")
+
+
+def test_add_rejects_invalid_domain(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    with pytest.raises(ValueError):
+        store.add("work", "not-a-domain")
+
+
+def test_add_rejects_duplicate_same_mode(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "example.com")
+    with pytest.raises(ValueError, match="already exists"):
+        store.add("work", "example.com")
+
+
+def test_add_rejects_duplicate_across_modes(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "example.com")
+    with pytest.raises(ValueError, match="already exists"):
+        store.add("sfw", "example.com")
+
+
+def test_remove_by_id(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    entry = store.add("work", "example.com")
+    removed = store.remove(entry.id)
+
+    assert removed.domain == "example.com"
+    assert store.list_entries() == []
+
+
+def test_remove_unknown_raises_keyerror(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    with pytest.raises(KeyError):
+        store.remove("nonexistent-id")
+
+
+def test_list_entries_all(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "facebook.com")
+    store.add("sfw", "adult-site.com")
+
+    entries = store.list_entries()
+    assert len(entries) == 2
+    domains = {e["domain"] for e in entries}
+    assert domains == {"facebook.com", "adult-site.com"}
+
+
+def test_list_entries_filtered_by_mode(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "facebook.com")
+    store.add("sfw", "adult-site.com")
+    store.add("work", "twitter.com")
+
+    work_entries = store.list_entries(mode="work")
+    assert len(work_entries) == 2
+    assert all(e["mode"] == "work" for e in work_entries)
+
+
+def test_entries_for_mode_returns_objects(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore, CustomDomainEntry
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "facebook.com")
+    store.add("sfw", "adult-site.com")
+
+    work = store.entries_for_mode("work")
+    assert len(work) == 1
+    assert isinstance(work[0], CustomDomainEntry)
+    assert work[0].domain == "facebook.com"
+
+
+def test_persist_and_load(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "facebook.com")
+    store.add("sfw", "adult-site.com")
+    store.persist()
+
+    store2 = CustomListStore(data_dir=tmp_path)
+    store2.load()
+    assert len(store2.list_entries()) == 2
+
+
+def test_load_handles_missing_file(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.load()  # should not raise
+    assert store.list_entries() == []
+
+
+def test_load_handles_corrupt_json(tmp_path):
+    from apps.permitato.custom_lists import CustomListStore
+
+    (tmp_path / "custom_lists.json").write_text("not json!!!")
+    store = CustomListStore(data_dir=tmp_path)
+    store.load()  # should not raise
+    assert store.list_entries() == []
+
+
+# ---------------------------------------------------------------------------
+# API route tests — direct handler calls with mock state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_custom_domains_returns_entries(tmp_path):
+    state = _make_state(tmp_path)
+    state.custom_list_store.add("work", "facebook.com")
+    state.custom_list_store.add("sfw", "adult-site.com")
+
+    result = await _call_get_custom_domains(state)
+    assert len(result["entries"]) == 2
+
+
+@pytest.mark.anyio
+async def test_get_custom_domains_filters_by_mode(tmp_path):
+    state = _make_state(tmp_path)
+    state.custom_list_store.add("work", "facebook.com")
+    state.custom_list_store.add("sfw", "adult-site.com")
+
+    result = await _call_get_custom_domains(state, mode="work")
+    assert len(result["entries"]) == 1
+    assert result["entries"][0]["mode"] == "work"
+
+
+@pytest.mark.anyio
+async def test_post_custom_domain_creates_and_syncs_pihole(tmp_path):
+    state = _make_state(tmp_path)
+
+    result = await _call_post_custom_domain(state, {
+        "mode": "work", "domain": "facebook.com",
+    })
+    assert result["entry"]["domain"] == "facebook.com"
+    assert result["entry"]["mode"] == "work"
+    assert len(state.custom_list_store.list_entries()) == 1
+
+    # Verify Pi-hole rule was added
+    state.adapter.add_domain_rule.assert_called_once()
+    call_kwargs = state.adapter.add_domain_rule.call_args
+    assert call_kwargs[1]["rule_type"] == "deny"
+    assert call_kwargs[1]["comment"].startswith("Permitato-custom:")
+
+
+@pytest.mark.anyio
+async def test_post_custom_domain_rejects_invalid_domain(tmp_path):
+    state = _make_state(tmp_path)
+
+    result, status = await _call_post_custom_domain(
+        state, {"mode": "work", "domain": "not-a-domain"}, return_status=True,
+    )
+    assert status == 400
+
+
+@pytest.mark.anyio
+async def test_post_custom_domain_rejects_invalid_mode(tmp_path):
+    state = _make_state(tmp_path)
+
+    result, status = await _call_post_custom_domain(
+        state, {"mode": "normal", "domain": "facebook.com"}, return_status=True,
+    )
+    assert status == 400
+
+
+@pytest.mark.anyio
+async def test_post_custom_domain_rejects_duplicate(tmp_path):
+    state = _make_state(tmp_path)
+    state.custom_list_store.add("work", "facebook.com")
+
+    result, status = await _call_post_custom_domain(
+        state, {"mode": "work", "domain": "facebook.com"}, return_status=True,
+    )
+    assert status == 400
+
+
+@pytest.mark.anyio
+async def test_post_custom_domain_returns_503_when_not_initialized(tmp_path):
+    result, status = await _call_post_custom_domain(
+        None, {"mode": "work", "domain": "facebook.com"}, return_status=True,
+    )
+    assert status == 503
+
+
+@pytest.mark.anyio
+async def test_delete_custom_domain_removes_and_syncs_pihole(tmp_path):
+    state = _make_state(tmp_path)
+    entry = state.custom_list_store.add("work", "facebook.com")
+
+    result = await _call_delete_custom_domain(state, entry.id)
+    assert result["deleted"] is True
+    assert len(state.custom_list_store.list_entries()) == 0
+
+    # Verify Pi-hole rule was removed
+    state.adapter.delete_domain_rule.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_delete_custom_domain_keeps_entry_on_pihole_failure(tmp_path):
+    from unittest.mock import AsyncMock
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+
+    state = _make_state(tmp_path)
+    entry = state.custom_list_store.add("work", "facebook.com")
+
+    state.adapter.delete_domain_rule = AsyncMock(side_effect=PiholeUnavailableError("gone"))
+
+    result, status = await _call_delete_custom_domain(
+        state, entry.id, return_status=True,
+    )
+    assert status == 503
+
+    # Entry must still be in the local store
+    assert len(state.custom_list_store.list_entries()) == 1
+    # Pi-hole should be marked degraded so compensation runs on reconnect
+    assert state.pihole_available is False
+
+
+@pytest.mark.anyio
+async def test_delete_custom_domain_returns_404_for_unknown(tmp_path):
+    state = _make_state(tmp_path)
+
+    result, status = await _call_delete_custom_domain(
+        state, "nonexistent-id", return_status=True,
+    )
+    assert status == 404
+
+
+@pytest.mark.anyio
+async def test_status_includes_custom_domain_count(tmp_path):
+    state = _make_state(tmp_path)
+    state.custom_list_store.add("work", "facebook.com")
+    state.custom_list_store.add("sfw", "adult-site.com")
+
+    result = await _call_get_status(state)
+    assert result["custom_domain_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — direct function calls with mock state
+# ---------------------------------------------------------------------------
+
+
+def _make_state(tmp_path):
+    from unittest.mock import AsyncMock, MagicMock
+    from apps.permitato.custom_lists import CustomListStore
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    adapter.add_domain_rule = AsyncMock(return_value={})
+    adapter.delete_domain_rule = AsyncMock(return_value=None)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.100",
+    )
+    state.custom_list_store = CustomListStore(data_dir=tmp_path)
+    state.group_map = {"permitato_work": 1, "permitato_sfw": 2, "permitato_exceptions": 3}
+    state.exception_group_id = 3
+    state.exception_store = MagicMock()
+    state.exception_store.active_count.return_value = 0
+    state.exception_store.list_active.return_value = []
+    state.schedule_store = MagicMock()
+    state.schedule_store.evaluate.return_value = None
+    return state
+
+
+async def _call_get_custom_domains(state, mode=None):
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.app.state.permit_state = state
+    request.query_params = {"mode": mode} if mode else {}
+
+    from apps.permitato.routes import get_custom_domains
+    return await get_custom_domains(request)
+
+
+async def _call_post_custom_domain(state, body, return_status=False):
+    from unittest.mock import AsyncMock, MagicMock
+    request = MagicMock()
+    request.app.state.permit_state = state
+    request.json = AsyncMock(return_value=body)
+
+    from apps.permitato.routes import add_custom_domain
+    result = await add_custom_domain(request)
+    if return_status:
+        if hasattr(result, "status_code"):
+            import json
+            return json.loads(result.body.decode()), result.status_code
+        return result, 200
+    return result
+
+
+async def _call_delete_custom_domain(state, entry_id, return_status=False):
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.app.state.permit_state = state
+
+    from apps.permitato.routes import delete_custom_domain
+    result = await delete_custom_domain(request, entry_id)
+    if return_status:
+        if hasattr(result, "status_code"):
+            import json
+            return json.loads(result.body.decode()), result.status_code
+        return result, 200
+    return result
+
+
+async def _call_get_status(state):
+    from unittest.mock import patch
+    from apps.permitato import routes
+
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.app.state.permit_state = state
+
+    return await routes.permitato_status(request)

--- a/apps/permitato/tests/test_hardening.py
+++ b/apps/permitato/tests/test_hardening.py
@@ -368,6 +368,124 @@ async def test_compensation_noop_without_exception_group(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Custom list compensation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_compensate_custom_lists_readds_missing(tmp_path):
+    from apps.permitato.state import PermitState, compensate_custom_lists
+    from apps.permitato.custom_lists import CustomListStore
+
+    adapter = AsyncMock()
+    adapter.get_domain_rules = AsyncMock(return_value=[])
+    adapter.add_domain_rule = AsyncMock()
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "facebook.com")
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        custom_list_store=store,
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    await compensate_custom_lists(state)
+
+    adapter.add_domain_rule.assert_called_once()
+    call_kw = adapter.add_domain_rule.call_args.kwargs
+    assert call_kw["rule_type"] == "deny"
+    assert call_kw["comment"].startswith("Permitato-custom:")
+
+
+@pytest.mark.anyio
+async def test_compensate_custom_lists_removes_orphaned(tmp_path):
+    from apps.permitato.state import PermitState, compensate_custom_lists
+    from apps.permitato.custom_lists import CustomListStore
+
+    adapter = AsyncMock()
+    adapter.get_domain_rules = AsyncMock(return_value=[
+        {"domain": r"(^|\.)old\.com$", "groups": [1], "comment": "Permitato-custom: old.com"},
+    ])
+    adapter.delete_domain_rule = AsyncMock()
+
+    store = CustomListStore(data_dir=tmp_path)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        custom_list_store=store,
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    await compensate_custom_lists(state)
+
+    adapter.delete_domain_rule.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_compensate_custom_lists_skips_builtin_rules(tmp_path):
+    from apps.permitato.state import PermitState, compensate_custom_lists
+    from apps.permitato.custom_lists import CustomListStore
+
+    adapter = AsyncMock()
+    adapter.get_domain_rules = AsyncMock(return_value=[
+        {"domain": r"(^|\.)facebook\.com$", "groups": [1], "comment": "Permitato: work mode"},
+    ])
+    adapter.delete_domain_rule = AsyncMock()
+    adapter.add_domain_rule = AsyncMock()
+
+    store = CustomListStore(data_dir=tmp_path)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        custom_list_store=store,
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    await compensate_custom_lists(state)
+
+    adapter.delete_domain_rule.assert_not_called()
+    adapter.add_domain_rule.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_compensate_custom_lists_noop_when_in_sync(tmp_path):
+    from apps.permitato.state import PermitState, compensate_custom_lists
+    from apps.permitato.custom_lists import CustomListStore
+    from apps.permitato.exceptions import build_domain_regex
+
+    adapter = AsyncMock()
+    regex = build_domain_regex("facebook.com")
+    adapter.get_domain_rules = AsyncMock(return_value=[
+        {"domain": regex, "groups": [1], "comment": "Permitato-custom: facebook.com"},
+    ])
+    adapter.delete_domain_rule = AsyncMock()
+    adapter.add_domain_rule = AsyncMock()
+
+    store = CustomListStore(data_dir=tmp_path)
+    store.add("work", "facebook.com")
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        custom_list_store=store,
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    await compensate_custom_lists(state)
+
+    adapter.delete_domain_rule.assert_not_called()
+    adapter.add_domain_rule.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Audit rotation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `CustomListStore` for per-mode user-defined blocklists (work/sfw), persisted to `custom_lists.json` with atomic writes
- Add `GET/POST/DELETE /custom-domains` API endpoints with Pi-hole deny/regex rule sync
- Add `compensate_custom_lists()` for reconnect reconciliation using `"Permitato-custom:"` comment prefix
- Add Custom Lists UI panel with Work/SFW tabs, add form, and remove buttons
- Add `custom_domain_added`/`custom_domain_removed` audit events for LLM context
- Fix pre-existing flaky `waitForFunction` in all Permitato Playwright specs

Closes #226

## Test evidence

### Python (816 passed)
```
uv run python -m pytest tests/unit tests/api apps/permitato/tests -q -n auto
816 passed in 10.79s
```

### Playwright (126 passed, 200/200 stress run on Permitato specs)
```
npx playwright test --reporter=dot --timeout=15000 --workers=75%
126 passed (31.6s)

npx playwright test apps/permitato/tests/ --repeat-each=10 --workers=75%
200 passed (34.0s)
```

## Pi QA

Pending — this changes Pi-hole group rules and needs real-device verification.