### PR TITLE
bug(permitato): keep manual mode when no schedule rules exist (#237)

### DIFF
--- a/apps/permitato/lifecycle.py
+++ b/apps/permitato/lifecycle.py
@@ -126,7 +126,7 @@ async def _apply_schedule_tick(
     """Single schedule evaluation tick — used by the loop and testable directly."""
     from apps.permitato.audit import write_audit_entry
 
-    if not state.schedule_store:
+    if not state.schedule_store or not state.schedule_store.list_rules():
         return
 
     scheduled_mode = state.schedule_store.evaluate(now)

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -437,7 +437,23 @@ async def delete_schedule_rule(request: Request, rule_id: str):
         "mode": rule.mode,
     })
 
-    await _apply_schedule_tick(state, _schedule_now())
+    if state.schedule_store.list_rules():
+        await _apply_schedule_tick(state, _schedule_now())
+    else:
+        state.override_mode = None
+        state.override_scheduled_mode = None
+        if state.mode != "normal":
+            old_mode = state.mode
+            state.mode = "normal"
+            state.persist()
+            await apply_mode_to_client(state)
+            write_audit_entry(state.data_dir, {
+                "event": "scheduled_mode_switch",
+                "from_mode": old_mode,
+                "to_mode": "normal",
+            })
+        else:
+            state.persist()
     return {"deleted": True}
 
 

--- a/apps/permitato/tests/test_schedule.py
+++ b/apps/permitato/tests/test_schedule.py
@@ -500,6 +500,67 @@ async def test_schedule_loop_noop_without_store(tmp_path):
     assert state.mode == "normal"
 
 
+@pytest.mark.anyio
+async def test_schedule_loop_noop_with_empty_store(tmp_path):
+    """Empty schedule store must not override manual mode switches."""
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    state.mode = "work"
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    await _apply_schedule_tick(state, datetime(2026, 3, 30, 10, 0))
+
+    assert state.mode == "work"
+
+
+@pytest.mark.anyio
+async def test_schedule_loop_empty_store_preserves_mode_across_ticks(tmp_path):
+    """Manual mode must survive repeated tick evaluations with no rules."""
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    store = ScheduleStore(data_dir=None)
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = store
+    state.mode = "sfw"
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    for minute in range(5):
+        await _apply_schedule_tick(state, datetime(2026, 3, 30, 10, minute))
+
+    assert state.mode == "sfw"
+
+
+@pytest.mark.anyio
+async def test_schedule_loop_empty_store_skips_pihole(tmp_path):
+    """No Pi-hole interaction when schedule store has no rules."""
+    from unittest.mock import AsyncMock
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    store = ScheduleStore(data_dir=None)
+
+    state = PermitState(data_dir=tmp_path, adapter=adapter)
+    state.schedule_store = store
+    state.mode = "work"
+    state.pihole_available = True
+
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    await _apply_schedule_tick(state, datetime(2026, 3, 30, 10, 0))
+
+    assert state.mode == "work"
+    adapter.update_client.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Startup schedule evaluation
 # ---------------------------------------------------------------------------
@@ -716,6 +777,36 @@ async def test_delete_schedule_applies_immediately(tmp_path):
 
     assert result["deleted"] is True
     assert state.mode == "normal"  # reverted because no rules match
+
+
+@pytest.mark.anyio
+async def test_delete_last_rule_clears_stale_override(tmp_path):
+    """Deleting the last rule while overriding to normal must clear override fields."""
+    from unittest.mock import AsyncMock, patch
+    from apps.permitato.schedule import ScheduleStore
+    from apps.permitato.state import PermitState
+
+    state = PermitState(data_dir=tmp_path, adapter=AsyncMock())
+    state.schedule_store = ScheduleStore(data_dir=tmp_path)
+    rule = state.schedule_store.add_rule("work", [0], "09:00", "17:00")
+    state.mode = "normal"
+    state.override_mode = "normal"
+    state.override_scheduled_mode = "work"
+    state.pihole_available = True
+
+    from apps.permitato import routes
+    now = datetime(2026, 3, 30, 14, 0)
+    with patch.object(routes, "_schedule_now", return_value=now):
+        await _call_delete_schedule(state, rule.id)
+
+    assert state.override_mode is None
+    assert state.override_scheduled_mode is None
+
+    # Adding a replacement rule in the same window must now take effect
+    state.schedule_store.add_rule("work", [0], "09:00", "17:00")
+    from apps.permitato.lifecycle import _apply_schedule_tick
+    await _apply_schedule_tick(state, now)
+    assert state.mode == "work"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep manual Permitato mode selections active when no schedule rules exist
- stop the schedule loop from forcing `normal` on empty schedule stores
- clear and persist stale override state when the final schedule rule is deleted

## Testing
- `uv run python -m pytest apps/permitato/tests/test_schedule.py -q`

## QA
- Pi QA pending

Closes #237
Refs #219
