### PR TITLE
bug(permitato): use the final conversational action and hide streamed markers (#241)

### DIFF
--- a/apps/permitato/intent.py
+++ b/apps/permitato/intent.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 
+logger = logging.getLogger(__name__)
+
 _ACTION_RE = re.compile(r"\[ACTION:(\w+)(?::([^\]]*))?\]")
+_PARTIAL_MARKER_RE = re.compile(r"\[(?:A(?:C(?:T(?:I(?:O(?:N(?::(?:[^\]]*)?)?)?)?)?)?)?)?$")
 
 _VALID_MODES = {"normal", "work", "sfw"}
 
@@ -29,10 +33,13 @@ class ParsedIntent:
 
 
 def extract_action_markers(text: str) -> ParsedIntent | None:
-    """Extract the first [ACTION:...] marker from text."""
-    match = _ACTION_RE.search(text)
-    if not match:
+    """Extract the last [ACTION:...] marker from text."""
+    matches = list(_ACTION_RE.finditer(text))
+    if not matches:
         return None
+    if len(matches) > 1:
+        logger.debug("Multiple markers found (%d), using last", len(matches))
+    match = matches[-1]
 
     action = match.group(1)
     raw_params = match.group(2) or ""
@@ -87,3 +94,16 @@ def parse_llm_response(text: str) -> ParsedIntent:
 def strip_action_markers(text: str) -> str:
     """Remove [ACTION:...] markers from text before displaying to user."""
     return _ACTION_RE.sub("", text)
+
+
+def clean_for_stream(text: str) -> str:
+    """Strip complete markers and trim trailing partial marker prefix.
+
+    Used during SSE streaming to prevent markers from leaking to the client.
+    A trailing ``[``, ``[A``, ``[ACT``, ``[ACTION:...`` without a closing
+    ``]`` is trimmed.  A mid-text ``[`` followed by non-marker content is
+    preserved.
+    """
+    cleaned = _ACTION_RE.sub("", text)
+    cleaned = _PARTIAL_MARKER_RE.sub("", cleaned)
+    return cleaned

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -13,7 +13,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from apps.permitato.audit import build_recent_context, read_audit_log, write_audit_entry
 from apps.permitato.custom_lists import CustomListStore
 from apps.permitato.exceptions import ExceptionStore, build_domain_regex
-from apps.permitato.intent import parse_llm_response, strip_action_markers
+from apps.permitato.intent import clean_for_stream, parse_llm_response, strip_action_markers
 from apps.permitato.stats import compute_stats
 from apps.permitato.modes import get_mode, MODES
 from apps.permitato.pihole_adapter import PiholeUnavailableError
@@ -646,6 +646,7 @@ async def permitato_chat(request: Request):
                         error_envelope = {"error": {"message": f"LLM returned {resp.status_code}", "code": resp.status_code}}
                     yield f"data: {json.dumps(error_envelope)}\n\ndata: [DONE]\n\n"
                     return
+                clean_sent = 0
                 async for line in resp.aiter_lines():
                     if not line.startswith("data: "):
                         yield line + "\n"
@@ -653,10 +654,11 @@ async def permitato_chat(request: Request):
 
                     data_str = line[6:]
                     if data_str.strip() == "[DONE]":
-                        # Parse intent from accumulated text before sending DONE
                         intent = parse_llm_response(accumulated_text)
+                        logger.info("Chat intent: action=%s params=%s text=%.120s", intent.action, intent.params, accumulated_text)
                         if intent.action != "none":
                             action_result = await _execute_action(state, intent, user_message)
+                            logger.info("Chat action result: %s", action_result)
                             yield f"data: {json.dumps({'permitato_action': action_result})}\n\n"
                         yield line + "\n"
                         continue
@@ -667,6 +669,13 @@ async def permitato_chat(request: Request):
                         content = delta.get("content", "")
                         if content:
                             accumulated_text += content
+                            clean = clean_for_stream(accumulated_text)
+                            new_chars = clean[clean_sent:]
+                            clean_sent = len(clean)
+                            if new_chars:
+                                chunk["choices"][0]["delta"]["content"] = new_chars
+                                yield f"data: {json.dumps(chunk)}\n\n"
+                            continue
                     except (json.JSONDecodeError, IndexError, KeyError):
                         pass
 

--- a/apps/permitato/tests/test_chat.py
+++ b/apps/permitato/tests/test_chat.py
@@ -1,0 +1,139 @@
+"""Tests for the Permitato chat SSE stream and action execution."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+from httpx import ASGITransport, AsyncClient, Response
+
+
+def _make_sse(*chunks: str, done: bool = True) -> str:
+    """Build a fake SSE body from content chunks."""
+    lines = []
+    for chunk in chunks:
+        payload = {"choices": [{"delta": {"content": chunk}}]}
+        lines.append(f"data: {json.dumps(payload)}\n\n")
+    if done:
+        lines.append("data: [DONE]\n\n")
+    return "".join(lines)
+
+
+def _build_app(state):
+    """Create a minimal FastAPI app with the permitato router wired up."""
+    from fastapi import FastAPI
+
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+    return app
+
+
+def _make_state(tmp_path):
+    """Build a PermitState suitable for chat action tests."""
+    from unittest.mock import AsyncMock
+
+    from apps.permitato.exceptions import ExceptionStore
+    from apps.permitato.state import PermitState
+
+    exc_store = ExceptionStore(data_dir=tmp_path)
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=AsyncMock(),
+        exception_store=exc_store,
+        mode="work",
+        pihole_available=True,
+        exception_group_id=3,
+    )
+    return state
+
+
+@pytest.mark.anyio
+async def test_chat_stream_strips_markers_and_executes_action(tmp_path):
+    """Chat stream must strip markers from SSE output and execute the action."""
+    state = _make_state(tmp_path)
+    app = _build_app(state)
+
+    sse_body = _make_sse(
+        "Sure, I'll unblock that for you. ",
+        "[ACTION:request_unblock:test-domain.com:work research]",
+    )
+
+    with respx.mock() as router:
+        router.post("http://127.0.0.1:1983/v1/chat/completions").mock(
+            return_value=Response(
+                200,
+                text=sse_body,
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "please unblock test-domain.com"},
+            )
+
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Markers must NOT appear in the stream
+    assert "[ACTION:" not in body
+
+    # Action result must be present
+    assert "permitato_action" in body
+    assert "exception_granted" in body
+    assert "test-domain.com" in body
+
+    # Exception must actually exist in the store
+    active = state.exception_store.list_active()
+    assert len(active) == 1
+    assert active[0]["domain"] == "test-domain.com"
+
+
+@pytest.mark.anyio
+async def test_chat_stream_last_marker_wins(tmp_path):
+    """When LLM emits multiple markers, the last one must be executed."""
+    state = _make_state(tmp_path)
+    app = _build_app(state)
+
+    sse_body = _make_sse(
+        "Hmm, I shouldn't do that. ",
+        "[ACTION:deny_unblock:youtube.com:distraction] ",
+        "Actually, you need it for a demo. ",
+        "[ACTION:request_unblock:youtube.com:work demo]",
+    )
+
+    with respx.mock() as router:
+        router.post("http://127.0.0.1:1983/v1/chat/completions").mock(
+            return_value=Response(
+                200,
+                text=sse_body,
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "unblock youtube.com please"},
+            )
+
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Last marker wins — should be exception_granted, not denied
+    assert "exception_granted" in body
+    assert "exception_denied" not in body
+
+    # Exception must exist
+    active = state.exception_store.list_active()
+    assert len(active) == 1
+    assert active[0]["domain"] == "youtube.com"

--- a/apps/permitato/tests/test_intent.py
+++ b/apps/permitato/tests/test_intent.py
@@ -90,3 +90,74 @@ def test_marker_takes_priority_over_fallback():
     )
     assert intent.action == "switch_mode"
     assert intent.params["mode"] == "sfw"
+
+
+# ---------------------------------------------------------------------------
+# Multi-marker: last marker wins
+# ---------------------------------------------------------------------------
+
+
+def test_extract_last_marker_when_multiple_present():
+    from apps.permitato.intent import parse_llm_response
+
+    intent = parse_llm_response(
+        "Let me switch. [ACTION:switch_mode:work] Actually, sfw is better. [ACTION:switch_mode:sfw]"
+    )
+    assert intent.action == "switch_mode"
+    assert intent.params["mode"] == "sfw"
+
+
+def test_extract_last_marker_different_actions():
+    from apps.permitato.intent import parse_llm_response
+
+    intent = parse_llm_response(
+        "I shouldn't unblock that. [ACTION:deny_unblock:youtube.com:distraction] "
+        "On second thought, you need it for work. [ACTION:request_unblock:youtube.com:work demo]"
+    )
+    assert intent.action == "request_unblock"
+    assert intent.params["domain"] == "youtube.com"
+    assert intent.params["reason"] == "work demo"
+
+
+# ---------------------------------------------------------------------------
+# clean_for_stream: strip complete + partial markers for SSE output
+# ---------------------------------------------------------------------------
+
+
+def test_clean_for_stream_strips_complete_marker():
+    from apps.permitato.intent import clean_for_stream
+
+    assert clean_for_stream("Sure! [ACTION:switch_mode:work] Done.") == "Sure!  Done."
+
+
+def test_clean_for_stream_trims_partial_marker_at_end():
+    from apps.permitato.intent import clean_for_stream
+
+    assert clean_for_stream("Sure! [ACTION:request_unbl") == "Sure! "
+
+
+def test_clean_for_stream_trims_trailing_lone_bracket():
+    from apps.permitato.intent import clean_for_stream
+
+    # Trailing [ is trimmed — it could be the start of a marker during streaming.
+    # If the next chunk proves otherwise, the bracket reappears in the delta.
+    assert clean_for_stream("See [this] and also [") == "See [this] and also "
+
+
+def test_clean_for_stream_preserves_mid_text_bracket():
+    from apps.permitato.intent import clean_for_stream
+
+    assert clean_for_stream("See [this] and also [ more") == "See [this] and also [ more"
+
+
+def test_clean_for_stream_trims_bracket_a():
+    from apps.permitato.intent import clean_for_stream
+
+    assert clean_for_stream("Hello [A") == "Hello "
+
+
+def test_clean_for_stream_strips_multiple_markers():
+    from apps.permitato.intent import clean_for_stream
+
+    text = "First [ACTION:deny_unblock:x.com:no] then [ACTION:request_unblock:x.com:yes] done."
+    assert clean_for_stream(text) == "First  then  done."


### PR DESCRIPTION
## Summary
- execute the final Permitato action marker instead of the first when the model emits multiple decisions
- strip action markers from the server-side SSE stream so raw markers never flash in the chat UI
- hold back split-marker prefixes, including a lone `[` chunk, so streamed markers stay hidden across arbitrary token boundaries
- log accumulated chat text, parsed intent, and action execution results for debugging

## Testing
- `uv run python -m pytest apps/permitato/tests/test_intent.py apps/permitato/tests/test_chat.py -q`

## QA
- Pi QA pending

Closes #241
Refs #219
