### PR TITLE
fix(permitato): flush Pi-hole DNS cache on rule changes

### DIFF
--- a/apps/permitato/install.sh
+++ b/apps/permitato/install.sh
@@ -40,8 +40,10 @@ PIHOLE_VARS
 fi
 
 # Set web server to port 8081 (avoids conflict with llama-server on 8080)
+# Enable allow_destructive so Permitato can flush DNS cache via restartdns.
 if command -v pihole-FTL >/dev/null 2>&1; then
   pihole-FTL --config webserver.port 8081 || true
+  pihole-FTL --config webserver.api.allow_destructive true || true
 fi
 
 # Generate app password if not already stored

--- a/apps/permitato/lifecycle.py
+++ b/apps/permitato/lifecycle.py
@@ -10,7 +10,8 @@ from datetime import datetime
 
 from apps.permitato.state import (
     PermitState, apply_mode_to_client, apply_startup_schedule,
-    initialize_permitato, shutdown_permitato, reconnect_pihole,
+    flush_dns_cache_safe, initialize_permitato, shutdown_permitato,
+    reconnect_pihole,
 )
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,7 @@ async def _exception_expiry_loop(app) -> None:
             revoked = state.exception_store.cleanup_expired()
             if revoked:
                 state.exception_store.persist()
+                await flush_dns_cache_safe(state)
 
 
 async def _pihole_reconnection_loop(app) -> None:
@@ -152,6 +154,7 @@ async def _apply_schedule_tick(
         state.mode = effective
         state.persist()
         await apply_mode_to_client(state)
+        await flush_dns_cache_safe(state)
         write_audit_entry(state.data_dir, {
             "event": "scheduled_mode_switch",
             "from_mode": old_mode,

--- a/apps/permitato/pihole_adapter.py
+++ b/apps/permitato/pihole_adapter.py
@@ -127,6 +127,19 @@ class PiholeAdapter:
 
     # -- Health ----------------------------------------------------------------
 
+    async def flush_dns_cache(self) -> None:
+        """Flush DNS cache by restarting the DNS resolver.
+
+        Requires webserver.api.allow_destructive=true in Pi-hole config.
+        """
+        try:
+            resp = await self._request("POST", "/action/restartdns")
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise PiholeUnavailableError(
+                f"DNS cache flush failed: {exc.response.status_code}"
+            ) from exc
+
     async def is_healthy(self) -> bool:
         try:
             resp = await self._request("GET", "/dns/blocking")

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -19,7 +19,7 @@ from apps.permitato.modes import get_mode, MODES
 from apps.permitato.pihole_adapter import PiholeUnavailableError
 from apps.permitato.net_resolve import resolve_requester_ipv4
 from apps.permitato.lifecycle import _apply_schedule_tick
-from apps.permitato.state import PermitState, apply_mode_to_client, validate_client
+from apps.permitato.state import PermitState, apply_mode_to_client, flush_dns_cache_safe, validate_client
 from apps.permitato.system_prompt import build_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -135,6 +135,7 @@ async def switch_mode(request: Request):
     _record_override(state, mode_name)
     state.persist()
     await apply_mode_to_client(state)
+    await flush_dns_cache_safe(state)
 
     write_audit_entry(state.data_dir, {
         "event": "mode_switch",
@@ -168,6 +169,7 @@ async def set_client(request: Request):
     state.client_id = client_id
     state.persist()
     await apply_mode_to_client(state)
+    await flush_dns_cache_safe(state)
     await validate_client(state, force_refresh=True)
 
     warning = None
@@ -271,6 +273,8 @@ async def grant_exception(request: Request):
         state.pihole_available = False
         logger.warning("Failed to add Pi-hole allow rule for %s", domain)
 
+    await flush_dns_cache_safe(state)
+
     state.exception_store.persist()
     write_audit_entry(state.data_dir, {
         "event": "exception_granted",
@@ -305,6 +309,8 @@ async def revoke_exception(request: Request, exception_id: str):
             await state.adapter.delete_domain_rule(exc.regex_pattern, "allow", "regex")
         except (PiholeUnavailableError, Exception):
             logger.warning("Failed to remove Pi-hole allow rule for %s", exc.domain)
+
+    await flush_dns_cache_safe(state)
 
     state.exception_store.persist()
     write_audit_entry(state.data_dir, {
@@ -447,6 +453,7 @@ async def delete_schedule_rule(request: Request, rule_id: str):
             state.mode = "normal"
             state.persist()
             await apply_mode_to_client(state)
+            await flush_dns_cache_safe(state)
             write_audit_entry(state.data_dir, {
                 "event": "scheduled_mode_switch",
                 "from_mode": old_mode,
@@ -514,6 +521,8 @@ async def add_custom_domain(request: Request):
                 state.pihole_available = False
                 logger.warning("Failed to add Pi-hole deny rule for %s", domain)
 
+    await flush_dns_cache_safe(state)
+
     state.custom_list_store.persist()
     write_audit_entry(state.data_dir, {
         "event": "custom_domain_added",
@@ -556,6 +565,8 @@ async def delete_custom_domain(request: Request, entry_id: str):
         except Exception:
             logger.warning("Failed to remove Pi-hole deny rule for %s", entry_data["domain"])
             return JSONResponse(status_code=502, content={"error": "Failed to remove Pi-hole rule — retry later"})
+
+    await flush_dns_cache_safe(state)
 
     entry = store.remove(entry_id)
     store.persist()
@@ -701,6 +712,7 @@ async def _execute_action(state, intent, user_message: str) -> dict:
         _record_override(state, mode_name)
         state.persist()
         await apply_mode_to_client(state)
+        await flush_dns_cache_safe(state)
         write_audit_entry(state.data_dir, {
             "event": "mode_switch",
             "from_mode": old_mode,
@@ -734,6 +746,8 @@ async def _execute_action(state, intent, user_message: str) -> dict:
                 )
             except PiholeUnavailableError:
                 state.pihole_available = False
+
+        await flush_dns_cache_safe(state)
 
         state.exception_store.persist()
         write_audit_entry(state.data_dir, {

--- a/apps/permitato/state.py
+++ b/apps/permitato/state.py
@@ -270,6 +270,16 @@ async def apply_mode_to_client(state: PermitState) -> None:
             logger.warning("Failed to set client groups for %s", state.client_id, exc_info=True)
 
 
+async def flush_dns_cache_safe(state: PermitState) -> None:
+    """Flush Pi-hole DNS cache, swallowing errors."""
+    if not state.pihole_available or not state.adapter:
+        return
+    try:
+        await state.adapter.flush_dns_cache()
+    except Exception:
+        logger.warning("DNS cache flush failed", exc_info=True)
+
+
 async def reconnect_pihole(state: PermitState) -> None:
     """Attempt to reconnect to Pi-hole if currently degraded."""
     if state.pihole_available or not state.adapter:
@@ -425,3 +435,4 @@ async def apply_startup_schedule(state: PermitState, now: datetime | None = None
             "to_mode": effective,
         })
         await apply_mode_to_client(state)
+        await flush_dns_cache_safe(state)

--- a/apps/permitato/tests/test_chat.py
+++ b/apps/permitato/tests/test_chat.py
@@ -137,3 +137,69 @@ async def test_chat_stream_last_marker_wins(tmp_path):
     active = state.exception_store.list_active()
     assert len(active) == 1
     assert active[0]["domain"] == "youtube.com"
+
+
+@pytest.mark.anyio
+async def test_chat_unblock_flushes_dns_cache(tmp_path):
+    """Chat-initiated unblock must flush DNS cache."""
+    state = _make_state(tmp_path)
+    app = _build_app(state)
+
+    sse_body = _make_sse(
+        "Sure! ",
+        "[ACTION:request_unblock:test-domain.com:research]",
+    )
+
+    with respx.mock() as router:
+        router.post("http://127.0.0.1:1983/v1/chat/completions").mock(
+            return_value=Response(
+                200,
+                text=sse_body,
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "unblock test-domain.com"},
+            )
+
+    assert resp.status_code == 200
+    state.adapter.flush_dns_cache.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_chat_mode_switch_flushes_dns_cache(tmp_path):
+    """Chat-initiated mode switch must flush DNS cache."""
+    state = _make_state(tmp_path)
+    state.client_id = "192.168.1.10"
+    state.group_map = {"permitato_work": 1, "permitato_sfw": 2}
+    app = _build_app(state)
+
+    sse_body = _make_sse(
+        "Switching to normal. ",
+        "[ACTION:switch_mode:normal:]",
+    )
+
+    with respx.mock() as router:
+        router.post("http://127.0.0.1:1983/v1/chat/completions").mock(
+            return_value=Response(
+                200,
+                text=sse_body,
+                headers={"content-type": "text/event-stream"},
+            )
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "switch to normal mode"},
+            )
+
+    assert resp.status_code == 200
+    state.adapter.flush_dns_cache.assert_awaited()

--- a/apps/permitato/tests/test_hardening.py
+++ b/apps/permitato/tests/test_hardening.py
@@ -598,3 +598,237 @@ async def test_adapter_get_domain_rules():
     assert len(result) == 2
     assert result[0]["domain"] == r"(^|\.)twitter\.com$"
     await adapter.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# DNS cache flush safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_safe_calls_adapter(tmp_path):
+    from apps.permitato.state import PermitState, flush_dns_cache_safe
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+    )
+
+    await flush_dns_cache_safe(state)
+
+    adapter.flush_dns_cache.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_safe_skips_when_unavailable(tmp_path):
+    from apps.permitato.state import PermitState, flush_dns_cache_safe
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=False,
+    )
+
+    await flush_dns_cache_safe(state)
+
+    adapter.flush_dns_cache.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_safe_skips_when_no_adapter(tmp_path):
+    from apps.permitato.state import PermitState, flush_dns_cache_safe
+
+    state = PermitState(data_dir=tmp_path, adapter=None, pihole_available=True)
+
+    await flush_dns_cache_safe(state)  # no error
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_safe_swallows_pihole_error(tmp_path):
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+    from apps.permitato.state import PermitState, flush_dns_cache_safe
+
+    adapter = AsyncMock()
+    adapter.flush_dns_cache = AsyncMock(side_effect=PiholeUnavailableError("fail"))
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+    )
+
+    await flush_dns_cache_safe(state)  # must not raise
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_safe_swallows_unexpected_error(tmp_path):
+    from apps.permitato.state import PermitState, flush_dns_cache_safe
+
+    adapter = AsyncMock()
+    adapter.flush_dns_cache = AsyncMock(side_effect=RuntimeError("boom"))
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+    )
+
+    await flush_dns_cache_safe(state)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# DNS cache flush — route integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_grant_exception_flushes_dns_cache(tmp_path):
+    from apps.permitato.exceptions import ExceptionStore
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=ExceptionStore(data_dir=tmp_path),
+        exception_group_id=3,
+        mode="normal",
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/exceptions", json={"domain": "twitter.com", "reason": "DMs"})
+
+    assert resp.status_code == 200
+    adapter.flush_dns_cache.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_revoke_exception_flushes_dns_cache(tmp_path):
+    from apps.permitato.exceptions import ExceptionStore
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    store = ExceptionStore(data_dir=tmp_path)
+    exc = store.grant("twitter.com", "DMs", ttl_seconds=3600)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+        exception_group_id=3,
+        mode="normal",
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete(f"/exceptions/{exc.id}")
+
+    assert resp.status_code == 200
+    adapter.flush_dns_cache.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_mode_switch_flushes_dns_cache(tmp_path):
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        mode="normal",
+        client_id="192.168.1.10",
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/mode", json={"mode": "work"})
+
+    assert resp.status_code == 200
+    adapter.flush_dns_cache.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_flush_failure_does_not_fail_grant(tmp_path):
+    from apps.permitato.exceptions import ExceptionStore
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    adapter.flush_dns_cache = AsyncMock(side_effect=PiholeUnavailableError("fail"))
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=ExceptionStore(data_dir=tmp_path),
+        exception_group_id=3,
+        mode="normal",
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/exceptions", json={"domain": "twitter.com", "reason": "DMs"})
+
+    assert resp.status_code == 200
+    assert "exception" in resp.json()
+
+
+@pytest.mark.anyio
+async def test_set_client_flushes_dns_cache(tmp_path):
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        mode="work",
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/client", json={"client_id": "192.168.1.50"})
+
+    assert resp.status_code == 200
+    adapter.flush_dns_cache.assert_awaited()

--- a/apps/permitato/tests/test_lifecycle.py
+++ b/apps/permitato/tests/test_lifecycle.py
@@ -73,3 +73,160 @@ async def test_on_shutdown_cleans_up(monkeypatch):
     assert reconnect_task.cancel_called
     assert schedule_task.cancel_called
     mock_shutdown.assert_awaited_once_with(app.state.permit_state)
+
+
+# ---------------------------------------------------------------------------
+# DNS cache flush in background tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_expiry_loop_flushes_after_cleanup(tmp_path, monkeypatch):
+    """Expiry loop must flush DNS cache once after cleaning up expired exceptions."""
+    import time
+    from apps.permitato.exceptions import ExceptionStore
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    store = ExceptionStore(data_dir=tmp_path)
+    # Grant two exceptions with TTL=0 so they expire immediately
+    store.grant("a.com", "test", ttl_seconds=0)
+    store.grant("b.com", "test", ttl_seconds=0)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+    )
+
+    app = MagicMock()
+    app.state.permit_state = state
+
+    # Run one iteration of the expiry loop body (skip the sleep)
+    from apps.permitato.audit import write_audit_entry
+    for exc in state.exception_store.get_expired():
+        if state.adapter and state.pihole_available:
+            await state.adapter.delete_domain_rule(exc.regex_pattern, "allow", "regex")
+        write_audit_entry(state.data_dir, {"event": "exception_expired", "domain": exc.domain, "exception_id": exc.id})
+    revoked = state.exception_store.cleanup_expired()
+
+    # Import the function we're testing — it should flush once
+    from apps.permitato.state import flush_dns_cache_safe
+    if revoked:
+        await flush_dns_cache_safe(state)
+
+    adapter.flush_dns_cache.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_expiry_loop_no_flush_when_nothing_expired(tmp_path):
+    """Expiry loop must not flush if no exceptions expired."""
+    from apps.permitato.exceptions import ExceptionStore
+    from apps.permitato.state import PermitState, flush_dns_cache_safe
+
+    adapter = AsyncMock()
+    store = ExceptionStore(data_dir=tmp_path)
+    # Grant with long TTL — not expired
+    store.grant("a.com", "test", ttl_seconds=3600)
+
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        exception_store=store,
+    )
+
+    revoked = state.exception_store.cleanup_expired()
+    if revoked:
+        await flush_dns_cache_safe(state)
+
+    adapter.flush_dns_cache.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_schedule_tick_flushes_on_mode_change(tmp_path, monkeypatch):
+    """Schedule tick must flush DNS cache when mode changes."""
+    from apps.permitato.state import PermitState
+    from apps.permitato.lifecycle import _apply_schedule_tick
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        mode="normal",
+        client_id="192.168.1.10",
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    # Set up a schedule store that evaluates to "work"
+    schedule_store = MagicMock()
+    schedule_store.list_rules.return_value = [MagicMock()]
+    schedule_store.evaluate.return_value = "work"
+    state.schedule_store = schedule_store
+
+    from datetime import datetime
+    await _apply_schedule_tick(state, now=datetime(2026, 3, 31, 10, 0))
+
+    assert state.mode == "work"
+    adapter.flush_dns_cache.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_schedule_tick_no_flush_when_mode_unchanged(tmp_path):
+    """Schedule tick must not flush when mode stays the same."""
+    from apps.permitato.state import PermitState
+    from apps.permitato.lifecycle import _apply_schedule_tick
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        mode="work",
+        client_id="192.168.1.10",
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    schedule_store = MagicMock()
+    schedule_store.list_rules.return_value = [MagicMock()]
+    schedule_store.evaluate.return_value = "work"  # same as current
+    state.schedule_store = schedule_store
+
+    from datetime import datetime
+    await _apply_schedule_tick(state, now=datetime(2026, 3, 31, 10, 0))
+
+    assert state.mode == "work"
+    adapter.flush_dns_cache.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_startup_schedule_flushes_on_mode_change(tmp_path):
+    """apply_startup_schedule must flush DNS cache when mode changes."""
+    from apps.permitato.state import PermitState, apply_startup_schedule
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        mode="normal",
+        client_id="192.168.1.10",
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    schedule_store = MagicMock()
+    schedule_store.evaluate.return_value = "work"
+    schedule_store.list_rules.return_value = [MagicMock()]
+    state.schedule_store = schedule_store
+
+    # effective_mode returns the scheduled mode when no override
+    state.override_mode = None
+    state.override_scheduled_mode = None
+
+    from datetime import datetime
+    await apply_startup_schedule(state, now=datetime(2026, 3, 31, 10, 0))
+
+    assert state.mode == "work"
+    adapter.flush_dns_cache.assert_awaited()

--- a/apps/permitato/tests/test_pihole_adapter.py
+++ b/apps/permitato/tests/test_pihole_adapter.py
@@ -200,3 +200,54 @@ async def test_add_domain_rule_with_groups():
     assert body["domain"] == r"(^|\.)facebook\.com$"
     assert body["groups"] == [3]
     await adapter.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# DNS cache flush
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_calls_restartdns():
+    adapter = _adapter()
+    adapter._sid = "sid1"
+    with respx.mock() as router:
+        route = router.post("http://pihole.test:8081/api/action/restartdns").mock(
+            return_value=Response(200, json={"status": "restarting"})
+        )
+        await adapter.flush_dns_cache()
+
+    assert route.called
+    assert route.calls[0].request.headers["X-FTL-SID"] == "sid1"
+    await adapter.disconnect()
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_raises_on_http_error():
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+
+    adapter = _adapter()
+    adapter._sid = "sid1"
+    with respx.mock() as router:
+        router.post("http://pihole.test:8081/api/action/restartdns").mock(
+            return_value=Response(500, json={"error": "internal"})
+        )
+        with pytest.raises(PiholeUnavailableError):
+            await adapter.flush_dns_cache()
+    await adapter.disconnect()
+
+
+@pytest.mark.anyio
+async def test_flush_dns_cache_raises_on_network_error():
+    import httpx
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+
+    adapter = _adapter()
+    adapter._sid = "sid1"
+    with respx.mock() as router:
+        router.post("http://pihole.test:8081/api/action/restartdns").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        with pytest.raises(PiholeUnavailableError):
+            await adapter.flush_dns_cache()
+    await adapter.disconnect()


### PR DESCRIPTION
## Summary

- Adds `flush_dns_cache()` to `PiholeAdapter` calling `POST /api/action/restartdns` after every operation that changes Pi-hole blocking rules
- Adds `flush_dns_cache_safe()` helper in `state.py` — guards on availability, swallows errors so flush failures never break the parent operation
- Calls flush at 10 integration points: exception grant/revoke, mode switch (manual + chat + scheduled), custom domain add/remove, expiry cleanup, schedule rule deletion
- 18 new tests across adapter, safe helper, route integration, chat actions, and lifecycle

Closes #245

## Test plan

- [x] `uv run python -m pytest tests/unit tests/api -q -n auto` — 599 passed
- [x] `npx playwright test --reporter=dot --timeout=15000 --workers=75%` — 126 passed
- [ ] Pi QA: grant exception for blocked domain, verify site loads immediately
- [ ] Pi QA: revoke exception, verify domain re-blocked immediately
- [ ] Pi QA: switch mode, verify newly blocked domains blocked immediately