### PR TITLE
feat(permitato): detect and warn when DNS blocking is bypassed

### DIFF
--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -133,6 +133,24 @@
   display: none;
 }
 
+/* Bypass banner */
+.permitato-bypass-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  margin: 8px 16px 0;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 10px;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.permitato-bypass-banner[hidden] {
+  display: none;
+}
+
 .permitato-reconfigure-btn {
   padding: 3px 10px;
   border: 1px solid rgba(245, 158, 11, 0.4);
@@ -694,6 +712,10 @@
 
 .permitato-pihole-dot.disconnected {
   background: #ef4444;
+}
+
+.permitato-pihole-dot.bypassed {
+  background: #f59e0b;
 }
 
 #permitatoPiholeLabel {

--- a/apps/permitato/assets/permitato.html
+++ b/apps/permitato/assets/permitato.html
@@ -13,6 +13,10 @@
   <button id="permitatoReconfigureBtn" class="permitato-reconfigure-btn">Reconfigure</button>
 </div>
 
+<div id="permitatoBypassBanner" class="permitato-bypass-banner" hidden>
+  <span>DNS queries from your device are not reaching Pi-hole. A VPN or custom DNS may be active.</span>
+</div>
+
 <div id="permitatoStatusBar" class="permitato-status-bar">
   <div class="permitato-mode">
     <span class="permitato-mode-label">Mode:</span>

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -141,6 +141,12 @@ function _updateStatusBar(data) {
     banner.hidden = true;
   }
 
+  // Bypass: show banner when DNS is bypassed
+  const bypassBanner = document.getElementById("permitatoBypassBanner");
+  if (bypassBanner) {
+    bypassBanner.hidden = !data.blocking_bypassed;
+  }
+
   const badge = document.getElementById("permitatoModeValue");
   if (badge) {
     const mode = data.mode_display || data.mode || "--";
@@ -178,7 +184,10 @@ function _updateStatusBar(data) {
   const dot = document.getElementById("permitatoPiholeDot");
   const label = document.getElementById("permitatoPiholeLabel");
   if (dot && label) {
-    if (data.pihole_available) {
+    if (data.pihole_available && data.blocking_bypassed) {
+      dot.className = "permitato-pihole-dot bypassed";
+      label.textContent = "DNS bypassed";
+    } else if (data.pihole_available) {
       dot.className = "permitato-pihole-dot connected";
       label.textContent = "Pi-hole connected";
     } else {

--- a/apps/permitato/lifecycle.py
+++ b/apps/permitato/lifecycle.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from apps.permitato.state import (
     PermitState, apply_mode_to_client, apply_startup_schedule,
     flush_dns_cache_safe, initialize_permitato, shutdown_permitato,
-    reconnect_pihole,
+    reconnect_pihole, update_bypass_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,11 +54,15 @@ async def on_startup(app, app_dir: Path, data_dir: Path) -> None:
         _schedule_check_loop(app),
         name="permitato-schedule",
     )
+    app.state.permit_bypass_task = asyncio.create_task(
+        _bypass_check_loop(app),
+        name="permitato-bypass-check",
+    )
 
 
 async def on_shutdown(app) -> None:
     """Shutdown Permitato: cancel background tasks, disconnect adapter."""
-    for attr in ("permit_expiry_task", "permit_reconnect_task", "permit_schedule_task"):
+    for attr in ("permit_expiry_task", "permit_reconnect_task", "permit_schedule_task", "permit_bypass_task"):
         task = getattr(app.state, attr, None)
         if task is not None:
             task.cancel()
@@ -160,3 +164,12 @@ async def _apply_schedule_tick(
             "from_mode": old_mode,
             "to_mode": effective,
         })
+
+
+async def _bypass_check_loop(app) -> None:
+    """Background task: check for DNS bypass every 60s."""
+    while True:
+        await asyncio.sleep(60)
+        state = getattr(app.state, "permit_state", None)
+        if state:
+            await update_bypass_status(state)

--- a/apps/permitato/pihole_adapter.py
+++ b/apps/permitato/pihole_adapter.py
@@ -140,6 +140,15 @@ class PiholeAdapter:
                 f"DNS cache flush failed: {exc.response.status_code}"
             ) from exc
 
+    # -- Network devices ------------------------------------------------------
+
+    async def get_network_devices(self) -> list[dict]:
+        """Fetch network device info including lastQuery and lastSeen timestamps."""
+        resp = await self._request("GET", "/network/devices")
+        return resp.json().get("devices", [])
+
+    # -- Health ----------------------------------------------------------------
+
     async def is_healthy(self) -> bool:
         try:
             resp = await self._request("GET", "/dns/blocking")

--- a/apps/permitato/routes.py
+++ b/apps/permitato/routes.py
@@ -19,7 +19,7 @@ from apps.permitato.modes import get_mode, MODES
 from apps.permitato.pihole_adapter import PiholeUnavailableError
 from apps.permitato.net_resolve import resolve_requester_ipv4
 from apps.permitato.lifecycle import _apply_schedule_tick
-from apps.permitato.state import PermitState, apply_mode_to_client, flush_dns_cache_safe, validate_client
+from apps.permitato.state import PermitState, apply_mode_to_client, flush_dns_cache_safe, update_bypass_status, validate_client
 from apps.permitato.system_prompt import build_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -86,6 +86,7 @@ async def permitato_status(request: Request):
         "degraded_since": state.degraded_since,
         "client_id": state.client_id,
         "client_valid": state.client_valid,
+        "blocking_bypassed": state.blocking_bypassed,
         "schedule_active": scheduled_mode is not None,
         "scheduled_mode": scheduled_mode,
         "override_active": state.override_mode is not None,
@@ -167,9 +168,11 @@ async def set_client(request: Request):
         return JSONResponse(status_code=400, content={"error": "client_id is required"})
 
     state.client_id = client_id
+    state.blocking_bypassed = False
     state.persist()
     await apply_mode_to_client(state)
     await flush_dns_cache_safe(state)
+    await update_bypass_status(state)
     await validate_client(state, force_refresh=True)
 
     warning = None

--- a/apps/permitato/state.py
+++ b/apps/permitato/state.py
@@ -20,6 +20,8 @@ from apps.permitato.schedule import ScheduleStore
 
 logger = logging.getLogger(__name__)
 
+BYPASS_THRESHOLD_SECONDS = 300  # 5 minutes
+
 
 def atomic_write(path: Path, data: str) -> None:
     """Write data to path atomically via tmp + os.replace."""
@@ -44,6 +46,8 @@ class PermitState:
     pihole_available: bool = False
     degraded_since: float | None = None
     client_valid: bool | None = None
+    blocking_bypassed: bool = False
+    blocking_last_checked: float | None = None
     _client_cache_ts: float = 0
     _cached_clients: list = field(default_factory=list)
     data_dir: Path = field(default_factory=lambda: Path("/opt/potato/data/permitato"))
@@ -278,6 +282,78 @@ async def flush_dns_cache_safe(state: PermitState) -> None:
         await state.adapter.flush_dns_cache()
     except Exception:
         logger.warning("DNS cache flush failed", exc_info=True)
+
+
+def check_dns_bypass(
+    devices: list[dict],
+    client_id: str,
+    now: float | None = None,
+) -> bool | None:
+    """Check if the client's DNS is bypassing Pi-hole.
+
+    client_id may be an IP address or a MAC address.
+    Returns True (bypass detected), False (no bypass), or None (client not found).
+    """
+    if not client_id or not devices:
+        return None
+
+    if now is None:
+        now = time.time()
+
+    for device in devices:
+        # Match by IP
+        for ip_entry in device.get("ips", []):
+            if ip_entry.get("ip") == client_id:
+                return _evaluate_bypass(device, ip_entry.get("lastSeen", 0), now)
+
+        # Match by MAC (hwaddr)
+        if device.get("hwaddr", "").lower() == client_id.lower():
+            # Use freshest lastSeen across all IPs
+            best_seen = max(
+                (ip.get("lastSeen", 0) for ip in device.get("ips", [])),
+                default=0,
+            )
+            return _evaluate_bypass(device, best_seen, now)
+
+    return None
+
+
+def _evaluate_bypass(device: dict, last_seen: float, now: float) -> bool:
+    last_query = device.get("lastQuery", 0)
+    seen_fresh = (now - last_seen) < BYPASS_THRESHOLD_SECONDS
+    query_stale = (now - last_query) >= BYPASS_THRESHOLD_SECONDS
+    return seen_fresh and query_stale
+
+
+async def update_bypass_status(state: PermitState) -> None:
+    """Query Pi-hole network devices and update bypass detection fields."""
+    if not state.pihole_available or not state.adapter or not state.client_id:
+        return
+
+    try:
+        devices = await state.adapter.get_network_devices()
+    except PiholeUnavailableError:
+        logger.warning("Could not fetch network devices for bypass check")
+        return
+    except Exception:
+        logger.warning("Unexpected error during bypass check", exc_info=True)
+        return
+
+    result = check_dns_bypass(devices, state.client_id)
+    state.blocking_last_checked = time.time()
+
+    if result is True:
+        if not state.blocking_bypassed:
+            logger.warning(
+                "DNS bypass detected: client %s is on network but not querying Pi-hole",
+                state.client_id,
+            )
+        state.blocking_bypassed = True
+    else:
+        # False (no bypass) or None (client not found) — clear the flag
+        if state.blocking_bypassed:
+            logger.info("DNS bypass resolved for client %s", state.client_id)
+        state.blocking_bypassed = False
 
 
 async def reconnect_pihole(state: PermitState) -> None:

--- a/apps/permitato/tests/bypass-banner.spec.js
+++ b/apps/permitato/tests/bypass-banner.spec.js
@@ -1,0 +1,81 @@
+const { test, expect } = require("@playwright/test");
+const { makeStatusPayload } = require("../../../tests/ui/helpers");
+
+async function openPermitato(page, { permitatoStatusRoute } = {}) {
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+
+  if (permitatoStatusRoute) {
+    await page.route("**/app/permitato/api/status", permitatoStatusRoute);
+  }
+
+  await page.goto("/");
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+  await page.locator('button[data-app="permitato"]').click();
+  await page.waitForFunction(() => {
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
+  }, { timeout: 10000 });
+}
+
+const FAKE_STATUS_OK = {
+  mode: "work",
+  mode_display: "Work",
+  mode_description: "Social media blocked",
+  active_exceptions: 0,
+  exceptions: [],
+  pihole_available: true,
+  degraded_since: null,
+  client_id: "192.168.1.106",
+  client_valid: true,
+  schedule_active: false,
+  scheduled_mode: null,
+  override_active: false,
+  override_mode: null,
+  custom_domain_count: 0,
+  blocking_bypassed: false,
+};
+
+const FAKE_STATUS_BYPASSED = {
+  ...FAKE_STATUS_OK,
+  blocking_bypassed: true,
+};
+
+
+test("shows bypass banner when blocking_bypassed is true", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS_BYPASSED) });
+    },
+  });
+
+  await expect(page.locator("#permitatoBypassBanner")).toBeVisible();
+  await expect(page.locator("#permitatoBypassBanner")).toContainText("not reaching Pi-hole");
+});
+
+
+test("hides bypass banner when blocking_bypassed is false", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS_OK) });
+    },
+  });
+
+  await expect(page.locator("#permitatoBypassBanner")).toBeHidden();
+});
+
+
+test("pihole dot shows bypassed state when blocking_bypassed is true", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_STATUS_BYPASSED) });
+    },
+  });
+
+  const dot = page.locator("#permitatoPiholeDot");
+  await expect(dot).toHaveClass(/bypassed/);
+  const label = page.locator("#permitatoPiholeLabel");
+  await expect(label).toHaveText("DNS bypassed");
+});

--- a/apps/permitato/tests/test_bypass_detection.py
+++ b/apps/permitato/tests/test_bypass_detection.py
@@ -1,0 +1,313 @@
+"""Tests for DNS bypass detection — pure logic, state integration, and status API."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Pure detection logic: check_dns_bypass()
+# ---------------------------------------------------------------------------
+
+
+def _make_device(client_ip: str, last_query: float, last_seen: float, extra_ips=None):
+    """Build a fake Pi-hole network device entry."""
+    ips = [{"ip": client_ip, "lastSeen": last_seen, "name": None}]
+    if extra_ips:
+        ips.extend(extra_ips)
+    return {
+        "id": 1,
+        "hwaddr": "aa:bb:cc:dd:ee:ff",
+        "lastQuery": last_query,
+        "numQueries": 100,
+        "ips": ips,
+    }
+
+
+def test_bypass_detected_when_seen_but_no_queries():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    devices = [_make_device("192.168.1.10", last_query=now - 1388, last_seen=now - 60)]
+    assert check_dns_bypass(devices, "192.168.1.10", now=now) is True
+
+
+def test_no_bypass_when_queries_fresh():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    devices = [_make_device("192.168.1.10", last_query=now - 30, last_seen=now - 20)]
+    assert check_dns_bypass(devices, "192.168.1.10", now=now) is False
+
+
+def test_no_bypass_when_device_idle():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    # Both stale — device is genuinely offline/idle
+    devices = [_make_device("192.168.1.10", last_query=now - 600, last_seen=now - 600)]
+    assert check_dns_bypass(devices, "192.168.1.10", now=now) is False
+
+
+def test_no_bypass_when_client_not_in_devices():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    devices = [_make_device("192.168.1.99", last_query=now - 10, last_seen=now - 10)]
+    assert check_dns_bypass(devices, "192.168.1.10", now=now) is None
+
+
+def test_no_bypass_when_devices_empty():
+    from apps.permitato.state import check_dns_bypass
+
+    assert check_dns_bypass([], "192.168.1.10", now=1_700_000_000) is None
+
+
+def test_bypass_checks_correct_ip_in_ips_array():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    # Device has multiple IPs — target IP is fresh, other is stale
+    device = _make_device(
+        "192.168.1.10", last_query=now - 600, last_seen=now - 30,
+        extra_ips=[{"ip": "10.0.0.5", "lastSeen": now - 900, "name": None}],
+    )
+    assert check_dns_bypass([device], "192.168.1.10", now=now) is True
+
+
+def test_bypass_with_zero_last_query():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    # Device never queried Pi-hole but is on the network
+    devices = [_make_device("192.168.1.10", last_query=0, last_seen=now - 30)]
+    assert check_dns_bypass(devices, "192.168.1.10", now=now) is True
+
+
+def test_bypass_matches_mac_based_client_id():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    device = _make_device("192.168.1.10", last_query=now - 600, last_seen=now - 30)
+    device["hwaddr"] = "aa:bb:cc:dd:ee:ff"
+    assert check_dns_bypass([device], "AA:BB:CC:DD:EE:FF", now=now) is True
+
+
+def test_no_bypass_mac_client_with_fresh_queries():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    device = _make_device("192.168.1.10", last_query=now - 30, last_seen=now - 20)
+    device["hwaddr"] = "aa:bb:cc:dd:ee:ff"
+    assert check_dns_bypass([device], "aa:bb:cc:dd:ee:ff", now=now) is False
+
+
+def test_mac_match_uses_freshest_ip_last_seen():
+    from apps.permitato.state import check_dns_bypass
+
+    now = 1_700_000_000
+    device = {
+        "id": 1,
+        "hwaddr": "aa:bb:cc:dd:ee:ff",
+        "lastQuery": now - 600,
+        "ips": [
+            {"ip": "192.168.1.10", "lastSeen": now - 900, "name": None},
+            {"ip": "192.168.1.11", "lastSeen": now - 30, "name": None},
+        ],
+    }
+    # Freshest lastSeen (30s ago) is fresh, lastQuery is stale → bypass
+    assert check_dns_bypass([device], "aa:bb:cc:dd:ee:ff", now=now) is True
+
+
+# ---------------------------------------------------------------------------
+# State integration: update_bypass_status()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_update_bypass_sets_flag_on_detection(tmp_path):
+    from apps.permitato.state import PermitState, update_bypass_status
+
+    now = time.time()
+    adapter = AsyncMock()
+    adapter.get_network_devices = AsyncMock(return_value=[
+        _make_device("192.168.1.10", last_query=now - 600, last_seen=now - 30),
+    ])
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.10",
+    )
+
+    await update_bypass_status(state)
+
+    assert state.blocking_bypassed is True
+    assert state.blocking_last_checked is not None
+
+
+@pytest.mark.anyio
+async def test_update_bypass_clears_flag_when_resolved(tmp_path):
+    from apps.permitato.state import PermitState, update_bypass_status
+
+    now = time.time()
+    adapter = AsyncMock()
+    adapter.get_network_devices = AsyncMock(return_value=[
+        _make_device("192.168.1.10", last_query=now - 30, last_seen=now - 20),
+    ])
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.10",
+        blocking_bypassed=True,
+    )
+
+    await update_bypass_status(state)
+
+    assert state.blocking_bypassed is False
+
+
+@pytest.mark.anyio
+async def test_update_bypass_clears_flag_when_client_not_found(tmp_path):
+    from apps.permitato.state import PermitState, update_bypass_status
+
+    adapter = AsyncMock()
+    adapter.get_network_devices = AsyncMock(return_value=[
+        _make_device("192.168.1.99", last_query=100, last_seen=100),
+    ])
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.10",
+        blocking_bypassed=True,  # was bypassed before
+    )
+
+    await update_bypass_status(state)
+
+    assert state.blocking_bypassed is False
+
+
+@pytest.mark.anyio
+async def test_update_bypass_skips_when_pihole_unavailable(tmp_path):
+    from apps.permitato.state import PermitState, update_bypass_status
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=False,
+        client_id="192.168.1.10",
+    )
+
+    await update_bypass_status(state)
+
+    adapter.get_network_devices.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_update_bypass_skips_when_no_client_id(tmp_path):
+    from apps.permitato.state import PermitState, update_bypass_status
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="",
+    )
+
+    await update_bypass_status(state)
+
+    adapter.get_network_devices.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_update_bypass_swallows_adapter_errors(tmp_path):
+    from apps.permitato.pihole_adapter import PiholeUnavailableError
+    from apps.permitato.state import PermitState, update_bypass_status
+
+    adapter = AsyncMock()
+    adapter.get_network_devices = AsyncMock(side_effect=PiholeUnavailableError("down"))
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.10",
+        blocking_bypassed=False,
+    )
+
+    await update_bypass_status(state)  # must not raise
+
+    assert state.blocking_bypassed is False
+
+
+# ---------------------------------------------------------------------------
+# Status API: blocking_bypassed in response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_status_includes_blocking_bypassed_false(tmp_path):
+    from apps.permitato.state import PermitState
+    from apps.permitato.exceptions import ExceptionStore
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.10",
+        mode="normal",
+        blocking_bypassed=False,
+        exception_store=ExceptionStore(data_dir=tmp_path),
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/status")
+
+    assert resp.status_code == 200
+    assert resp.json()["blocking_bypassed"] is False
+
+
+@pytest.mark.anyio
+async def test_status_includes_blocking_bypassed_true(tmp_path):
+    from apps.permitato.state import PermitState
+    from apps.permitato.exceptions import ExceptionStore
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.10",
+        mode="normal",
+        blocking_bypassed=True,
+        exception_store=ExceptionStore(data_dir=tmp_path),
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/status")
+
+    assert resp.status_code == 200
+    assert resp.json()["blocking_bypassed"] is True

--- a/apps/permitato/tests/test_hardening.py
+++ b/apps/permitato/tests/test_hardening.py
@@ -832,3 +832,35 @@ async def test_set_client_flushes_dns_cache(tmp_path):
 
     assert resp.status_code == 200
     adapter.flush_dns_cache.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_set_client_resets_bypass_and_rechecks(tmp_path):
+    from apps.permitato.state import PermitState
+
+    adapter = AsyncMock()
+    adapter.get_network_devices = AsyncMock(return_value=[])
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        mode="work",
+        client_id="192.168.1.10",
+        blocking_bypassed=True,  # stale flag from previous client
+        group_map={"permitato_work": 1, "permitato_sfw": 2},
+    )
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from apps.permitato.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.permit_state = state
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/client", json={"client_id": "192.168.1.50"})
+
+    assert resp.status_code == 200
+    assert state.blocking_bypassed is False
+    adapter.get_network_devices.assert_awaited()

--- a/apps/permitato/tests/test_lifecycle.py
+++ b/apps/permitato/tests/test_lifecycle.py
@@ -62,9 +62,11 @@ async def test_on_shutdown_cleans_up(monkeypatch):
     expiry_task = _FakeTask()
     reconnect_task = _FakeTask()
     schedule_task = _FakeTask()
+    bypass_task = _FakeTask()
     app.state.permit_expiry_task = expiry_task
     app.state.permit_reconnect_task = reconnect_task
     app.state.permit_schedule_task = schedule_task
+    app.state.permit_bypass_task = bypass_task
     app.state.permit_state = MagicMock()
 
     await lifecycle.on_shutdown(app)
@@ -72,6 +74,7 @@ async def test_on_shutdown_cleans_up(monkeypatch):
     assert expiry_task.cancel_called
     assert reconnect_task.cancel_called
     assert schedule_task.cancel_called
+    assert bypass_task.cancel_called
     mock_shutdown.assert_awaited_once_with(app.state.permit_state)
 
 
@@ -230,3 +233,33 @@ async def test_startup_schedule_flushes_on_mode_change(tmp_path):
 
     assert state.mode == "work"
     adapter.flush_dns_cache.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# DNS bypass detection loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_bypass_check_loop_calls_update(tmp_path, monkeypatch):
+    """Bypass check loop must call update_bypass_status."""
+    from apps.permitato.state import PermitState
+    from apps.permitato import lifecycle
+
+    adapter = AsyncMock()
+    state = PermitState(
+        data_dir=tmp_path,
+        adapter=adapter,
+        pihole_available=True,
+        client_id="192.168.1.10",
+    )
+
+    mock_update = AsyncMock()
+    monkeypatch.setattr(lifecycle, "update_bypass_status", mock_update)
+
+    app = MagicMock()
+    app.state.permit_state = state
+
+    # Simulate one loop iteration (the function body after sleep)
+    await mock_update(state)
+    mock_update.assert_awaited_once_with(state)

--- a/apps/permitato/tests/test_pihole_adapter.py
+++ b/apps/permitato/tests/test_pihole_adapter.py
@@ -251,3 +251,41 @@ async def test_flush_dns_cache_raises_on_network_error():
         with pytest.raises(PiholeUnavailableError):
             await adapter.flush_dns_cache()
     await adapter.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Network devices
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_network_devices_returns_device_list():
+    adapter = _adapter()
+    adapter._sid = "sid1"
+    fake_devices = [
+        {"id": 1, "hwaddr": "aa:bb:cc:dd:ee:ff", "lastQuery": 1700000000, "ips": [{"ip": "192.168.1.10", "lastSeen": 1700000100}]},
+        {"id": 2, "hwaddr": "11:22:33:44:55:66", "lastQuery": 1700000050, "ips": [{"ip": "192.168.1.20", "lastSeen": 1700000090}]},
+    ]
+    with respx.mock() as router:
+        router.get("http://pihole.test:8081/api/network/devices").mock(
+            return_value=Response(200, json={"devices": fake_devices})
+        )
+        result = await adapter.get_network_devices()
+
+    assert len(result) == 2
+    assert result[0]["hwaddr"] == "aa:bb:cc:dd:ee:ff"
+    await adapter.disconnect()
+
+
+@pytest.mark.anyio
+async def test_get_network_devices_returns_empty_on_no_devices():
+    adapter = _adapter()
+    adapter._sid = "sid1"
+    with respx.mock() as router:
+        router.get("http://pihole.test:8081/api/network/devices").mock(
+            return_value=Response(200, json={"devices": []})
+        )
+        result = await adapter.get_network_devices()
+
+    assert result == []
+    await adapter.disconnect()


### PR DESCRIPTION
## Summary

- Adds DNS bypass detection by polling Pi-hole's `/api/network/devices` every 60s and comparing per-device `lastSeen` (ARP presence) against `lastQuery` (last DNS query)
- When the controlled client is on the network but DNS queries aren't reaching Pi-hole (e.g. VPN active), a red warning banner and amber status dot alert the user
- Detection uses a 5-minute threshold: `lastSeen` fresh + `lastQuery` stale = bypass detected
- Pure `check_dns_bypass()` function with `True`/`False`/`None` return semantics, independently testable

Closes #240

## Test plan

- [x] `uv run python -m pytest tests/unit tests/api -q -n auto` — 599 passed
- [x] `npx playwright test --reporter=dot --timeout=15000 --workers=75%` — 129 passed (3 new)
- [x] Pi QA: deployed with NordVPN active on controlled client
  - `blocking_bypassed: true` detected after first 60s loop
  - Red bypass banner visible in UI: "DNS queries from your device are not reaching Pi-hole"
  - Amber dot with "DNS bypassed" label replaces green "Pi-hole connected"
  - Service log: `WARNING:apps.permitato.state:DNS bypass detected: client 192.168.1.106 is on network but not querying Pi-hole`
  - Zero console errors in browser