### PR TITLE
chore(permitato): UI polish — mode pulse, app persistence, delete confirmations

### DIFF
--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -1109,3 +1109,21 @@
   border-color: var(--text);
   color: var(--text);
 }
+
+/* Mode switch pulse feedback */
+@keyframes mode-pulse {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.12); }
+  100% { transform: scale(1); }
+}
+
+.permitato-mode-badge.mode-changed {
+  animation: mode-pulse 0.35s ease-out;
+}
+
+/* Destructive action confirm state */
+.confirm-pending {
+  color: #ef4444 !important;
+  border-color: #ef4444 !important;
+  font-weight: 600;
+}

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -10,6 +10,7 @@ let _lastClientFetchTs = 0;
 let _panelOpen = false;
 let _schedulePanelOpen = false;
 let _statsPanelOpen = false;
+let _lastRenderedMode = null;
 let _customListPanelOpen = false;
 let _customListTab = "work";
 let _latestCustomDomains = [];
@@ -152,6 +153,13 @@ function _updateStatusBar(data) {
     const mode = data.mode_display || data.mode || "--";
     badge.textContent = mode;
     badge.setAttribute("data-mode", data.mode || "");
+    if (_lastRenderedMode !== null && data.mode !== _lastRenderedMode) {
+      badge.classList.remove("mode-changed");
+      void badge.offsetWidth;
+      badge.classList.add("mode-changed");
+      badge.addEventListener("animationend", () => badge.classList.remove("mode-changed"), { once: true });
+    }
+    _lastRenderedMode = data.mode;
   }
 
   // Schedule/override indicator
@@ -320,6 +328,7 @@ function _renderExceptions() {
   const empty = document.getElementById("permitatoExceptionsEmpty");
   const degraded = document.getElementById("permitatoExceptionsDegraded");
   if (!list) return;
+  if (list.querySelector(".confirm-pending")) return;
 
   if (degraded) degraded.hidden = _latestPiholeAvailable;
 
@@ -360,7 +369,7 @@ function _renderExceptions() {
     const btn = document.createElement("button");
     btn.className = "exc-revoke-btn";
     btn.textContent = "Revoke";
-    btn.addEventListener("click", () => _revokeException(exc.id));
+    btn.addEventListener("click", () => _confirmAction(btn, () => _revokeException(exc.id)));
     right.appendChild(btn);
 
     li.appendChild(right);
@@ -480,7 +489,7 @@ function _renderScheduleRules(rules) {
     const btn = document.createElement("button");
     btn.className = "sched-delete-btn";
     btn.textContent = "Delete";
-    btn.addEventListener("click", () => _deleteScheduleRule(rule.id));
+    btn.addEventListener("click", () => _confirmAction(btn, () => _deleteScheduleRule(rule.id)));
     right.appendChild(btn);
 
     li.appendChild(right);
@@ -608,7 +617,7 @@ function _renderCustomDomains() {
     const btn = document.createElement("button");
     btn.className = "custom-domain-remove-btn";
     btn.textContent = "Remove";
-    btn.addEventListener("click", () => _deleteCustomDomain(entry.id));
+    btn.addEventListener("click", () => _confirmAction(btn, () => _deleteCustomDomain(entry.id)));
     li.appendChild(btn);
 
     list.appendChild(li);
@@ -805,6 +814,32 @@ function _showRecoveryBanner(clientId) {
   if (!banner || !text) return;
   text.textContent = `Your controlled device (${clientId}) is no longer available in Pi-hole.`;
   banner.hidden = false;
+}
+
+// --- Confirm-before-delete utility ---
+
+function _confirmAction(btn, action) {
+  if (btn.dataset.confirming) return;
+  const original = btn.textContent;
+  btn.textContent = "Sure?";
+  btn.classList.add("confirm-pending");
+  btn.dataset.confirming = "1";
+
+  const timer = setTimeout(() => revert(), 3000);
+
+  function onConfirm() {
+    clearTimeout(timer);
+    revert();
+    action();
+  }
+  function revert() {
+    btn.removeEventListener("click", onConfirm);
+    btn.textContent = original;
+    btn.classList.remove("confirm-pending");
+    delete btn.dataset.confirming;
+  }
+
+  btn.addEventListener("click", onConfirm, { once: true });
 }
 
 // --- Session persistence (IndexedDB) ---

--- a/apps/permitato/tests/custom-list-panel.spec.js
+++ b/apps/permitato/tests/custom-list-panel.spec.js
@@ -129,6 +129,9 @@ test("removing a domain calls DELETE and refreshes list", async ({ page }) => {
   await page.locator("#permitatoCustomListToggle").click();
   await expect(page.locator("#permitatoCustomList li")).toHaveCount(1);
 
+  // Click remove — enters confirm state
+  await page.locator(".custom-domain-remove-btn").first().click();
+  // Confirm by clicking again
   await page.locator(".custom-domain-remove-btn").first().click();
 
   // After remove, Work tab should be empty

--- a/apps/permitato/tests/exceptions-panel.spec.js
+++ b/apps/permitato/tests/exceptions-panel.spec.js
@@ -104,7 +104,9 @@ test("revoke calls DELETE and refreshes the panel", async ({ page }) => {
   await page.locator("#permitatoExceptionsToggle").click();
   await expect(page.locator("#permitatoExceptionsList li")).toHaveCount(2);
 
-  // Click revoke on first item
+  // Click revoke on first item — enters confirm state
+  await page.locator(".exc-revoke-btn").first().click();
+  // Confirm by clicking again
   await page.locator(".exc-revoke-btn").first().click();
 
   // Should update to 1 exception after the re-poll

--- a/apps/permitato/tests/ui-polish.spec.js
+++ b/apps/permitato/tests/ui-polish.spec.js
@@ -1,0 +1,160 @@
+const { test, expect } = require("@playwright/test");
+const { waitUntilReady, makeStatusPayload } = require("../../../tests/ui/helpers");
+
+const NOW = Math.floor(Date.now() / 1000);
+
+async function openPermitato(page, { permitatoStatusRoute } = {}) {
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+  if (permitatoStatusRoute) {
+    await page.route("**/app/permitato/api/status", permitatoStatusRoute);
+  }
+  await page.goto("/");
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+  await page.locator('button[data-app="permitato"]').click();
+  await page.waitForFunction(() => {
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
+  }, { timeout: 10000 });
+}
+
+const WORK_STATUS = {
+  mode: "work",
+  mode_display: "Work",
+  mode_description: "Social media blocked",
+  active_exceptions: 1,
+  exceptions: [
+    { id: "exc-1", domain: "twitter.com", reason: "check DMs", granted_at: NOW - 600, expires_at: NOW + 2400, ttl_seconds: 3600 },
+  ],
+  pihole_available: true,
+  degraded_since: null,
+  client_id: "192.168.1.100",
+  client_valid: true,
+  blocking_bypassed: false,
+  schedule_active: false,
+  scheduled_mode: null,
+  override_active: false,
+  override_mode: null,
+  custom_domain_count: 0,
+};
+
+
+test("mode switch shows pulse animation on badge", async ({ page }) => {
+  let currentMode = "work";
+
+  await page.route("**/app/permitato/api/mode", async (route) => {
+    const body = JSON.parse(route.request().postData());
+    currentMode = body.mode;
+    await route.fulfill({ status: 200, body: JSON.stringify({ mode: currentMode, mode_display: currentMode.charAt(0).toUpperCase() + currentMode.slice(1) }) });
+  });
+
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify({
+        ...WORK_STATUS,
+        mode: currentMode,
+        mode_display: currentMode.charAt(0).toUpperCase() + currentMode.slice(1),
+      }) });
+    },
+  });
+
+  // Switch to normal mode
+  await page.locator('.permitato-mode-btn[data-mode="normal"]').click();
+
+  // Badge should get the pulse animation class
+  await expect(page.locator("#permitatoModeValue")).toHaveClass(/mode-changed/, { timeout: 5000 });
+});
+
+
+test("active app persists across page reload", async ({ page }) => {
+  await page.route("**/status", async (route) => {
+    if (route.request().url().includes("/app/permitato/")) return route.fallback();
+    await route.fulfill({ status: 200, body: JSON.stringify(makeStatusPayload()) });
+  });
+  await page.route("**/app/permitato/api/status", async (route) => {
+    await route.fulfill({ status: 200, body: JSON.stringify(WORK_STATUS) });
+  });
+
+  await page.goto("/");
+  await page.waitForSelector('button[data-app="permitato"]', { timeout: 5000 });
+
+  // Switch to Permitato
+  await page.locator('button[data-app="permitato"]').click();
+  await page.waitForFunction(() => {
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
+  }, { timeout: 10000 });
+
+  // Verify Permitato is active
+  await expect(page.locator('button[data-app="permitato"]')).toHaveClass(/active/);
+
+  // Reload — should return to Permitato, not Chat
+  await page.reload();
+  await page.waitForFunction(() => {
+    const badge = document.getElementById("permitatoModeValue");
+    return badge && badge.textContent !== "--" && badge.textContent !== "";
+  }, { timeout: 10000 });
+
+  await expect(page.locator('button[data-app="permitato"]')).toHaveClass(/active/);
+});
+
+
+test("revoke button enters confirm state before firing DELETE", async ({ page }) => {
+  let deleteCount = 0;
+
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(WORK_STATUS) });
+    },
+  });
+
+  await page.route("**/app/permitato/api/exceptions/exc-1", async (route) => {
+    if (route.request().method() === "DELETE") {
+      deleteCount++;
+      await route.fulfill({ status: 200, body: JSON.stringify({ revoked: true }) });
+    } else {
+      await route.fallback();
+    }
+  });
+
+  // Open exceptions panel
+  await page.locator("#permitatoExceptionsToggle").click();
+  await expect(page.locator("#permitatoExceptionsList li")).toHaveCount(1);
+
+  const btn = page.locator(".exc-revoke-btn").first();
+
+  // First click — should show "Sure?" but NOT fire DELETE
+  await btn.click();
+  await expect(btn).toHaveText("Sure?");
+  await expect(btn).toHaveClass(/confirm-pending/);
+  expect(deleteCount).toBe(0);
+
+  // Second click — should fire DELETE
+  await btn.click();
+  expect(deleteCount).toBe(1);
+});
+
+
+test("confirm state reverts after timeout", async ({ page }) => {
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(WORK_STATUS) });
+    },
+  });
+
+  // Open exceptions panel
+  await page.locator("#permitatoExceptionsToggle").click();
+  await expect(page.locator("#permitatoExceptionsList li")).toHaveCount(1);
+
+  const btn = page.locator(".exc-revoke-btn").first();
+
+  // Click to enter confirm state
+  await btn.click();
+  await expect(btn).toHaveText("Sure?");
+
+  // Wait for timeout to revert (3s + buffer)
+  await expect(btn).toHaveText("Revoke", { timeout: 5000 });
+  await expect(btn).not.toHaveClass(/confirm-pending/);
+});

--- a/core/assets/shell.js
+++ b/core/assets/shell.js
@@ -468,6 +468,7 @@ import { registerPlatformShell } from "./platform-controls.js";
       if (titleEl) titleEl.textContent = entry.title;
 
       _activeAppId = appId;
+      try { localStorage.setItem("potato_active_app", appId); } catch { /* quota */ }
 
       // Show existing wrapper if app was already initialized
       if (_appWrappers[appId]) {
@@ -495,9 +496,15 @@ import { registerPlatformShell } from "./platform-controls.js";
     // Discover apps, then load the first available UI app, then start polling
     const appContainer = document.getElementById("appContainer");
     if (appContainer) {
-      _discoverApps().then(() => {
-        const defaultApp = Object.keys(_appRegistry)[0] || "chat";
-        return switchApp(defaultApp);
+      _discoverApps().then(async () => {
+        // Read saved app before any switchApp call (which overwrites localStorage).
+        const saved = localStorage.getItem("potato_active_app");
+        // Always init chat first — it binds shell controls (settings, model switcher).
+        const firstApp = Object.keys(_appRegistry)[0] || "chat";
+        await switchApp(firstApp);
+        if (saved && saved !== firstApp && _appRegistry[saved]) {
+          await switchApp(saved);
+        }
       }).then(() => startPollingLoop()).catch(() => startPollingLoop());
     } else {
       startPollingLoop();


### PR DESCRIPTION
## Summary

Closes #242

Three polish items from the #236 milestone review:

- **Mode switch pulse**: badge briefly scales up on mode change so it's not missed. `@keyframes mode-pulse` animation triggered by a `mode-changed` class, with a guard to skip initial page load.
- **App persistence**: active app saved to `localStorage` (`potato_active_app`) in `switchApp()`, restored on boot with validation that the saved app still exists in the registry. Reloading while on Permitato now returns to Permitato.
- **Delete confirmations**: `_confirmAction(btn, action)` utility — first click shows "Sure?" in red for 3s, second click fires the action, timeout reverts. Wired into exception revoke, schedule rule delete, and custom domain remove.

Two items from the ticket were already implemented (override indicator in status bar, chat history via IndexedDB) — no changes needed.

## Test evidence

```
pytest: 599 passed in 9.72s
playwright: 139 passed (34.3s)
```

4 new Playwright tests (`ui-polish.spec.js`):
- mode switch shows pulse animation
- active app persists across reload
- revoke enters confirm state before DELETE
- confirm state reverts after timeout

2 existing tests updated for confirm pattern:
- `exceptions-panel.spec.js` — revoke now needs two clicks
- `custom-list-panel.spec.js` — remove now needs two clicks

## Files changed

| File | Change |
|------|--------|
| `apps/permitato/assets/permitato.css` | Pulse keyframes, confirm-pending styling |
| `apps/permitato/assets/permitato.js` | Mode tracking, pulse trigger, `_confirmAction()`, 3 handler wires |
| `core/assets/shell.js` | localStorage save/restore of active app |
| `apps/permitato/tests/ui-polish.spec.js` | New — 4 smoke tests |
| `apps/permitato/tests/exceptions-panel.spec.js` | Updated for confirm pattern |
| `apps/permitato/tests/custom-list-panel.spec.js` | Updated for confirm pattern |