### PR TITLE
fix(permitato): don't close onboarding when client is invalid

### DIFF
--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -130,8 +130,12 @@ function _updateStatusBar(data) {
     _showOnboarding();
     return;
   }
-  if (data.client_id && _onboardingVisible && !_pendingClientSelection) {
+  if (data.client_id && data.client_valid !== false && _onboardingVisible && !_pendingClientSelection) {
     _hideOnboarding();
+  }
+  // Reconfigure: keep refreshing clients while overlay is open with invalid client
+  if (data.client_valid === false && _onboardingVisible && !_pendingClientSelection) {
+    _showOnboarding();
   }
 
   // Recovery: show banner when client is invalid

--- a/apps/permitato/tests/onboarding.spec.js
+++ b/apps/permitato/tests/onboarding.spec.js
@@ -159,6 +159,50 @@ test("reconfigure button opens onboarding overlay", async ({ page }) => {
   await expect(page.locator("#permitatoRecoveryBanner")).toBeVisible();
   await page.locator("#permitatoReconfigureBtn").click();
   await expect(page.locator("#permitatoOnboarding")).toBeVisible();
+
+  // Wait for a status poll to complete — overlay must survive it
+  await page.waitForResponse((resp) => resp.url().includes("/app/permitato/api/status") && resp.status() === 200);
+  await expect(page.locator("#permitatoOnboarding")).toBeVisible();
+});
+
+
+test("reconfigure overlay picks up newly discovered devices", async ({ page }) => {
+  let clientFetchCount = 0;
+  const UPDATED_CLIENTS = {
+    clients: [
+      ...FAKE_CLIENTS.clients,
+      { client: "192.168.1.50", name: "New device", id: 3, selected: false, is_requester: false },
+    ],
+    pihole_available: true,
+  };
+
+  await page.clock.install();
+
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(FAKE_PERMITATO_STATUS_INVALID_CLIENT) });
+    },
+    clientsRoute: async (route) => {
+      clientFetchCount++;
+      const data = clientFetchCount >= 2 ? UPDATED_CLIENTS : FAKE_CLIENTS;
+      await route.fulfill({ status: 200, body: JSON.stringify(data) });
+    },
+  });
+
+  await expect(page.locator("#permitatoRecoveryBanner")).toBeVisible();
+  await page.locator("#permitatoReconfigureBtn").click();
+  await expect(page.locator("#permitatoOnboarding")).toBeVisible();
+  await expect(page.locator("#permitatoClientList li")).toHaveCount(2);
+
+  // Advance past the 30-second client refresh throttle and wait for refresh
+  const clientRefresh = page.waitForResponse(
+    (resp) => resp.url().includes("/app/permitato/api/clients") && resp.status() === 200
+  );
+  await page.clock.fastForward(35000);
+  await clientRefresh;
+
+  await expect(page.locator("#permitatoClientList li")).toHaveCount(3);
+  await expect(page.locator("#permitatoClientList")).toContainText("New device");
 });
 
 


### PR DESCRIPTION
## Summary

- The hide-onboarding guard in `_updateStatusBar` checked `data.client_id` but not `data.client_valid`, so the 5-second status poll immediately closed the overlay after clicking Reconfigure
- Added `data.client_valid !== false` to the guard condition on line 133 of `permitato.js`

Closes #253
Refs #236

## Test plan

- [x] Updated Playwright test verifies overlay survives a status poll cycle with `client_valid: false`
- [x] Existing "selecting a client hides onboarding" test still passes (valid client still dismisses overlay)
- [x] Full suite green: 599 pytest + 139 Playwright

```
599 passed in 9.97s
139 passed (33.6s)
```