### PR TITLE
fix(permitato): constrain chat messages to scroll container

### DIFF
--- a/apps/permitato/assets/permitato.css
+++ b/apps/permitato/assets/permitato.css
@@ -726,6 +726,7 @@
 /* Messages */
 .permitato-messages {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 16px;
   display: flex;

--- a/apps/permitato/assets/permitato.js
+++ b/apps/permitato/assets/permitato.js
@@ -222,6 +222,7 @@ async function _onSubmit(e) {
   _requestInFlight = true;
 
   const assistantEl = _appendMessage("assistant", "");
+  const messagesContainer = document.getElementById("permitatoMessages");
 
   try {
     const resp = await fetch(`${PERMITATO_API}/chat`, {
@@ -267,6 +268,7 @@ async function _onSubmit(e) {
           if (parsed.error) {
             const msg = parsed.error.message || parsed.error.detail || "LLM unavailable";
             assistantEl.textContent = msg;
+            if (messagesContainer) messagesContainer.scrollTop = messagesContainer.scrollHeight;
             accumulated = msg;
             continue;
           }
@@ -275,6 +277,7 @@ async function _onSubmit(e) {
           if (delta) {
             accumulated += delta;
             assistantEl.textContent = accumulated.replace(/\[ACTION:[^\]]*\]/g, "").trim();
+            if (messagesContainer) messagesContainer.scrollTop = messagesContainer.scrollHeight;
           }
         } catch {
           // incomplete JSON — will be completed in next chunk
@@ -284,6 +287,7 @@ async function _onSubmit(e) {
 
     const cleanText = accumulated.replace(/\[ACTION:[^\]]*\]/g, "").trim();
     assistantEl.textContent = cleanText;
+    if (messagesContainer) messagesContainer.scrollTop = messagesContainer.scrollHeight;
     _history.push({ role: "assistant", content: cleanText });
     _saveSession();
 

--- a/apps/permitato/tests/ui-polish.spec.js
+++ b/apps/permitato/tests/ui-polish.spec.js
@@ -137,6 +137,40 @@ test("revoke button enters confirm state before firing DELETE", async ({ page })
 });
 
 
+test("status bar stays visible after long chat response", async ({ page }) => {
+  // Build an SSE response with enough text to overflow the messages area
+  const longText = "This is a detailed response about your request. ".repeat(40);
+  const chunks = longText.match(/.{1,60}/g);
+  const sseBody = chunks.map(c =>
+    `data: ${JSON.stringify({ choices: [{ delta: { content: c } }] })}`
+  ).join("\n") + "\ndata: [DONE]\n";
+
+  await page.route("**/app/permitato/api/chat", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+      body: sseBody,
+    });
+  });
+
+  await openPermitato(page, {
+    permitatoStatusRoute: async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify(WORK_STATUS) });
+    },
+  });
+
+  // Send a message
+  await page.locator("#permitatoPrompt").fill("Tell me something long");
+  await page.locator("#permitatoSendBtn").click();
+
+  // Wait for the assistant response to render
+  await expect(page.locator(".permitato-msg.assistant").last()).toContainText("detailed response", { timeout: 5000 });
+
+  // Status bar must remain in viewport — not scrolled off the page
+  await expect(page.locator("#permitatoStatusBar")).toBeInViewport();
+});
+
+
 test("confirm state reverts after timeout", async ({ page }) => {
   await openPermitato(page, {
     permitatoStatusRoute: async (route) => {

--- a/core/assets/shell.css
+++ b/core/assets/shell.css
@@ -61,7 +61,7 @@
     }
 
     .app-shell {
-      min-height: 100%;
+      height: 100%;
       display: grid;
       grid-template-columns: auto 340px minmax(0, 1fr);
     }
@@ -453,6 +453,12 @@
       border-radius: 999px;
       border: 1px solid rgba(255, 255, 255, 0.06);
       pointer-events: none;
+    }
+
+    #appContainer {
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
     }
 
     .chat-shell {


### PR DESCRIPTION
## Summary

- `#appContainer` had no CSS rules, so `.permitato-messages { flex: 1 }` had no flex parent — the container grew unbounded, scrolling the entire page (sidebar + status bar out of view)
- Added flex column layout to `#appContainer` in `shell.css` and `min-height: 0` to `.permitato-messages` so it shrinks and scrolls internally
- Added scroll-to-bottom during SSE streaming — previously only fired once on message create, not during content updates

Closes #254
Refs #236

## Test plan

- [x] New Playwright test: status bar stays in viewport after long streaming response
- [x] Chat app Playwright suite passes (regression check for `#appContainer` change)
- [x] Full suite green: 599 pytest + 141 Playwright

```
599 passed in 9.82s
141 passed (33.3s)
```