### PR TITLE
fix(ui): show active runtime family in status badge

### DIFF
--- a/core/assets/status.js
+++ b/core/assets/status.js
@@ -34,6 +34,8 @@ import { formatBytes, formatCountdownSeconds } from "./utils.js";
       const isHealthy = isLocalModelConnected(statusPayload) || (backendMode === "fake" && isReady);
       const isLoading = backendMode === "llama" && hasModel && !llamaHealthy && statusState === "BOOTING";
       const isFailed = backendMode === "llama" && statusState === "ERROR";
+      const runtimeFamily = statusPayload?.llama_runtime?.current?.family;
+      const runtimeLabel = runtimeFamily === "llama_cpp" ? "llama.cpp" : (runtimeFamily || "llama.cpp");
       badge.classList.remove("online", "loading", "failed", "offline");
       dot.classList.remove("online", "loading", "failed", "offline");
       dot.hidden = false;
@@ -49,7 +51,7 @@ import { formatBytes, formatCountdownSeconds } from "./utils.js";
       } else if (isHealthy) {
         badge.classList.add("online");
         dot.classList.add("online");
-        label.textContent = `CONNECTED:llama.cpp${modelSuffix}`;
+        label.textContent = `CONNECTED:${runtimeLabel}${modelSuffix}`;
       } else if (isLoading) {
         badge.classList.add("loading");
         dot.classList.add("loading");
@@ -61,15 +63,15 @@ import { formatBytes, formatCountdownSeconds } from "./utils.js";
           spinner.style.setProperty("--load-pct", loadPct);
         }
         const pctSuffix = typeof loadPct === "number" ? `:${loadPct}%` : modelSuffix;
-        label.textContent = `LOADING:llama.cpp${pctSuffix}`;
+        label.textContent = `LOADING:${runtimeLabel}${pctSuffix}`;
       } else if (isFailed) {
         badge.classList.add("failed");
         dot.classList.add("failed");
-        label.textContent = `FAILED:llama.cpp${modelSuffix}`;
+        label.textContent = `FAILED:${runtimeLabel}${modelSuffix}`;
       } else {
         badge.classList.add("offline");
         dot.classList.add("offline");
-        label.textContent = "DISCONNECTED:llama.cpp";
+        label.textContent = `DISCONNECTED:${runtimeLabel}`;
       }
     }
 

--- a/tests/ui/runtime.spec.js
+++ b/tests/ui/runtime.spec.js
@@ -157,6 +157,7 @@ test("llama booting with model present shows loading badge", async ({ page }) =>
         model: { filename: "Qwen3.5-2B-Q4_K_M.gguf" },
         llama_server: { healthy: false, running: false, url: "http://127.0.0.1:8080" },
         backend: { mode: "llama", active: "llama", fallback_active: false },
+        llama_runtime: { current: { family: "ik_llama" } },
         download: {
           bytes_total: 2497282336,
           bytes_downloaded: 2497282336,
@@ -174,7 +175,7 @@ test("llama booting with model present shows loading badge", async ({ page }) =>
 
   await page.goto("/");
   await waitForStatusApplied(page);
-  await expect(page.locator("#statusLabel")).toHaveText("LOADING:llama.cpp:Qwen3.5-2B-Q4_K_M.gguf");
+  await expect(page.locator("#statusLabel")).toHaveText("LOADING:ik_llama:Qwen3.5-2B-Q4_K_M.gguf");
   await expect(page.locator("#statusBadge")).toHaveClass(/loading/);
 });
 
@@ -189,6 +190,7 @@ test("llama error state shows failed badge", async ({ page }) => {
         model: { filename: "Qwen3.5-2B-Q4_K_M.gguf" },
         llama_server: { healthy: false, running: false, url: "http://127.0.0.1:8080" },
         backend: { mode: "llama", active: "llama", fallback_active: false },
+        llama_runtime: { current: { family: "ik_llama" } },
         download: {
           bytes_total: 2497282336,
           bytes_downloaded: 2497282336,
@@ -206,8 +208,74 @@ test("llama error state shows failed badge", async ({ page }) => {
 
   await page.goto("/");
   await waitForStatusApplied(page);
-  await expect(page.locator("#statusLabel")).toHaveText("FAILED:llama.cpp:Qwen3.5-2B-Q4_K_M.gguf");
+  await expect(page.locator("#statusLabel")).toHaveText("FAILED:ik_llama:Qwen3.5-2B-Q4_K_M.gguf");
   await expect(page.locator("#statusBadge")).toHaveClass(/failed/);
+});
+
+test("status badge shows ik_llama runtime family when connected", async ({ page }) => {
+  await page.route("**/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(makeStatusPayload()),
+    });
+  });
+  await page.goto("/");
+  await waitForStatusApplied(page);
+  await expect(page.locator("#statusLabel")).toHaveText(/CONNECTED:ik_llama/);
+});
+
+test("status badge shows llama.cpp when llama_cpp runtime family is active", async ({ page }) => {
+  await page.route("**/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(makeStatusPayload({
+        llama_runtime: {
+          current: { family: "llama_cpp", llama_cpp_commit: "def67890", profile: "universal", has_server_binary: true },
+          available_runtimes: [
+            { family: "ik_llama", commit: "abc12345", is_active: false, compatible: true },
+            { family: "llama_cpp", commit: "def67890", is_active: true, compatible: true },
+          ],
+          switch: { active: false, target_family: null, error: null },
+          memory_loading: { mode: "auto", label: "Automatic", no_mmap_env: "0" },
+          large_model_override: { enabled: false },
+        },
+      })),
+    });
+  });
+  await page.goto("/");
+  await waitForStatusApplied(page);
+  await expect(page.locator("#statusLabel")).toHaveText(/CONNECTED:llama\.cpp/);
+});
+
+test("status badge updates runtime family after runtime switch", async ({ page }) => {
+  let currentFamily = "ik_llama";
+  await page.route("**/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(makeStatusPayload({
+        llama_runtime: {
+          current: { family: currentFamily, llama_cpp_commit: "abc12345", profile: "pi5-opt", has_server_binary: true },
+          available_runtimes: [
+            { family: "ik_llama", commit: "abc12345", is_active: currentFamily === "ik_llama", compatible: true },
+            { family: "llama_cpp", commit: "def67890", is_active: currentFamily === "llama_cpp", compatible: true },
+          ],
+          switch: { active: false, target_family: null, error: null },
+          memory_loading: { mode: "auto", label: "Automatic", no_mmap_env: "0" },
+          large_model_override: { enabled: false },
+        },
+      })),
+    });
+  });
+  await page.goto("/");
+  await waitForStatusApplied(page);
+  await expect(page.locator("#statusLabel")).toHaveText(/CONNECTED:ik_llama/);
+
+  currentFamily = "llama_cpp";
+  await page.waitForTimeout(2500);
+  await expect(page.locator("#statusLabel")).toHaveText(/CONNECTED:llama\.cpp/);
 });
 
 test("mobile hamburger controls sidebar drawer and keeps composer actions aligned", async ({ page }) => {
@@ -791,7 +859,7 @@ test("composer chip shows determinate loading progress when model_loading is act
   await page.goto("/");
   await waitForStatusApplied(page);
   // Badge shows loading state with progress ring and percentage
-  await expect(page.locator("#statusLabel")).toHaveText("LOADING:llama.cpp:67%");
+  await expect(page.locator("#statusLabel")).toHaveText("LOADING:ik_llama:67%");
   await expect(page.locator("#statusBadge")).toHaveClass(/loading/);
   await expect(page.locator("#statusSpinner")).toBeVisible();
   await expect(page.locator("#statusSpinner")).toHaveClass(/has-progress/);


### PR DESCRIPTION
## Summary

- Read `llama_runtime.current.family` from the status payload instead of hardcoding `llama.cpp` in the top-right badge label
- Maps `llama_cpp` → `llama.cpp` (project name) and passes `ik_llama` through unchanged
- Falls back to `llama.cpp` when the payload has no runtime info (pre-first-poll, disconnected)

Closes #259

## Changes

| File | What |
|------|------|
| `core/assets/status.js` | Replace 4 hardcoded `llama.cpp` strings with runtime family from payload |
| `tests/ui/runtime.spec.js` | Update 3 existing assertions + add 3 new tests |

## Test evidence

```
599 passed in 10.13s (pytest)
144 passed (33.2s) (playwright)
```

New Playwright tests:
- `status badge shows ik_llama runtime family when connected`
- `status badge shows llama.cpp when llama_cpp runtime family is active`
- `status badge updates runtime family after runtime switch`

## Test plan

- [x] All 599 pytest tests pass
- [x] All 144 Playwright tests pass (including 3 new)
- [ ] Pi QA: verify badge shows correct runtime on real device