### PR TITLE
fix(runtime): support ByteShape Qwen3.5-9B projector selection

### DIFF
--- a/bin/start_llama.sh
+++ b/bin/start_llama.sh
@@ -182,41 +182,56 @@ resolve_mmproj_repo() {
     return 0
   fi
 
-  if [[ "${model_name}" == *qwen*3.5*2b* ]]; then
+  if [[ "${model_name}" == *qwen*3.5*-2b[-_.]* ]]; then
     printf 'unsloth/Qwen3.5-2B-GGUF'
     return 0
   fi
-  if [[ "${model_name}" == *qwen*3.5*4b* ]]; then
+  if [[ "${model_name}" == *qwen*3.5*-4b[-_.]* ]]; then
     printf 'unsloth/Qwen3.5-4B-GGUF'
     return 0
   fi
+  if [[ "${model_name}" == *qwen*3.5*-9b[-_.]* ]]; then
+    printf 'unsloth/Qwen3.5-9B-GGUF'
+    return 0
+  fi
 
-  # Default fallback for unrecognized vision models
-  printf 'unsloth/Qwen3.5-2B-GGUF'
+  # No fallback — unrecognized sizes must not silently get a wrong projector (#258)
+  return 1
 }
 
-qwen35_mmproj_name_candidates() {
+_mmproj_candidates_for_precision() {
+  local precision="${1}" generic="${2:-}"
   local model_stem trimmed_stem next_stem
   model_stem="$(basename "${MODEL_PATH}")"
   model_stem="${model_stem%.gguf}"
   trimmed_stem="${model_stem}"
 
-  printf 'mmproj-%s-f16.gguf\n' "${model_stem}"
+  printf 'mmproj-%s-%s.gguf\n' "${model_stem}" "${precision}"
   while true; do
     next_stem="$(printf '%s\n' "${trimmed_stem}" | sed -E 's/-(I?Q[0-9]+(_[A-Za-z0-9]+)*|[0-9]+(\.[0-9]+)?bpw)$//I')"
     if [ -z "${next_stem}" ] || [ "${next_stem}" = "${trimmed_stem}" ]; then
       break
     fi
     trimmed_stem="${next_stem}"
-    printf 'mmproj-%s-f16.gguf\n' "${trimmed_stem}"
+    printf 'mmproj-%s-%s.gguf\n' "${trimmed_stem}" "${precision}"
   done
 
+  [ -n "${generic}" ] && printf '%s\n' "${generic}"
+}
+
+qwen35_mmproj_name_candidates() {
+  # Model-specific candidates first (f16 preferred, bf16 fallback),
+  # then generic F16 last. This ensures a downloaded model-specific
+  # bf16 projector is found before a stale generic F16.
+  _mmproj_candidates_for_precision f16
+  _mmproj_candidates_for_precision bf16
   printf '%s\n' "mmproj-F16.gguf"
 }
 
 mmproj_filename_candidates() {
   if model_is_qwen35_vision; then
     printf '%s\n' "mmproj-F16.gguf"
+    printf '%s\n' "mmproj-bf16.gguf"
   fi
 }
 
@@ -231,28 +246,37 @@ download_mmproj() {
   local tmp
   local candidate
   model_dir="$(dirname "${MODEL_PATH}")"
-  repo="$(resolve_mmproj_repo)"
+  repo="$(resolve_mmproj_repo || true)"
+  if [ -z "${repo}" ]; then
+    return 1
+  fi
 
   if ! command -v curl >/dev/null 2>&1; then
     return 1
   fi
 
-  # Determine preferred model-specific local name (last entry before generic).
+  # Determine preferred model-specific local names (last entry before each generic).
   preferred_local=""
+  preferred_local_bf16=""
   while read -r candidate; do
     [ -n "${candidate}" ] || continue
     [ "${candidate}" = "mmproj-F16.gguf" ] && break
     preferred_local="${candidate}"
-  done < <(qwen35_mmproj_name_candidates)
+  done < <(_mmproj_candidates_for_precision f16 mmproj-F16.gguf)
+  if [ -n "${preferred_local}" ]; then
+    preferred_local_bf16="${preferred_local%-f16.gguf}-bf16.gguf"
+  fi
 
   while read -r candidate; do
     [ -n "${candidate}" ] || continue
     url="https://huggingface.co/${repo}/resolve/main/${candidate}?download=true"
     remote_name="$(basename "${url%%\?*}")"
-    # When downloading the generic file, save with model-specific name
+    # When downloading a generic file, save with model-specific name
     # to prevent stale reuse across model switches (#136).
     if [ "${remote_name}" = "mmproj-F16.gguf" ] && [ -n "${preferred_local}" ]; then
       local_name="${preferred_local}"
+    elif [ "${remote_name}" = "mmproj-bf16.gguf" ] && [ -n "${preferred_local_bf16}" ]; then
+      local_name="${preferred_local_bf16}"
     else
       local_name="${remote_name}"
     fi
@@ -261,9 +285,10 @@ download_mmproj() {
     rm -f "${tmp}"
     if ionice -c3 nice -n 19 curl --fail --location --continue-at - --output "${tmp}" "${url}"; then
       mv -f "${tmp}" "${target}"
-      # Clean up stale generic after saving model-specific file.
-      if [ "${local_name}" != "mmproj-F16.gguf" ]; then
+      # Clean up stale generics after saving model-specific file.
+      if [ "${local_name}" != "mmproj-F16.gguf" ] && [ "${local_name}" != "mmproj-bf16.gguf" ]; then
         rm -f "${model_dir}/mmproj-F16.gguf"
+        rm -f "${model_dir}/mmproj-bf16.gguf"
       fi
       MMPROJ_PATH="${target}"
       return 0
@@ -317,10 +342,11 @@ pick_mmproj() {
   fi
 
   if model_is_qwen35_vision; then
-    # 1. Try exact model-specific match (skip generic — handled below).
+    # 1. Try exact model-specific match (skip generics — handled below).
     while read -r candidate_base; do
       [ -n "${candidate_base}" ] || continue
       [ "${candidate_base}" = "mmproj-F16.gguf" ] && continue
+      [ "${candidate_base}" = "mmproj-bf16.gguf" ] && continue
       for candidate in "${mmproj_candidates[@]}"; do
         if [ "$(basename "${candidate}")" = "${candidate_base}" ]; then
           MMPROJ_PATH="${candidate}"
@@ -338,6 +364,8 @@ pick_mmproj() {
     # 3. Offline fallback: accept only generic mmproj-F16.gguf.
     #    Do NOT accept other models' specific projectors — they have
     #    different embedding dimensions and would crash llama-server (#136).
+    #    Generic mmproj-bf16.gguf is also excluded: it's ByteShape-specific
+    #    and could be stale from a different model size.
     for candidate in "${mmproj_candidates[@]}"; do
       candidate_base="$(basename "${candidate}" | tr '[:upper:]' '[:lower:]')"
       if [[ "${candidate_base}" == mmproj-f16.gguf ]]; then

--- a/core/constants/model_families.py
+++ b/core/constants/model_families.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import re
 from typing import Final
 
 QWEN35_PROJECTOR_REPO_RULES: Final[tuple[tuple[tuple[str, ...], str], ...]] = (
     (("35b", "a3b", "hauhaucs"), "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive"),
     (("35b", "a3b"), "AesSedai/Qwen3.5-35B-A3B-GGUF"),
+    (("9b", "byteshape"), "byteshape/Qwen3.5-9B-GGUF"),
+    (("9b",), "unsloth/Qwen3.5-9B-GGUF"),
     (("4b", "hauhaucs"), "HauhauCS/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive"),
     (("4b",), "unsloth/Qwen3.5-4B-GGUF"),
     (("2b",), "unsloth/Qwen3.5-2B-GGUF"),
@@ -21,16 +24,31 @@ def is_qwen35_filename(filename: str | None) -> bool:
     return bool(model_name) and "qwen" in model_name and "3.5" in model_name
 
 
-def _qwen35_projector_repo(filename: str | None) -> str | None:
+def _token_at_boundary(token: str, text: str) -> bool:
+    """Match token only when surrounded by non-alphanumeric boundaries.
+
+    Prevents substring collisions like '9b' matching inside '19b'
+    or '2b' matching inside '3.92bpw'.
+    """
+    return bool(re.search(r"(?<![a-z0-9])" + re.escape(token) + r"(?![a-z0-9])", text))
+
+
+def _qwen35_projector_repo(filename: str | None, source_url: str | None = None) -> str | None:
     model_name = _normalized_model_name(filename)
     if not is_qwen35_filename(model_name):
         return None
 
+    # Match tokens against filename + source URL so publisher-specific rules
+    # fire even when the filename itself doesn't contain the publisher name.
+    match_text = model_name
+    if source_url:
+        match_text = _normalized_model_name(source_url) + " " + match_text
+
     for required_tokens, repo in QWEN35_PROJECTOR_REPO_RULES:
-        if all(token in model_name for token in required_tokens):
+        if all(_token_at_boundary(token, match_text) for token in required_tokens):
             return repo
     return None
 
 
-def projector_repo_for_model(filename: str | None) -> str | None:
-    return _qwen35_projector_repo(filename)
+def projector_repo_for_model(filename: str | None, source_url: str | None = None) -> str | None:
+    return _qwen35_projector_repo(filename, source_url=source_url)

--- a/core/main.py
+++ b/core/main.py
@@ -877,7 +877,7 @@ def _runtime_env(runtime: RuntimeConfig) -> dict[str, str]:
         active_settings = normalize_model_settings(active_model.get("settings"), filename=active_filename)
         vision_settings = active_settings.get("vision", {})
         if model_supports_vision_filename(active_filename) and bool(vision_settings.get("enabled", False)):
-            mmproj_repo = projector_repo_for_model(active_filename)
+            mmproj_repo = projector_repo_for_model(active_filename, source_url=active_model.get("source_url"))
             if mmproj_repo:
                 env["POTATO_AUTO_DOWNLOAD_MMPROJ"] = "1"
                 env["POTATO_HF_MMPROJ_REPO"] = mmproj_repo

--- a/core/model_state.py
+++ b/core/model_state.py
@@ -679,10 +679,14 @@ def default_projector_candidates_for_model(filename: str | None) -> list[str]:
                 stem_candidates.append(trimmed_stem)
 
         candidates: list[str] = []
-        for candidate_stem in stem_candidates:
-            candidate_name = f"mmproj-{candidate_stem}-f16.gguf"
-            if candidate_name not in candidates:
-                candidates.append(candidate_name)
+        # Model-specific candidates first (f16 preferred, bf16 fallback),
+        # then generic F16 last. This ensures a downloaded model-specific
+        # bf16 projector is found before a stale generic F16.
+        for precision in ("f16", "bf16"):
+            for candidate_stem in stem_candidates:
+                candidate_name = f"mmproj-{candidate_stem}-{precision}.gguf"
+                if candidate_name not in candidates:
+                    candidates.append(candidate_name)
         if "mmproj-F16.gguf" not in candidates:
             candidates.append("mmproj-F16.gguf")
         return candidates
@@ -705,7 +709,7 @@ def download_default_projector_for_model(*, runtime: RuntimeConfig, model_id: st
     filename = str(model.get("filename") or "")
     if not model_supports_vision_filename(filename):
         return False, "vision_not_supported", None
-    repo = projector_repo_for_model(filename)
+    repo = projector_repo_for_model(filename, source_url=model.get("source_url"))
     candidates = default_projector_candidates_for_model(filename)
     if not repo or not candidates:
         return False, "projector_repo_unknown", None
@@ -713,30 +717,42 @@ def download_default_projector_for_model(*, runtime: RuntimeConfig, model_id: st
     models_dir = runtime.base_dir / "models"
     models_dir.mkdir(parents=True, exist_ok=True)
 
-    # Determine preferred model-specific local name (last candidate before generic).
+    # Determine preferred model-specific local names (last candidate before each generic).
     # E.g. for Qwen3.5-2B-Q4_K_M.gguf → "mmproj-Qwen3.5-2B-f16.gguf"
+    _generics = {"mmproj-F16.gguf", "mmproj-bf16.gguf"}
     preferred_local: str | None = None
     for c in candidates:
         if c == "mmproj-F16.gguf":
             break
         preferred_local = c
+    preferred_local_bf16: str | None = None
+    if preferred_local:
+        preferred_local_bf16 = preferred_local.replace("-f16.gguf", "-bf16.gguf")
 
-    # Check for existing model-specific files first (skip stale generic).
+    # Check for existing model-specific files first (skip stale generics).
     for candidate in candidates:
-        if candidate == "mmproj-F16.gguf" and preferred_local:
+        if candidate in _generics and preferred_local:
             continue
         target_path = models_dir / candidate
         if target_path.exists():
             return True, "downloaded", candidate
 
+    # Download targets include generic bf16 for repos that only ship it
+    # (e.g. ByteShape), even though it's excluded from local discovery.
+    download_targets = list(candidates)
+    if "mmproj-bf16.gguf" not in download_targets:
+        download_targets.append("mmproj-bf16.gguf")
+
     client = httpx.Client(follow_redirects=True, timeout=120.0)
     try:
-        for candidate in candidates:
+        for candidate in download_targets:
             url = f"https://huggingface.co/{repo}/resolve/main/{candidate}"
-            # When downloading the generic file, save with model-specific name
+            # When downloading a generic file, save with model-specific name
             # to prevent stale reuse across model switches (#136).
             if candidate == "mmproj-F16.gguf" and preferred_local:
                 local_name = preferred_local
+            elif candidate == "mmproj-bf16.gguf" and preferred_local_bf16:
+                local_name = preferred_local_bf16
             else:
                 local_name = candidate
             target_path = models_dir / local_name
@@ -751,9 +767,10 @@ def download_default_projector_for_model(*, runtime: RuntimeConfig, model_id: st
                             if chunk:
                                 handle.write(chunk)
                 part_path.replace(target_path)
-                # Clean up stale generic after saving model-specific file.
-                if local_name != "mmproj-F16.gguf":
-                    (models_dir / "mmproj-F16.gguf").unlink(missing_ok=True)
+                # Clean up stale generics after saving model-specific file.
+                if local_name not in _generics:
+                    for g in _generics:
+                        (models_dir / g).unlink(missing_ok=True)
                 return True, "downloaded", local_name
             except Exception:
                 part_path.unlink(missing_ok=True)

--- a/tests/unit/test_model_families.py
+++ b/tests/unit/test_model_families.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pytest
+
+from core.constants.model_families import projector_repo_for_model
+
+
+def test_projector_repo_for_qwen35_9b():
+    """Qwen3.5-9B generic model resolves to unsloth 9B projector repo."""
+    assert projector_repo_for_model("Qwen3.5-9B-Q4_K_S-3.92bpw.gguf") == "unsloth/Qwen3.5-9B-GGUF"
+
+
+def test_projector_repo_for_qwen35_9b_byteshape_by_filename():
+    """ByteShape in filename resolves to ByteShape repo."""
+    assert projector_repo_for_model("byteshape-Qwen3.5-9B-Q4_K_S.gguf") == "byteshape/Qwen3.5-9B-GGUF"
+
+
+def test_projector_repo_for_qwen35_9b_byteshape_by_source_url():
+    """ByteShape in source_url resolves to ByteShape repo even when filename
+    has no publisher prefix — this is the real HuggingFace scenario."""
+    assert projector_repo_for_model(
+        "Qwen3.5-9B-Q4_K_S-3.92bpw.gguf",
+        source_url="https://huggingface.co/byteshape/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_S-3.92bpw.gguf",
+    ) == "byteshape/Qwen3.5-9B-GGUF"
+
+
+def test_projector_repo_for_qwen35_9b_without_source_url():
+    """Generic 9B without source_url falls back to unsloth."""
+    assert projector_repo_for_model("Qwen3.5-9B-Q4_K_S-3.92bpw.gguf") == "unsloth/Qwen3.5-9B-GGUF"
+
+
+def test_projector_repo_returns_none_for_unknown_qwen35_size():
+    """Unrecognized Qwen3.5 sizes must return None, not silently fall back."""
+    assert projector_repo_for_model("Qwen3.5-7B-Q4_K_M.gguf") is None
+
+
+def test_projector_repo_no_substring_collision_19b():
+    """19B must NOT match the 9B rule — '9b' is a substring of '19b'."""
+    assert projector_repo_for_model("Qwen3.5-Creative-19B-A3B-REAP.Q4_K_S.gguf") is None
+
+
+def test_projector_repo_no_substring_collision_bpw():
+    """3.92bpw must NOT match the 2B rule — '2b' is a substring of '3.92bpw'."""
+    result = projector_repo_for_model("Qwen3.5-9B-Q4_K_S-3.92bpw.gguf")
+    assert result == "unsloth/Qwen3.5-9B-GGUF", f"got {result!r} (2B collision via '3.92bpw')"
+
+
+def test_projector_repo_dot_delimited_9b():
+    """Dot-delimited filenames like Qwen3.5-9B.gguf must still match."""
+    assert projector_repo_for_model("Qwen3.5-9B.gguf") == "unsloth/Qwen3.5-9B-GGUF"
+    assert projector_repo_for_model("Qwen3.5-9B.Q4_K_S.gguf") == "unsloth/Qwen3.5-9B-GGUF"
+
+
+def test_projector_repo_dot_delimited_4b():
+    """Dot-delimited filenames like Qwen3.5-4B.Q4_K_M.gguf must still match."""
+    assert projector_repo_for_model("Qwen3.5-4B.Q4_K_M.gguf") == "unsloth/Qwen3.5-4B-GGUF"
+
+
+def test_default_candidates_include_model_specific_bf16_but_not_generic():
+    """default_projector_candidates_for_model must include model-specific bf16
+    names but NOT generic mmproj-bf16.gguf (unsafe cross-model reuse)."""
+    from core.model_state import default_projector_candidates_for_model
+
+    candidates = default_projector_candidates_for_model("Qwen3.5-9B-Q4_K_S.gguf")
+    assert "mmproj-F16.gguf" in candidates
+    assert "mmproj-Qwen3.5-9B-f16.gguf" in candidates
+    assert "mmproj-Qwen3.5-9B-bf16.gguf" in candidates
+    # Generic bf16 must NOT be in the list — it's unsafe for cross-model reuse
+    assert "mmproj-bf16.gguf" not in candidates
+
+
+def test_projector_status_finds_model_specific_bf16_on_disk(runtime):
+    """build_model_projector_status must detect a model-specific bf16 projector."""
+    from core.model_state import build_model_projector_status
+
+    models_dir = runtime.base_dir / "models"
+    (models_dir / "mmproj-Qwen3.5-9B-bf16.gguf").write_bytes(b"bf16-projector")
+
+    model = {
+        "filename": "Qwen3.5-9B-Q4_K_S.gguf",
+        "settings": {
+            "vision": {"enabled": True, "projector_mode": "default", "projector_filename": None},
+        },
+    }
+    status = build_model_projector_status(runtime, model)
+    assert status["present"] is True
+    assert "bf16" in status["filename"]
+
+
+def test_projector_status_ignores_stale_generic_bf16_for_wrong_model(runtime):
+    """A generic mmproj-bf16.gguf left over from a 9B download must NOT be
+    reported as present for a 4B model — wrong dimensions would crash. #136."""
+    from core.model_state import build_model_projector_status
+
+    models_dir = runtime.base_dir / "models"
+    (models_dir / "mmproj-bf16.gguf").write_bytes(b"stale-9b-bf16")
+
+    model = {
+        "filename": "Qwen3.5-4B-Q4_K_M.gguf",
+        "settings": {
+            "vision": {"enabled": True, "projector_mode": "default", "projector_filename": None},
+        },
+    }
+    status = build_model_projector_status(runtime, model)
+    assert status["present"] is False, (
+        "Generic mmproj-bf16.gguf must not be accepted for a different model size"
+    )
+
+
+@pytest.mark.parametrize(
+    "filename, expected_repo",
+    [
+        ("Qwen3.5-2B-Q4_K_M.gguf", "unsloth/Qwen3.5-2B-GGUF"),
+        ("Qwen3.5-4B-Q4_K_M.gguf", "unsloth/Qwen3.5-4B-GGUF"),
+        ("Qwen3.5-0.8B-Q4_K_M.gguf", "unsloth/Qwen3.5-0.8B-GGUF"),
+        ("Qwen3.5-35B-A3B-Q2_K_L.gguf", "AesSedai/Qwen3.5-35B-A3B-GGUF"),
+    ],
+)
+def test_projector_repo_existing_sizes_unchanged(filename: str, expected_repo: str):
+    """Existing size mappings must not regress."""
+    assert projector_repo_for_model(filename) == expected_repo

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -1139,6 +1139,55 @@ printf '%s\\n' "$@" > "$ARGS_OUT"
     assert str(generic_mmproj) in args
 
 
+def test_resolve_mmproj_repo_does_not_fallback_to_2b_for_unknown_qwen35():
+    """resolve_mmproj_repo must NOT return any repo for unrecognized Qwen3.5
+    sizes (e.g. 7B). Uses 7B to avoid token collisions. Regression test for #258."""
+    script_path = str(REPO_ROOT / "bin" / "start_llama.sh")
+    wrapper = r"""#!/usr/bin/env bash
+set -uo pipefail
+MODEL_PATH="/tmp/Qwen3.5-7B-Q4_K_M.gguf"
+HF_MMPROJ_REPO=""
+model_filename_lower() { basename "${MODEL_PATH}" | tr '[:upper:]' '[:lower:]'; }
+eval "$(sed -n '/^resolve_mmproj_repo()/,/^}/p' '__SCRIPT__')"
+output="$(resolve_mmproj_repo)" && rc=0 || rc=$?
+printf '%s' "$output"
+""".replace("__SCRIPT__", script_path)
+    result = subprocess.run(
+        ["bash", "-c", wrapper],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.stdout.strip() == "", (
+        f"resolve_mmproj_repo must not return any repo for unknown sizes: got {result.stdout!r}"
+    )
+
+
+def test_mmproj_filename_candidates_includes_bf16():
+    """mmproj_filename_candidates must include mmproj-bf16.gguf as a fallback
+    for repos that only ship BF16 projectors (e.g. ByteShape). #258."""
+    script_path = str(REPO_ROOT / "bin" / "start_llama.sh")
+    wrapper = r"""#!/usr/bin/env bash
+set -uo pipefail
+MODEL_PATH="/tmp/Qwen3.5-9B-Q4_K_S.gguf"
+model_is_qwen35_vision() { return 0; }
+eval "$(sed -n '/^mmproj_filename_candidates()/,/^}/p' '__SCRIPT__')"
+mmproj_filename_candidates
+""".replace("__SCRIPT__", script_path)
+    result = subprocess.run(
+        ["bash", "-c", wrapper],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    candidates = result.stdout.strip().splitlines()
+    assert "mmproj-F16.gguf" in candidates, "F16 must be listed first"
+    assert "mmproj-bf16.gguf" in candidates, "bf16 must be listed as fallback"
+    assert candidates.index("mmproj-F16.gguf") < candidates.index("mmproj-bf16.gguf"), (
+        "F16 must come before bf16"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pi-hole installation section in install_dev.sh (#212)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route ByteShape Qwen3.5-9B projector downloads to the correct 9B repo instead of falling back to the incompatible 2B path
- keep projector reuse safe across model switches by preferring model-specific files and excluding stale generic bf16 fallbacks
- preserve generic F16 as the offline compatibility path while allowing bf16 downloads when a repo only ships that projector

## Risk / Rollback
- touches Qwen3.5 projector resolution and runtime launch behavior only
- rollback is a normal revert of this PR if projector startup regresses

## Tests
- `uv run python -m pytest tests/unit/test_shell_scripts.py tests/api/test_projector_download.py tests/api/test_runtime_env.py tests/unit/test_model_families.py -q`
  - `71 passed in 9.10s`
- manual spot checks:
  - unsupported `Qwen3.5-7B` falls back to generic `mmproj-F16.gguf` instead of aborting under `set -e`
  - `Qwen3.5-9B` prefers model-specific `mmproj-...-bf16.gguf` over stale generic `mmproj-F16.gguf`

## Pi QA
- existing branch evidence indicates the ByteShape 9B bf16 path was verified on Pi 5 during ticket work
- I did not rerun device QA during merge prep

Closes #258
