### PR TITLE
feat(runtime): add Unsloth Gemma 4 support for E2B, E4B, and 26B-A4B

### DIFF
--- a/apps/chat/assets/chat-engine.js
+++ b/apps/chat/assets/chat-engine.js
@@ -361,6 +361,13 @@ import { saveActiveSession } from "./session-manager.js";
       }
     }
 
+    // TODO(llama.cpp#21326): remove _stripChannelTokens once the upstream PEG
+    // parser handles Gemma 4 <|channel>thought tokens natively.
+    const _CHANNEL_RE = /<\|channel>[^<]*<channel\|>/g;
+    function _stripChannelTokens(text) {
+      return text.replace(_CHANNEL_RE, "");
+    }
+
     export function consumeSseDeltas(state, chunkText) {
       if (!chunkText) return { deltas: [], reasoningDeltas: [], events: [] };
       state.buffer += chunkText.replace(/\r\n/g, "\n");
@@ -612,7 +619,7 @@ import { saveActiveSession } from "./session-manager.js";
                 throwIfRequestStoppedAfterPrefill(requestCtx, finishResult);
               }
               assistantText += delta;
-              updateMessage(activeAssistantView, assistantText, { showActions: false });
+              updateMessage(activeAssistantView, _stripChannelTokens(assistantText), { showActions: false });
             }
             for (const reasoningDelta of parsed.reasoningDeltas) {
               assistantReasoningText += reasoningDelta;
@@ -653,7 +660,7 @@ import { saveActiveSession } from "./session-manager.js";
             const finishResult = await markPrefillGenerationStarted(requestCtx);
             throwIfRequestStoppedAfterPrefill(requestCtx, finishResult);
           }
-          const finalAssistantText = assistantText.trim() || formatReasoningOnlyMessage(assistantReasoningText);
+          const finalAssistantText = _stripChannelTokens(assistantText).trim() || formatReasoningOnlyMessage(assistantReasoningText);
           updateMessage(activeAssistantView, finalAssistantText, { showActions: true });
           const elapsedSeconds = Math.max(0, (performance.now() - requestStartMs) / 1000);
           if (requestCtx.stoppedByUser) {
@@ -677,7 +684,7 @@ import { saveActiveSession } from "./session-manager.js";
           throwIfRequestStoppedAfterPrefill(requestCtx, finishResult);
         }
         const message = body?.choices?.[0]?.message || {};
-        const messageContent = typeof message?.content === "string" ? message.content.trim() : "";
+        const messageContent = typeof message?.content === "string" ? _stripChannelTokens(message.content).trim() : "";
         const msg = messageContent || formatReasoningOnlyMessage(message?.reasoning_content) || JSON.stringify(body);
         updateMessage(activeAssistantView, msg, { showActions: true });
         const elapsedSeconds = Math.max(0, (performance.now() - requestStartMs) / 1000);

--- a/bin/build_llama_runtime.sh
+++ b/bin/build_llama_runtime.sh
@@ -59,6 +59,7 @@ copy_runtime_deps() {
           continue
           ;;
       esac
+      [ -e "${bundle_lib}/${base}" ] && continue
       cp -L "${dep}" "${bundle_lib}/"
     done < <(ldd "${f}" 2>/dev/null | awk '
       $2 == "=>" && $3 ~ /^\// { print $3 }
@@ -267,8 +268,12 @@ if command -v patchelf >/dev/null 2>&1; then
 fi
 
 shopt -s nullglob
-for so in "${build_dir}/bin/"*.so* "${build_dir}/lib/"*.so*; do
-  cp -P "${so}" "${slot_dir}/lib/"
+# Copy lib/ first (real files), then bin/ (may contain symlinks).
+# Use cp -L to dereference symlinks so we always get the real file.
+for so in "${build_dir}/lib/"*.so* "${build_dir}/bin/"*.so*; do
+  base="$(basename "${so}")"
+  [ -e "${slot_dir}/lib/${base}" ] && continue
+  cp -L "${so}" "${slot_dir}/lib/"
 done
 shopt -u nullglob
 

--- a/bin/start_llama.sh
+++ b/bin/start_llama.sh
@@ -19,6 +19,7 @@ HF_MMPROJ_REPO="${POTATO_HF_MMPROJ_REPO:-}"
 # Plain Qwen3.5 2B/4B filenames are ambiguous across text-only and multimodal GGUFs.
 # Keep this opt-in so text models are not forced into mmproj by default.
 VISION_MODEL_NAME_PATTERN_QWEN35="${POTATO_VISION_MODEL_NAME_PATTERN_QWEN35:-0}"
+VISION_MODEL_NAME_PATTERN_GEMMA4="${POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4:-0}"
 
 CACHE_TYPE_K="${POTATO_CACHE_TYPE_K:-q8_0}"
 CACHE_TYPE_V="${POTATO_CACHE_TYPE_V:-q8_0}"
@@ -167,8 +168,17 @@ model_is_qwen35_vision() {
   [[ "${model_name}" == *qwen*3.5* ]]
 }
 
+model_is_gemma4_vision() {
+  local model_name
+  model_name="$(model_filename_lower)"
+  [[ "${model_name}" == *gemma*-4-* ]]
+}
+
 model_requires_mmproj() {
   if [ "${VISION_MODEL_NAME_PATTERN_QWEN35}" = "1" ] && model_is_qwen35_vision; then
+    return 0
+  fi
+  if [ "${VISION_MODEL_NAME_PATTERN_GEMMA4}" = "1" ] && model_is_gemma4_vision; then
     return 0
   fi
   return 1
@@ -195,6 +205,20 @@ resolve_mmproj_repo() {
     return 0
   fi
 
+  # Gemma 4 variants
+  if [[ "${model_name}" == *gemma*-4-*e2b* ]]; then
+    printf 'unsloth/gemma-4-E2B-it-GGUF'
+    return 0
+  fi
+  if [[ "${model_name}" == *gemma*-4-*e4b* ]]; then
+    printf 'unsloth/gemma-4-E4B-it-GGUF'
+    return 0
+  fi
+  if [[ "${model_name}" == *gemma*-4-*26b*a4b* ]]; then
+    printf 'unsloth/gemma-4-26B-A4B-it-GGUF'
+    return 0
+  fi
+
   # No fallback — unrecognized sizes must not silently get a wrong projector (#258)
   return 1
 }
@@ -208,7 +232,7 @@ _mmproj_candidates_for_precision() {
 
   printf 'mmproj-%s-%s.gguf\n' "${model_stem}" "${precision}"
   while true; do
-    next_stem="$(printf '%s\n' "${trimmed_stem}" | sed -E 's/-(I?Q[0-9]+(_[A-Za-z0-9]+)*|[0-9]+(\.[0-9]+)?bpw)$//I')"
+    next_stem="$(printf '%s\n' "${trimmed_stem}" | sed -E 's/-(UD-)?(I?Q[0-9]+(_[A-Za-z0-9]+)*|[0-9]+(\.[0-9]+)?bpw|MXFP[0-9]+_MOE)$//I')"
     if [ -z "${next_stem}" ] || [ "${next_stem}" = "${trimmed_stem}" ]; then
       break
     fi
@@ -228,10 +252,19 @@ qwen35_mmproj_name_candidates() {
   printf '%s\n' "mmproj-F16.gguf"
 }
 
+gemma4_mmproj_name_candidates() {
+  _mmproj_candidates_for_precision f16
+  _mmproj_candidates_for_precision bf16
+  printf '%s\n' "mmproj-F16.gguf"
+}
+
 mmproj_filename_candidates() {
   if model_is_qwen35_vision; then
     printf '%s\n' "mmproj-F16.gguf"
     printf '%s\n' "mmproj-bf16.gguf"
+  elif model_is_gemma4_vision; then
+    printf '%s\n' "mmproj-F16.gguf"
+    printf '%s\n' "mmproj-BF16.gguf"
   fi
 }
 
@@ -315,7 +348,7 @@ pick_mmproj() {
     # try to replace it with a model-specific version (#136).
     if [ "$(basename "${MMPROJ_PATH}")" = "mmproj-F16.gguf" ] \
         && [ "${AUTO_DOWNLOAD_MMPROJ}" = "1" ] \
-        && model_is_qwen35_vision; then
+        && { model_is_qwen35_vision || model_is_gemma4_vision; }; then
       if download_mmproj; then
         return 0
       fi
@@ -341,19 +374,32 @@ pick_mmproj() {
     die "No mmproj file found in ${model_dir}. Set POTATO_MMPROJ_PATH or place mmproj*.gguf there."
   fi
 
+  # Curated vision model families: try model-specific projectors first,
+  # then auto-download, then generic F16 fallback.
+  local vision_family_name=''
+  local vision_candidates_fn=''
   if model_is_qwen35_vision; then
+    vision_family_name='Qwen3.5'
+    vision_candidates_fn='qwen35_mmproj_name_candidates'
+  elif model_is_gemma4_vision; then
+    vision_family_name='Gemma 4'
+    vision_candidates_fn='gemma4_mmproj_name_candidates'
+  fi
+
+  if [ -n "${vision_family_name}" ]; then
     # 1. Try exact model-specific match (skip generics — handled below).
     while read -r candidate_base; do
       [ -n "${candidate_base}" ] || continue
       [ "${candidate_base}" = "mmproj-F16.gguf" ] && continue
       [ "${candidate_base}" = "mmproj-bf16.gguf" ] && continue
+      [ "${candidate_base}" = "mmproj-BF16.gguf" ] && continue
       for candidate in "${mmproj_candidates[@]}"; do
         if [ "$(basename "${candidate}")" = "${candidate_base}" ]; then
           MMPROJ_PATH="${candidate}"
           return 0
         fi
       done
-    done < <(qwen35_mmproj_name_candidates | awk '!seen[$0]++')
+    done < <(${vision_candidates_fn} | awk '!seen[$0]++')
 
     # 2. No model-specific match — try auto-download before falling back.
     #    download_mmproj saves with a model-specific local name (#136).
@@ -364,8 +410,6 @@ pick_mmproj() {
     # 3. Offline fallback: accept only generic mmproj-F16.gguf.
     #    Do NOT accept other models' specific projectors — they have
     #    different embedding dimensions and would crash llama-server (#136).
-    #    Generic mmproj-bf16.gguf is also excluded: it's ByteShape-specific
-    #    and could be stale from a different model size.
     for candidate in "${mmproj_candidates[@]}"; do
       candidate_base="$(basename "${candidate}" | tr '[:upper:]' '[:lower:]')"
       if [[ "${candidate_base}" == mmproj-f16.gguf ]]; then
@@ -376,7 +420,7 @@ pick_mmproj() {
       mmproj_candidates=("${compatible_candidates[@]}")
       compatible_candidates=()
     else
-      die "No compatible mmproj found for Qwen3.5 vision model (model: $(basename "${MODEL_PATH}"))."
+      die "No compatible mmproj found for ${vision_family_name} vision model (model: $(basename "${MODEL_PATH}"))."
     fi
   fi
 

--- a/core/constants/__init__.py
+++ b/core/constants/__init__.py
@@ -1,9 +1,15 @@
 from .model_families import (
+    is_gemma4_filename,
     is_qwen35_filename,
     projector_repo_for_model,
+    recommended_runtime_for_model,
 )
 
 __all__ = [
+    "is_gemma4_filename",
     "is_qwen35_filename",
     "projector_repo_for_model",
+    "recommended_runtime_for_model",
 ]
+
+

--- a/core/constants/model_families.py
+++ b/core/constants/model_families.py
@@ -50,5 +50,42 @@ def _qwen35_projector_repo(filename: str | None, source_url: str | None = None) 
     return None
 
 
+GEMMA4_PROJECTOR_REPO_RULES: Final[tuple[tuple[tuple[str, ...], str], ...]] = (
+    (("e2b",), "unsloth/gemma-4-E2B-it-GGUF"),
+    (("e4b",), "unsloth/gemma-4-E4B-it-GGUF"),
+    (("26b", "a4b"), "unsloth/gemma-4-26B-A4B-it-GGUF"),
+)
+
+
+def is_gemma4_filename(filename: str | None) -> bool:
+    model_name = _normalized_model_name(filename)
+    return bool(model_name) and "gemma" in model_name and _token_at_boundary("4", model_name)
+
+
+def _gemma4_projector_repo(filename: str | None, source_url: str | None = None) -> str | None:
+    model_name = _normalized_model_name(filename)
+    if not is_gemma4_filename(model_name):
+        return None
+
+    match_text = model_name
+    if source_url:
+        match_text = _normalized_model_name(source_url) + " " + match_text
+
+    for required_tokens, repo in GEMMA4_PROJECTOR_REPO_RULES:
+        if all(_token_at_boundary(token, match_text) for token in required_tokens):
+            return repo
+    return None
+
+
+def recommended_runtime_for_model(filename: str | None) -> str | None:
+    """Return the preferred runtime family for a model, or None for no preference."""
+    if is_gemma4_filename(filename):
+        return "llama_cpp"
+    return None
+
+
 def projector_repo_for_model(filename: str | None, source_url: str | None = None) -> str | None:
-    return _qwen35_projector_repo(filename, source_url=source_url)
+    return (
+        _qwen35_projector_repo(filename, source_url=source_url)
+        or _gemma4_projector_repo(filename, source_url=source_url)
+    )

--- a/core/main.py
+++ b/core/main.py
@@ -34,8 +34,10 @@ except ModuleNotFoundError:
 
 try:
     from core.constants import (
+        is_gemma4_filename,
         is_qwen35_filename,
         projector_repo_for_model,
+        recommended_runtime_for_model,
     )
     from core.model_state import (
         DEFAULT_MODEL_CHAT_SETTINGS,
@@ -96,6 +98,7 @@ try:
         POWER_CALIBRATION_DEFAULT_B,
         RuntimeConfig,
         _MODEL_LOADING_INACTIVE,
+        _detect_installed_runtime_family,
         build_large_model_compatibility,
         build_llama_large_model_override_status,
         build_llama_memory_loading_status,
@@ -157,8 +160,10 @@ try:
     )
 except ModuleNotFoundError:
     from constants import (  # type: ignore[no-redef]
+        is_gemma4_filename,
         is_qwen35_filename,
         projector_repo_for_model,
+        recommended_runtime_for_model,
     )
     from model_state import (  # type: ignore[no-redef]
         DEFAULT_MODEL_CHAT_SETTINGS,
@@ -219,6 +224,7 @@ except ModuleNotFoundError:
         POWER_CALIBRATION_DEFAULT_B,
         RuntimeConfig,
         _MODEL_LOADING_INACTIVE,
+        _detect_installed_runtime_family,
         build_large_model_compatibility,
         build_llama_large_model_override_status,
         build_llama_memory_loading_status,
@@ -866,6 +872,7 @@ def _runtime_env(runtime: RuntimeConfig) -> dict[str, str]:
     env["POTATO_LLAMA_NO_MMAP"] = str(build_llama_memory_loading_status(runtime).get("no_mmap_env") or "auto")
     env["POTATO_AUTO_DOWNLOAD_MMPROJ"] = "0"
     env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] = "0"
+    env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] = "0"
     env.pop("POTATO_MMPROJ_PATH", None)
     try:
         state = ensure_models_state(runtime)
@@ -883,6 +890,8 @@ def _runtime_env(runtime: RuntimeConfig) -> dict[str, str]:
                 env["POTATO_HF_MMPROJ_REPO"] = mmproj_repo
             if is_qwen35_filename(active_filename):
                 env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] = "1"
+            if is_gemma4_filename(active_filename):
+                env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] = "1"
             projector_status = build_model_projector_status(runtime, active_model)
             if projector_status.get("present") and projector_status.get("path"):
                 env["POTATO_MMPROJ_PATH"] = str(projector_status["path"])
@@ -1306,10 +1315,28 @@ async def activate_model(
     filename = str(target.get("filename") or "")
     if not model_file_present(runtime, filename):
         return False, "model_not_ready", False
+    # Auto-switch runtime before committing the model state so a failed
+    # install doesn't leave Potato pointing at an unrunnable model.
+    preferred = recommended_runtime_for_model(filename)
+    if preferred:
+        current = _detect_installed_runtime_family(runtime)
+        if current and current != preferred:
+            slot = find_runtime_slot_by_family(runtime, preferred)
+            if slot is not None:
+                slot_path = Path(slot["path"])
+                logger.info("Auto-switching runtime %s -> %s for model %s", current, preferred, filename)
+                async with app.state.llama_runtime_switch_lock:
+                    result = await install_llama_runtime_bundle(runtime, slot_path)
+                if not isinstance(result, dict) or not result.get("ok", False):
+                    reason = result.get("reason", "unknown") if isinstance(result, dict) else "unknown"
+                    logger.error("Runtime auto-switch failed during activation: %s", reason)
+                    return False, "runtime_switch_failed", False
+
     state["active_model_id"] = model_id
     target["status"] = "ready"
     save_models_state(runtime, state)
     runtime.model_path = resolve_model_runtime_path(runtime, filename)
+
     restarted, _reason = await restart_managed_llama_process(app)
     return True, "activated", restarted
 

--- a/core/model_state.py
+++ b/core/model_state.py
@@ -91,6 +91,12 @@ def model_supports_vision_filename(filename: str | None) -> bool:
         return True
     if "qwen" in value and "3.5" in value:
         return True
+    try:
+        from core.constants import is_gemma4_filename
+    except ModuleNotFoundError:
+        from constants import is_gemma4_filename  # type: ignore[no-redef]
+    if is_gemma4_filename(value):
+        return True
     return False
 
 
@@ -655,42 +661,52 @@ def delete_model(runtime: RuntimeConfig, *, model_id: str) -> tuple[bool, str, b
     return True, "deleted", deleted_file, freed_bytes, was_active
 
 
+def _is_vision_family(filename: str) -> bool:
+    """Return True if the filename belongs to a curated vision model family."""
+    model_name = filename.strip().lower()
+    if "qwen" in model_name and "3.5" in model_name:
+        return True
+    try:
+        from core.constants import is_gemma4_filename
+    except ModuleNotFoundError:
+        from constants import is_gemma4_filename  # type: ignore[no-redef]
+    return is_gemma4_filename(model_name)
+
+
 def default_projector_candidates_for_model(filename: str | None) -> list[str]:
     """Return ordered list of mmproj filename candidates for a given model."""
-    model_name = str(filename or "").strip().lower()
-    if not model_name:
+    model_name = str(filename or "").strip()
+    if not model_name or not _is_vision_family(model_name):
         return []
-    if "qwen" in model_name and "3.5" in model_name:
-        import re as _re
-        stem = Path(str(filename or "")).stem
-        stem_candidates = [stem]
-        trimmed_stem = stem
-        while True:
-            next_stem = _re.sub(
-                r"-(?:\d+(?:\.\d+)?bpw|I?Q\d+(?:_[A-Za-z0-9]+)*)$",
-                "",
-                trimmed_stem,
-                flags=_re.IGNORECASE,
-            )
-            if next_stem == trimmed_stem or not next_stem:
-                break
-            trimmed_stem = next_stem
-            if trimmed_stem not in stem_candidates:
-                stem_candidates.append(trimmed_stem)
 
-        candidates: list[str] = []
-        # Model-specific candidates first (f16 preferred, bf16 fallback),
-        # then generic F16 last. This ensures a downloaded model-specific
-        # bf16 projector is found before a stale generic F16.
-        for precision in ("f16", "bf16"):
-            for candidate_stem in stem_candidates:
-                candidate_name = f"mmproj-{candidate_stem}-{precision}.gguf"
-                if candidate_name not in candidates:
-                    candidates.append(candidate_name)
-        if "mmproj-F16.gguf" not in candidates:
-            candidates.append("mmproj-F16.gguf")
-        return candidates
-    return []
+    stem = Path(model_name).stem
+    stem_candidates = [stem]
+    trimmed_stem = stem
+    while True:
+        next_stem = re.sub(
+            r"-(?:UD-)?(?:\d+(?:\.\d+)?bpw|I?Q\d+(?:_[A-Za-z0-9]+)*|MXFP\d+_MOE)$",
+            "",
+            trimmed_stem,
+            flags=re.IGNORECASE,
+        )
+        if next_stem == trimmed_stem or not next_stem:
+            break
+        trimmed_stem = next_stem
+        if trimmed_stem not in stem_candidates:
+            stem_candidates.append(trimmed_stem)
+
+    candidates: list[str] = []
+    # Model-specific candidates first (f16 preferred, bf16 fallback),
+    # then generic F16 last. This ensures a downloaded model-specific
+    # bf16 projector is found before a stale generic F16.
+    for precision in ("f16", "bf16"):
+        for candidate_stem in stem_candidates:
+            candidate_name = f"mmproj-{candidate_stem}-{precision}.gguf"
+            if candidate_name not in candidates:
+                candidates.append(candidate_name)
+    if "mmproj-F16.gguf" not in candidates:
+        candidates.append("mmproj-F16.gguf")
+    return candidates
 
 
 def download_default_projector_for_model(*, runtime: RuntimeConfig, model_id: str) -> tuple[bool, str, str | None]:

--- a/tests/api/test_runtime_env.py
+++ b/tests/api/test_runtime_env.py
@@ -345,3 +345,105 @@ def test_model_switch_passes_generic_with_auto_download_for_shell_upgrade(runtim
     assert "POTATO_HF_MMPROJ_REPO" in env
 
 
+# ── Gemma 4 runtime env ────────────────────────────────────────────
+
+
+def test_runtime_env_sets_gemma4_vision_flag_when_active(runtime):
+    model_filename = "gemma-4-E2B-it-Q4_K_M.gguf"
+    model_path = runtime.base_dir / "models" / model_filename
+    model_path.write_bytes(b"gguf")
+    mmproj = runtime.base_dir / "models" / "mmproj-gemma-4-E2B-it-f16.gguf"
+    mmproj.write_bytes(b"projector")
+    runtime.models_state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "countdown_enabled": True,
+                "default_model_downloaded_once": True,
+                "active_model_id": "gemma4-model",
+                "default_model_id": "default",
+                "current_download_model_id": None,
+                "models": [
+                    {
+                        "id": "default",
+                        "filename": runtime.model_path.name,
+                        "source_url": "https://example.com/default.gguf",
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                    },
+                    {
+                        "id": "gemma4-model",
+                        "filename": model_filename,
+                        "source_url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf",
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                        "settings": {
+                            "vision": {
+                                "enabled": True,
+                                "projector_mode": "default",
+                                "projector_filename": None,
+                            }
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = _runtime_env(runtime)
+
+    assert env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] == "1"
+    assert env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] == "0"
+    assert env["POTATO_AUTO_DOWNLOAD_MMPROJ"] == "1"
+    assert env["POTATO_HF_MMPROJ_REPO"] == "unsloth/gemma-4-E2B-it-GGUF"
+    assert "POTATO_MMPROJ_PATH" in env
+    assert "gemma-4-E2B-it" in env["POTATO_MMPROJ_PATH"]
+
+
+def test_runtime_env_disables_gemma4_flag_when_vision_off(runtime):
+    model_filename = "gemma-4-E4B-it-Q4_0.gguf"
+    model_path = runtime.base_dir / "models" / model_filename
+    model_path.write_bytes(b"gguf")
+    runtime.model_path = model_path
+    runtime.models_state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "countdown_enabled": True,
+                "default_model_downloaded_once": True,
+                "active_model_id": "gemma4-model",
+                "default_model_id": "gemma4-model",
+                "current_download_model_id": None,
+                "models": [
+                    {
+                        "id": "gemma4-model",
+                        "filename": model_filename,
+                        "source_url": "https://example.com/gemma4.gguf",
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                        "settings": {
+                            "vision": {
+                                "enabled": False,
+                                "projector_mode": "default",
+                                "projector_filename": None,
+                            }
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = _runtime_env(runtime)
+
+    assert env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] == "0"
+    assert env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] == "0"
+    assert env["POTATO_AUTO_DOWNLOAD_MMPROJ"] == "0"
+    assert "POTATO_MMPROJ_PATH" not in env
+
+

--- a/tests/unit/test_model_families.py
+++ b/tests/unit/test_model_families.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from core.constants.model_families import projector_repo_for_model
+from core.constants.model_families import is_gemma4_filename, projector_repo_for_model, recommended_runtime_for_model
 
 
 def test_projector_repo_for_qwen35_9b():
@@ -119,3 +119,139 @@ def test_projector_status_ignores_stale_generic_bf16_for_wrong_model(runtime):
 def test_projector_repo_existing_sizes_unchanged(filename: str, expected_repo: str):
     """Existing size mappings must not regress."""
     assert projector_repo_for_model(filename) == expected_repo
+
+
+# ── Gemma 4 detection ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "gemma-4-E2B-it-Q4_K_M.gguf",
+        "gemma-4-E2B-it-UD-Q4_K_XL.gguf",
+        "gemma-4-E4B-it-Q4_0.gguf",
+        "gemma-4-E4B-it-Q8_0.gguf",
+        "gemma-4-26B-A4B-it-UD-IQ2_M.gguf",
+        "gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf",
+    ],
+)
+def test_is_gemma4_filename_positive(filename: str):
+    """All Gemma 4 variant filenames are detected."""
+    assert is_gemma4_filename(filename) is True
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "gemma-3-9b-it-Q4_K_M.gguf",
+        "Qwen3.5-4B-Q4_K_M.gguf",
+        "llama-4-scout-Q4_K_M.gguf",
+        None,
+        "",
+    ],
+)
+def test_is_gemma4_filename_negative(filename):
+    """Non-Gemma-4 filenames must not match."""
+    assert is_gemma4_filename(filename) is False
+
+
+# ── Gemma 4 projector repo resolution ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "filename, expected_repo",
+    [
+        ("gemma-4-E2B-it-Q4_K_M.gguf", "unsloth/gemma-4-E2B-it-GGUF"),
+        ("gemma-4-E2B-it-UD-Q4_K_XL.gguf", "unsloth/gemma-4-E2B-it-GGUF"),
+        ("gemma-4-E2B-it-Q8_0.gguf", "unsloth/gemma-4-E2B-it-GGUF"),
+        ("gemma-4-E2B-it-IQ4_NL.gguf", "unsloth/gemma-4-E2B-it-GGUF"),
+        ("gemma-4-E4B-it-Q4_0.gguf", "unsloth/gemma-4-E4B-it-GGUF"),
+        ("gemma-4-E4B-it-Q8_0.gguf", "unsloth/gemma-4-E4B-it-GGUF"),
+        ("gemma-4-26B-A4B-it-UD-IQ2_M.gguf", "unsloth/gemma-4-26B-A4B-it-GGUF"),
+        ("gemma-4-26B-A4B-it-UD-Q4_K_XL.gguf", "unsloth/gemma-4-26B-A4B-it-GGUF"),
+    ],
+)
+def test_projector_repo_for_gemma4(filename: str, expected_repo: str):
+    """Each Gemma 4 variant resolves to its Unsloth projector repo."""
+    assert projector_repo_for_model(filename) == expected_repo
+
+
+def test_projector_repo_returns_none_for_unknown_gemma4_variant():
+    """Unrecognized Gemma 4 variants must return None."""
+    assert projector_repo_for_model("gemma-4-99B-it-Q4_K_M.gguf") is None
+
+
+def test_projector_repo_gemma4_no_collision_with_quant_4():
+    """'4' in Q4_K_M must not trigger Gemma 4 detection on non-Gemma models."""
+    assert projector_repo_for_model("some-model-Q4_K_M.gguf") is None
+
+
+def test_projector_repo_gemma4_does_not_break_qwen35():
+    """Qwen3.5 repos must still resolve correctly with Gemma 4 code present."""
+    assert projector_repo_for_model("Qwen3.5-2B-Q4_K_M.gguf") == "unsloth/Qwen3.5-2B-GGUF"
+    assert projector_repo_for_model("Qwen3.5-9B-Q4_K_S.gguf") == "unsloth/Qwen3.5-9B-GGUF"
+
+
+# ── Gemma 4 projector candidates ───────────────────────────────────
+
+
+def test_default_candidates_gemma4_e2b():
+    """Gemma 4 E2B produces model-specific f16/bf16 then generic F16."""
+    from core.model_state import default_projector_candidates_for_model
+
+    candidates = default_projector_candidates_for_model("gemma-4-E2B-it-Q4_K_M.gguf")
+    assert len(candidates) > 0
+    assert "mmproj-gemma-4-E2B-it-f16.gguf" in candidates
+    assert "mmproj-gemma-4-E2B-it-bf16.gguf" in candidates
+    assert "mmproj-F16.gguf" in candidates
+    # Generic bf16 must NOT be in the list
+    assert "mmproj-bf16.gguf" not in candidates
+    # f16 model-specific should come before generic
+    assert candidates.index("mmproj-gemma-4-E2B-it-f16.gguf") < candidates.index("mmproj-F16.gguf")
+
+
+def test_default_candidates_gemma4_26b_a4b():
+    """Gemma 4 26B-A4B stem-trimming strips the UD-IQ2_M quant suffix."""
+    from core.model_state import default_projector_candidates_for_model
+
+    candidates = default_projector_candidates_for_model("gemma-4-26B-A4B-it-UD-IQ2_M.gguf")
+    assert "mmproj-gemma-4-26B-A4B-it-f16.gguf" in candidates
+    assert "mmproj-F16.gguf" in candidates
+
+
+def test_projector_status_gemma4_finds_model_specific_on_disk(runtime):
+    """build_model_projector_status detects a Gemma 4 model-specific projector."""
+    from core.model_state import build_model_projector_status
+
+    models_dir = runtime.base_dir / "models"
+    (models_dir / "mmproj-gemma-4-E2B-it-f16.gguf").write_bytes(b"g4-projector")
+
+    model = {
+        "filename": "gemma-4-E2B-it-Q4_K_M.gguf",
+        "settings": {
+            "vision": {"enabled": True, "projector_mode": "default", "projector_filename": None},
+        },
+    }
+    status = build_model_projector_status(runtime, model)
+    assert status["present"] is True
+    assert "gemma-4-E2B-it" in status["filename"]
+
+
+# ── Recommended runtime ────────────────────────────────────────────
+
+
+def test_recommended_runtime_gemma4_is_llama_cpp():
+    """Gemma 4 models should prefer the llama_cpp runtime."""
+    assert recommended_runtime_for_model("gemma-4-E2B-it-Q4_K_M.gguf") == "llama_cpp"
+    assert recommended_runtime_for_model("gemma-4-E4B-it-Q4_0.gguf") == "llama_cpp"
+    assert recommended_runtime_for_model("gemma-4-26B-A4B-it-UD-IQ2_M.gguf") == "llama_cpp"
+
+
+def test_recommended_runtime_qwen35_has_no_preference():
+    """Qwen3.5 models should have no runtime preference (None)."""
+    assert recommended_runtime_for_model("Qwen3.5-2B-Q4_K_M.gguf") is None
+
+
+def test_recommended_runtime_unknown_model_has_no_preference():
+    """Unknown models should have no runtime preference."""
+    assert recommended_runtime_for_model("some-random-model.gguf") is None

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -1188,6 +1188,84 @@ mmproj_filename_candidates
     )
 
 
+# ── Gemma 4 shell integration ─────────────────────────────────────
+
+
+def test_start_llama_gemma4_vision_uses_mmproj(tmp_path: Path):
+    """Gemma 4 with vision flag enabled must include --mmproj in command."""
+    runtime_dir = tmp_path / "llama"
+    runtime_bin = runtime_dir / "bin"
+    runtime_bin.mkdir(parents=True)
+
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    model_path = model_dir / "gemma-4-E2B-it-Q4_K_M.gguf"
+    model_path.write_bytes(b"gguf")
+    f16_mmproj = model_dir / "mmproj-F16.gguf"
+    f16_mmproj.write_bytes(b"f16")
+
+    args_out = tmp_path / "args.txt"
+    write_stub(
+        runtime_bin / "llama-server",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$ARGS_OUT"
+""",
+    )
+
+    env = os.environ.copy()
+    env["POTATO_BASE_DIR"] = str(tmp_path)
+    env["POTATO_LLAMA_RUNTIME_DIR"] = str(runtime_dir)
+    env["POTATO_MODEL_PATH"] = str(model_path)
+    env["POTATO_AUTO_DOWNLOAD_MMPROJ"] = "0"
+    env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] = "1"
+    env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] = "0"
+    env["ARGS_OUT"] = str(args_out)
+
+    subprocess.run([str(REPO_ROOT / "bin" / "start_llama.sh")], check=True, cwd=REPO_ROOT, env=env)
+
+    args = args_out.read_text(encoding="utf-8")
+    assert "--mmproj" in args
+    assert str(f16_mmproj) in args
+
+
+def test_start_llama_gemma4_text_only_skips_mmproj(tmp_path: Path):
+    """Without Gemma 4 vision flag, no --mmproj even with Gemma 4 filename."""
+    runtime_dir = tmp_path / "llama"
+    runtime_bin = runtime_dir / "bin"
+    runtime_bin.mkdir(parents=True)
+
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    model_path = model_dir / "gemma-4-E2B-it-Q4_K_M.gguf"
+    model_path.write_bytes(b"gguf")
+    f16_mmproj = model_dir / "mmproj-F16.gguf"
+    f16_mmproj.write_bytes(b"f16")
+
+    args_out = tmp_path / "args.txt"
+    write_stub(
+        runtime_bin / "llama-server",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$ARGS_OUT"
+""",
+    )
+
+    env = os.environ.copy()
+    env["POTATO_BASE_DIR"] = str(tmp_path)
+    env["POTATO_LLAMA_RUNTIME_DIR"] = str(runtime_dir)
+    env["POTATO_MODEL_PATH"] = str(model_path)
+    env["POTATO_AUTO_DOWNLOAD_MMPROJ"] = "0"
+    env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] = "0"
+    env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] = "0"
+    env["ARGS_OUT"] = str(args_out)
+
+    subprocess.run([str(REPO_ROOT / "bin" / "start_llama.sh")], check=True, cwd=REPO_ROOT, env=env)
+
+    args = args_out.read_text(encoding="utf-8")
+    assert "--mmproj" not in args
+
+
 # ---------------------------------------------------------------------------
 # Pi-hole installation section in install_dev.sh (#212)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #265

## Summary

- Add first-class Potato support for Unsloth Gemma 4 GGUFs: E2B, E4B, and experimental 26B-A4B
- Model family detection, projector repo resolution, vision capability detection, and runtime env propagation
- Shell integration: mmproj handling, repo resolution, and candidate generation for all three variants
- Auto-switch to `llama_cpp` runtime when activating Gemma 4 models (ik_llama doesn't have `gemma3n`/`gemma4` arch support yet — tracked in ikawrakow/ik_llama.cpp#1572)
- Strip Gemma 4 `<|channel>thought` tokens in the chat UI (upstream llama.cpp PEG parser bug, fix pending in ggml-org/llama.cpp#21326)
- Fix `cp` same-file error in `build_llama_runtime.sh` universal profile packaging
- Refactored `default_projector_candidates_for_model` into a shared helper for both Qwen3.5 and Gemma 4
- Built and deployed upstream `llama.cpp` (commit `a1cfb64`) to the `llama_cpp` runtime slot on Pi

## Test evidence

```
pytest: 649 passed in 10.45s
playwright: 144 passed (35.1s)
```

## Pi QA

- **ssd.local (Pi 5 8GB)**: E2B Q4_K_M — loads, vision works, projector auto-downloads ✓
- **ssd.local (Pi 5 8GB)**: E4B Q4_0 — loads, inference works ✓
- **potato.local (Pi 5 16GB)**: 26B-A4B IQ4_NL — loads (15.5GB RSS), inference at 2.76 tok/sec, vision with mmproj works ✓
- **potato.local**: Channel token stripping verified clean via Chrome MCP ✓
- Qwen3.5 regression: switched back, no issues ✓