### PR TITLE
feat(runtime): route all Gemma 4 models to ik_llama

### DIFF
--- a/core/assets/settings-ui.js
+++ b/core/assets/settings-ui.js
@@ -259,13 +259,13 @@ import { flushPendingNoticeDismissal } from "./platform-notify.js";
           seed,
           system_prompt: document.getElementById("systemPrompt").value.trim(),
         },
-        vision: {
-          enabled: supportsVision && Boolean(document.getElementById("visionEnabled")?.checked),
-          projector_mode: "default",
-          projector_filename: supportsVision
-            ? String(document.getElementById("downloadProjectorBtn")?.dataset?.projectorFilename || "")
-            : "",
-        },
+        vision: supportsVision
+          ? {
+              enabled: Boolean(document.getElementById("visionEnabled")?.checked),
+              projector_mode: "default",
+              projector_filename: String(document.getElementById("downloadProjectorBtn")?.dataset?.projectorFilename || ""),
+            }
+          : (selectedModel?.settings?.vision || { enabled: false, projector_mode: "default", projector_filename: "" }),
       };
     }
 
@@ -368,7 +368,7 @@ import { flushPendingNoticeDismissal } from "./platform-notify.js";
         || String(repetitionPenaltyEl.value || "") !== String(chat.repetition_penalty)
         || String(presencePenaltyEl.value || "") !== String(chat.presence_penalty)
         || String(maxTokensEl.value || "") !== String(chat.max_tokens)
-        || (visionEnabledEl ? Boolean(visionEnabledEl.checked) !== Boolean(vision.enabled) : false)
+        || (visionEnabledEl && !visionEnabledEl.disabled ? Boolean(visionEnabledEl.checked) !== Boolean(vision.enabled) : false)
       );
     }
 

--- a/core/constants/model_families.py
+++ b/core/constants/model_families.py
@@ -80,7 +80,7 @@ def _gemma4_projector_repo(filename: str | None, source_url: str | None = None) 
 def recommended_runtime_for_model(filename: str | None) -> str | None:
     """Return the preferred runtime family for a model, or None for no preference."""
     if is_gemma4_filename(filename):
-        return "llama_cpp"
+        return "ik_llama"
     return None
 
 

--- a/core/main.py
+++ b/core/main.py
@@ -675,6 +675,14 @@ def _build_status_fs(
             }
         )
 
+    # ik_llama doesn't support gemma4v vision — downgrade capabilities so
+    # the UI hides image upload instead of sending images to a text-only server.
+    installed_family = _detect_installed_runtime_family(runtime)
+    if installed_family == "ik_llama":
+        for entry in models_payload:
+            if is_gemma4_filename(str(entry.get("filename") or "")):
+                entry["capabilities"] = dict(entry["capabilities"], vision=False)
+
     download_payload = dict(download)
     download_payload["active"] = bool(download_active)
     download_payload["auto_start_seconds"] = int(max(0, runtime.auto_download_idle_seconds))
@@ -760,7 +768,11 @@ def _build_status_fs(
             "active_model_id": models_state.get("active_model_id"),
             "storage": describe_model_storage(runtime, active_model_path.name),
             "settings": normalize_model_settings(active_model.get("settings"), filename=active_model_path.name),
-            "capabilities": build_model_capabilities(active_model_path.name),
+            "capabilities": (
+                dict(build_model_capabilities(active_model_path.name), vision=False)
+                if installed_family == "ik_llama" and is_gemma4_filename(active_model_path.name)
+                else build_model_capabilities(active_model_path.name)
+            ),
             "projector": build_model_projector_status(runtime, active_model),
         },
         "models": models_payload,
@@ -900,6 +912,15 @@ def _runtime_env(runtime: RuntimeConfig) -> dict[str, str]:
                 projector_filename = str(vision_settings.get("projector_filename") or "").strip()
                 if projector_mode == "custom" and projector_filename:
                     env["POTATO_MMPROJ_PATH"] = str(runtime.base_dir / "models" / projector_filename)
+    # ik_llama doesn't support the gemma4v vision projector type yet —
+    # suppress vision to avoid a clip_init failure loop.
+    if isinstance(active_model, dict):
+        active_fn = str(active_model.get("filename") or "")
+        installed_family = _detect_installed_runtime_family(runtime)
+        if is_gemma4_filename(active_fn) and installed_family == "ik_llama":
+            env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] = "0"
+            env.pop("POTATO_MMPROJ_PATH", None)
+
     device_class = classify_runtime_device(
         pi_model_name=_read_pi_device_model_name(),
     )
@@ -1318,6 +1339,17 @@ async def activate_model(
     # Auto-switch runtime before committing the model state so a failed
     # install doesn't leave Potato pointing at an unrunnable model.
     preferred = recommended_runtime_for_model(filename)
+    if preferred:
+        device_class = classify_runtime_device(
+            pi_model_name=_read_pi_device_model_name(),
+        )
+        compat = check_runtime_device_compatibility(device_class, preferred)
+        if not compat.get("compatible", True):
+            logger.info(
+                "Skipping auto-switch to %s for %s: %s",
+                preferred, filename, compat.get("reason", "incompatible"),
+            )
+            preferred = None
     if preferred:
         current = _detect_installed_runtime_family(runtime)
         if current and current != preferred:

--- a/tests/api/test_runtime_env.py
+++ b/tests/api/test_runtime_env.py
@@ -403,6 +403,131 @@ def test_runtime_env_sets_gemma4_vision_flag_when_active(runtime):
     assert "gemma-4-E2B-it" in env["POTATO_MMPROJ_PATH"]
 
 
+def test_runtime_env_suppresses_gemma4_vision_on_ik_llama(runtime):
+    """When ik_llama is the active runtime, Gemma 4 vision must be suppressed
+    because the fork doesn't support gemma4v projectors.  KV cache must NOT
+    be overridden — q8_0 default is correct with the upstream D=512 kernel."""
+    model_filename = "gemma-4-26B-A4B-it-UD-IQ4_NL.gguf"
+    model_path = runtime.base_dir / "models" / model_filename
+    model_path.write_bytes(b"gguf")
+    mmproj = runtime.base_dir / "models" / "mmproj-gemma-4-26B-A4B-it-f16.gguf"
+    mmproj.write_bytes(b"projector")
+    # Simulate ik_llama as the installed runtime
+    llama_dir = runtime.base_dir / "llama"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "runtime.json").write_text(
+        '{"family": "ik_llama", "commit": "584df79e"}',
+        encoding="utf-8",
+    )
+    runtime.models_state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "countdown_enabled": True,
+                "default_model_downloaded_once": True,
+                "active_model_id": "gemma4-model",
+                "default_model_id": "default",
+                "current_download_model_id": None,
+                "models": [
+                    {
+                        "id": "default",
+                        "filename": runtime.model_path.name,
+                        "source_url": "https://example.com/default.gguf",
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                    },
+                    {
+                        "id": "gemma4-model",
+                        "filename": model_filename,
+                        "source_url": "https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/main/" + model_filename,
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                        "settings": {
+                            "vision": {
+                                "enabled": True,
+                                "projector_mode": "default",
+                                "projector_filename": None,
+                            }
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = _runtime_env(runtime)
+
+    # Vision must be suppressed — ik_llama doesn't support gemma4v projectors
+    assert env["POTATO_VISION_MODEL_NAME_PATTERN_GEMMA4"] == "0"
+    assert "POTATO_MMPROJ_PATH" not in env
+    # KV cache must NOT be overridden — q8_0 default works with D=512 kernel
+    assert "POTATO_CACHE_TYPE_K" not in env
+    assert "POTATO_CACHE_TYPE_V" not in env
+
+
+def test_status_reports_gemma4_vision_false_on_ik_llama(runtime):
+    """When ik_llama is installed, /status must report capabilities.vision=false
+    for the active Gemma 4 model so the UI hides image upload (#270 P2)."""
+    runtime.enable_orchestrator = True
+    app = create_app(runtime=runtime, enable_orchestrator=True)
+    app.dependency_overrides[get_runtime] = lambda: runtime
+
+    model_filename = "gemma-4-E2B-it-Q4_K_M.gguf"
+    model_path = runtime.base_dir / "models" / model_filename
+    model_path.write_bytes(b"gguf")
+    # Simulate ik_llama as the installed runtime
+    llama_dir = runtime.base_dir / "llama"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "runtime.json").write_text(
+        '{"family": "ik_llama", "commit": "584df79e"}',
+        encoding="utf-8",
+    )
+    runtime.models_state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "countdown_enabled": True,
+                "default_model_downloaded_once": True,
+                "active_model_id": "gemma4-model",
+                "default_model_id": "gemma4-model",
+                "current_download_model_id": None,
+                "models": [
+                    {
+                        "id": "gemma4-model",
+                        "filename": model_filename,
+                        "source_url": "https://example.com/gemma4.gguf",
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                        "settings": {
+                            "vision": {
+                                "enabled": True,
+                                "projector_mode": "default",
+                                "projector_filename": None,
+                            }
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    # Active model capabilities must report vision=false on ik_llama
+    assert body["model"]["capabilities"]["vision"] is False
+    # Model list entry should also reflect no vision
+    gemma4_entry = next(m for m in body["models"] if m["id"] == "gemma4-model")
+    assert gemma4_entry["capabilities"]["vision"] is False
+
+
 def test_runtime_env_disables_gemma4_flag_when_vision_off(runtime):
     model_filename = "gemma-4-E4B-it-Q4_0.gguf"
     model_path = runtime.base_dir / "models" / model_filename

--- a/tests/unit/test_model_families.py
+++ b/tests/unit/test_model_families.py
@@ -240,11 +240,12 @@ def test_projector_status_gemma4_finds_model_specific_on_disk(runtime):
 # ── Recommended runtime ────────────────────────────────────────────
 
 
-def test_recommended_runtime_gemma4_is_llama_cpp():
-    """Gemma 4 models should prefer the llama_cpp runtime."""
-    assert recommended_runtime_for_model("gemma-4-E2B-it-Q4_K_M.gguf") == "llama_cpp"
-    assert recommended_runtime_for_model("gemma-4-E4B-it-Q4_0.gguf") == "llama_cpp"
-    assert recommended_runtime_for_model("gemma-4-26B-A4B-it-UD-IQ2_M.gguf") == "llama_cpp"
+def test_recommended_runtime_gemma4_is_ik_llama():
+    """All Gemma 4 variants prefer ik_llama for the IQK speedup."""
+    assert recommended_runtime_for_model("gemma-4-E2B-it-Q4_K_M.gguf") == "ik_llama"
+    assert recommended_runtime_for_model("gemma-4-E4B-it-Q4_0.gguf") == "ik_llama"
+    assert recommended_runtime_for_model("gemma-4-26B-A4B-it-UD-IQ2_M.gguf") == "ik_llama"
+    assert recommended_runtime_for_model("gemma-4-26B-A4B-it-UD-IQ4_NL.gguf") == "ik_llama"
 
 
 def test_recommended_runtime_qwen35_has_no_preference():


### PR DESCRIPTION
## Summary

- All Gemma 4 models now prefer `ik_llama` runtime (was `llama_cpp`)
- Upstream `ik_llama` PR #1581 (`ik/gemma4` @ `584df79e`) adds the missing `iqk_fa_512_512` kernel for Gemma 4's D=512 global attention layers, unblocking q8_0 KV cache for the 26B-A4B model
- Vision suppressed on ik_llama (gemma4v projector unsupported in fork)
- Device compatibility check guards Pi 4 from auto-switching to ik_llama

## Benchmark (Pi 5 16GB, gemma-4-26B-A4B-it-UD-IQ4_NL.gguf)

| Runtime | KV cache | Prompt pp512 (t/s) | Generation tg128 (t/s) | RSS |
|---------|----------|--------------------|-----------------------|-----|
| **ik_llama** (upstream ik/gemma4) | **q8_0** | **31.40 ± 0.00** | **3.15 ± 0.04** | **13.0 GB** |
| ik_llama (spike f16 fallback) | f16 | 29.64 ± 0.15 | 3.10 ± 0.02 | ~15.9 GB |
| llama_cpp (spike baseline) | q8_0 | 8.57 ± 0.30 | 2.70 ± 0.09 | — |
| **Delta vs llama_cpp** | | **+266%** | **+17%** | |

Correctness verified: "What is 2+2?" → "Two plus two equals four."

## Test output

```
650 passed in 10.06s    (pytest unit + API)
144 passed (35.8s)      (Playwright)
```

## Pi QA

- Device: Pi 5 16GB (potato.local)
- ik_llama built from upstream `ikawrakow/ik_llama.cpp` PR #1581 branch `ik/gemma4` @ `584df79e`
- q8_0 KV cache at 4096 context: server starts, loads, generates correctly
- RSS 13.0 GB — well under the 14.5 GB target

Closes #270
Refs #268