### PR TITLE
hotfix(runtime): keep Gemma 4 E2B/E4B on llama_cpp and add benchmark results

### DIFF
--- a/core/constants/model_families.py
+++ b/core/constants/model_families.py
@@ -77,9 +77,14 @@ def _gemma4_projector_repo(filename: str | None, source_url: str | None = None) 
     return None
 
 
+def _is_gemma4_26b_a4b(filename: str | None) -> bool:
+    model_name = _normalized_model_name(filename)
+    return is_gemma4_filename(model_name) and "26b" in model_name and "a4b" in model_name
+
+
 def recommended_runtime_for_model(filename: str | None) -> str | None:
     """Return the preferred runtime family for a model, or None for no preference."""
-    if is_gemma4_filename(filename):
+    if _is_gemma4_26b_a4b(filename):
         return "ik_llama"
     return None
 

--- a/docs/benchmarks/gemma4-pi-benchmark-2026-04-04.md
+++ b/docs/benchmarks/gemma4-pi-benchmark-2026-04-04.md
@@ -1,0 +1,73 @@
+# Gemma 4 Pi Benchmark — 2026-04-04
+
+> **Status: Experimental.** Gemma 4 support on Potato OS is early-stage. The ik_llama runtime only supports 26B-A4B; E2B/E4B fall back to llama_cpp. Proper Gemma 4 support (including ByteShape quants and full ik_llama coverage) is pending upstream work.
+
+Spike: #274
+
+## Hardware
+
+| Label | Board | RAM | Storage | Runtime |
+|-------|-------|-----|---------|---------|
+| Pi 5 16GB / SD | Raspberry Pi 5 Rev 1.1 | 16 GB | SD card | llama_cpp (a1cfb64) / ik_llama (9a0a4628) |
+| Pi 5 8GB / SSD | Raspberry Pi 5 Rev 1.0 | 8 GB | NVMe SSD, 2 GB zram swap | llama_cpp (a1cfb64) / ik_llama (9a0a4628) |
+| Pi 4 8GB / SD | Raspberry Pi 4 Rev 1.4 | 8 GB | SD card, 2 GB swap | llama_cpp (a1cfb64) |
+
+## Models tested
+
+| Model | Filename | Quant | Size |
+|-------|----------|-------|------|
+| E2B | gemma-4-E2B-it-Q4_K_M.gguf | Q4_K_M | 2.88 GiB |
+| E4B | gemma-4-E4B-it-Q4_0.gguf | Q4_0 | 4.49 GiB |
+| 26B-A4B | gemma-4-26B-A4B-it-UD-IQ4_NL.gguf | IQ4_NL | 12.48 GiB |
+
+## Methodology
+
+### Multi-turn chat benchmark
+- 5-turn conversation with fixed prompts (quantum computing topic)
+- 16k context, prompt caching enabled
+- max_tokens=512 per turn, temperature=0.7, top_p=0.8
+- ~2k–2.5k total generated tokens per run
+- No parallel workloads during measurement
+
+### llama-bench
+- pp512 (prompt processing, 512 tokens) and tg128 (text generation, 128 tokens)
+- 1 repetition, no concurrent workloads
+
+## Results
+
+### Pi 5 16GB / SD
+
+| Model | Quant | Runtime | Chat gen t/s | Prompt t/s (T1 → T2+) | Chat tokens | pp512 t/s | tg128 t/s | Swap |
+|-------|-------|---------|-------------|----------------------|-------------|-----------|-----------|------|
+| E2B | Q4_K_M | llama_cpp | 6.5 | 26.1 → 29.5 | 2081 (5/5) | 28.02 | 6.71 | 669 MB |
+| E4B | Q4_0 | llama_cpp | 3.7 | 18.7 → 21.9 | 2535 (5/5) | 18.46 | 3.48 | 669 MB |
+| 26B-A4B | IQ4_NL | ik_llama | 3.0 | 9.4 → 16.3 | 2450 (5/5) | 6.38 | 2.54 | 442 MB |
+
+### Pi 5 8GB / SSD
+
+| Model | Quant | Runtime | Chat gen t/s | Prompt t/s (T1 → T2+) | Chat tokens | pp512 t/s | tg128 t/s | Swap |
+|-------|-------|---------|-------------|----------------------|-------------|-----------|-----------|------|
+| E2B | Q4_K_M | llama_cpp | 6.8 | 26.2 → 32.7 | 2079 (5/5) | 31.86 | 5.97 | 390 MB |
+| E4B | Q4_0 | llama_cpp | 3.5 | 18.6 → 23.3 | 2536 (5/5) | 25.75 | 3.26 | 493 MB |
+| 26B-A4B | IQ4_NL | ik_llama | 1.9 | 3.3 → 4.3 | 2522 (5/5) | OOM | OOM | 2047 MB (full) |
+
+### Pi 4 8GB / SD
+
+| Model | Quant | Runtime | Chat gen t/s | Prompt t/s (T1 → T2+) | Chat tokens | pp512 t/s | tg128 t/s | Swap |
+|-------|-------|---------|-------------|----------------------|-------------|-----------|-----------|------|
+| E2B | Q4_K_M | llama_cpp | 1.7 | 5.3 → 3.4 | 2077 (5/5) | 4.06 | 1.68 | 0 MB |
+| E4B | Q4_0 | llama_cpp | timeout | timeout | timeout | 2.02 | 0.87 | — |
+
+## Notes
+
+- **Prompt t/s (T1 → T2+)**: T1 is the first turn (no cached context). T2+ is the average of turns 2–5, where prior conversation history is in KV cache. Higher T2+ reflects cache reuse, not a warmup effect.
+- **ik_llama 26B-A4B only**: The ik_llama Gemma 4 WIP branch (upstream `ik/gemma4`) crashes on E2B/E4B with `GGML_ASSERT(ggml_can_repeat(b, a))`. Only 26B-A4B loads successfully. E2B/E4B fall back to llama_cpp.
+- **Pi 5 8GB 26B OOM on llama-bench**: llama-bench OOM-kills on 26B with 8 GB RAM despite mmap=1. The `universal` llama_cpp profile appears to load model weights into anonymous memory rather than file-backed pages. The chat benchmark (via llama-server) completes because Potato manages memory differently, but at 1.9 t/s with full swap.
+- **Pi 4 E4B timeout**: At 0.87 t/s generation, a single 512-token response takes ~10 minutes. The 600s per-turn timeout was exceeded.
+- **Pi 4 prompt t/s decreases on later turns**: Unlike Pi 5, Pi 4 shows slower prompt processing on later turns (5.3 → 3.4 t/s). Likely memory bandwidth saturation as the KV cache grows on the older architecture.
+
+## Open items
+
+- Upstream ik_llama Gemma 4 support for E2B/E4B (tracked in #272)
+- ByteShape quants for Gemma 4 (not yet available from upstream)
+- Investigate mmap behavior with `universal` llama_cpp profile on 8 GB devices

--- a/tests/e2e/bench_gemma4_chat.py
+++ b/tests/e2e/bench_gemma4_chat.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Gemma 4 multi-turn chat benchmark for Potato OS spike #274.
+
+Usage:
+    python3 tests/e2e/bench_gemma4_chat.py --host potato.local
+    python3 tests/e2e/bench_gemma4_chat.py --host ssd.local --port 8080
+"""
+import argparse
+import json
+import time
+import urllib.request
+import urllib.error
+
+CHAT_TURNS = [
+    "What are the main differences between classical and quantum computing? Explain in detail.",
+    "Can you explain quantum entanglement in simpler terms, with a concrete analogy?",
+    "How might quantum computing affect modern cryptography and security?",
+    "What's the current state of quantum error correction research?",
+    "Summarize the key takeaways from our conversation in bullet points.",
+]
+
+def chat_completion(host, port, messages, max_tokens=512):
+    """Send a chat completion request and return timing + response."""
+    url = f"http://{host}:{port}/v1/chat/completions"
+    payload = json.dumps({
+        "model": "default",
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "stream": False,
+    }).encode()
+
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            body = json.loads(resp.read())
+    except urllib.error.URLError as e:
+        return {"error": str(e), "wall_time": time.monotonic() - t0}
+    wall = time.monotonic() - t0
+
+    choice = body.get("choices", [{}])[0]
+    usage = body.get("usage", {})
+    timings = body.get("timings", {})
+
+    return {
+        "wall_time": round(wall, 2),
+        "prompt_tokens": usage.get("prompt_tokens", 0),
+        "completion_tokens": usage.get("completion_tokens", 0),
+        "prompt_tps": round(timings.get("prompt_per_second", 0), 2),
+        "gen_tps": round(timings.get("predicted_per_second", 0), 2),
+        "prompt_ms": round(timings.get("prompt_ms", 0), 1),
+        "gen_ms": round(timings.get("predicted_ms", 0), 1),
+        "reply": choice.get("message", {}).get("content", "")[:100],
+    }
+
+def get_status(host):
+    """Get device status."""
+    url = f"http://{host}/status"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            return json.loads(resp.read())
+    except Exception:
+        return {}
+
+def get_memory(host, sshpass="raspberry"):
+    """Get memory info via SSH."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["sshpass", "-p", sshpass, "ssh", "-o", "StrictHostKeyChecking=accept-new",
+             f"pi@{host}", "free -m | grep -E 'Mem|Swap'"],
+            capture_output=True, text=True, timeout=10
+        )
+        return result.stdout.strip()
+    except Exception:
+        return "unavailable"
+
+def run_benchmark(host, port=1983):
+    status = get_status(host)
+    model = status.get("model", {}).get("filename", "unknown")
+    rt = status.get("llama_runtime", {}).get("current", {})
+    runtime = f"{rt.get('family', '?')} ({rt.get('llama_cpp_commit', '?')})"
+
+    print(f"\n{'='*70}")
+    print(f"Host:    {host}")
+    print(f"Model:   {model}")
+    print(f"Runtime: {runtime}")
+    print(f"Memory:  {get_memory(host)}")
+    print(f"{'='*70}")
+
+    messages = []
+    total_gen = 0
+    results = []
+
+    for i, user_msg in enumerate(CHAT_TURNS):
+        messages.append({"role": "user", "content": user_msg})
+        print(f"\n--- Turn {i+1}/{len(CHAT_TURNS)} ---")
+        print(f"User: {user_msg[:80]}...")
+
+        r = chat_completion(host, port, messages, max_tokens=512)
+        if "error" in r:
+            print(f"ERROR: {r['error']}")
+            results.append(r)
+            break
+
+        total_gen += r["completion_tokens"]
+        messages.append({"role": "assistant", "content": r.get("reply", "")})
+
+        print(f"  Prompt:  {r['prompt_tokens']} tok, {r['prompt_tps']} t/s ({r['prompt_ms']}ms)")
+        print(f"  Gen:     {r['completion_tokens']} tok, {r['gen_tps']} t/s ({r['gen_ms']}ms)")
+        print(f"  Wall:    {r['wall_time']}s")
+        print(f"  Reply:   {r['reply'][:80]}...")
+        results.append(r)
+
+    print(f"\n--- Summary ---")
+    print(f"Total generated: {total_gen} tokens across {len(results)} turns")
+    if results and "gen_tps" in results[0]:
+        gen_rates = [r["gen_tps"] for r in results if "gen_tps" in r and r["gen_tps"] > 0]
+        prompt_rates = [r["prompt_tps"] for r in results if "prompt_tps" in r and r["prompt_tps"] > 0]
+        if gen_rates:
+            print(f"Gen t/s:   min={min(gen_rates)}, max={max(gen_rates)}, avg={sum(gen_rates)/len(gen_rates):.1f}")
+        if prompt_rates:
+            print(f"Prompt t/s: min={min(prompt_rates)}, max={max(prompt_rates)}, avg={sum(prompt_rates)/len(prompt_rates):.1f}")
+            if len(prompt_rates) > 1:
+                print(f"  Turn 1 prompt: {prompt_rates[0]} t/s vs Turn 2+: {sum(prompt_rates[1:])/len(prompt_rates[1:]):.1f} t/s (caching effect)")
+    print(f"Memory after: {get_memory(host)}")
+    print()
+
+    return {"host": host, "model": model, "runtime": runtime, "turns": results, "total_gen": total_gen}
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--port", type=int, default=80)
+    args = parser.parse_args()
+    run_benchmark(args.host, args.port)

--- a/tests/ui/settings.spec.js
+++ b/tests/ui/settings.spec.js
@@ -31,6 +31,11 @@ test("seed mode defaults to random, toggles deterministic, persists, and control
   await expect(seedField).toBeDisabled();
   await saveModelSettings(page);
   await closeSettingsModal(page);
+  // Wait for status poll to reflect saved generation_mode before sending
+  await expect(async () => {
+    const status = await page.evaluate(() => fetch("/status").then((r) => r.json()));
+    expect(status.model.settings.chat.generation_mode).toBe("random");
+  }).toPass({ timeout: 5000 });
   await promptField.fill("Seed random request.");
   const randomRequestPromise = page.waitForRequest("**/v1/chat/completions");
   await promptField.press("Enter");

--- a/tests/unit/test_model_families.py
+++ b/tests/unit/test_model_families.py
@@ -240,12 +240,16 @@ def test_projector_status_gemma4_finds_model_specific_on_disk(runtime):
 # ── Recommended runtime ────────────────────────────────────────────
 
 
-def test_recommended_runtime_gemma4_is_ik_llama():
-    """All Gemma 4 variants prefer ik_llama for the IQK speedup."""
-    assert recommended_runtime_for_model("gemma-4-E2B-it-Q4_K_M.gguf") == "ik_llama"
-    assert recommended_runtime_for_model("gemma-4-E4B-it-Q4_0.gguf") == "ik_llama"
+def test_recommended_runtime_gemma4_26b_a4b_is_ik_llama():
+    """Only Gemma 4 26B-A4B routes to ik_llama (E2B/E4B not yet supported upstream)."""
     assert recommended_runtime_for_model("gemma-4-26B-A4B-it-UD-IQ2_M.gguf") == "ik_llama"
     assert recommended_runtime_for_model("gemma-4-26B-A4B-it-UD-IQ4_NL.gguf") == "ik_llama"
+
+
+def test_recommended_runtime_gemma4_e2b_e4b_no_preference():
+    """Gemma 4 E2B/E4B use default runtime (ik_llama WIP doesn't support them yet)."""
+    assert recommended_runtime_for_model("gemma-4-E2B-it-Q4_K_M.gguf") is None
+    assert recommended_runtime_for_model("gemma-4-E4B-it-Q4_0.gguf") is None
 
 
 def test_recommended_runtime_qwen35_has_no_preference():


### PR DESCRIPTION
### What changed

- keeps Gemma 4 `E2B` and `E4B` on `llama_cpp` while the current temporary `ik_llama` Gemma 4 branch only supports `26B-A4B`
- leaves `26B-A4B` on `ik_llama`
- adds the Gemma 4 Pi benchmark write-up and the multi-turn chat helper used for the measurements
- hardens the flaky seed-mode Playwright check to wait for persisted settings before asserting

### Why

The current Gemma 4 `ik_llama` WIP path crashes on `E2B` and `E4B`, so routing all Gemma 4 variants there regresses working text inference. This PR narrows that runtime preference to the currently supported `26B-A4B` path and records the benchmark findings that motivated the release fix.

### Linked issues

Closes #277
Refs #274
Refs #272

### Tests run

- `uv run python -m pytest tests/unit/test_model_families.py -q`
- `npx playwright test tests/ui/settings.spec.js --reporter=dot --timeout=15000`

### Test results

- `45 passed in 0.03s`
- `14 passed (19.5s)`

### Pi QA

Real-device benchmark evidence captured in `docs/benchmarks/gemma4-pi-benchmark-2026-04-04.md`:

- Pi 5 16GB / SD
- Pi 5 8GB / SSD
- Pi 4 8GB / SD

Key outcome:
- `ik_llama` currently works for `26B-A4B`
- `E2B` and `E4B` should stay on `llama_cpp` for now
