### PR TITLE
chore(workflow): make org project board the only supported board

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ PRs must include:
 
 - `main` is merge-only. No direct commits for feature/bug/chore work.
 - Branch from `main`: `feat/issue-<id>-<slug>`, `fix/issue-<id>-<slug>`, `chore/issue-<id>-<slug>`.
+- Use the org-owned `Potato OS` board at `https://github.com/orgs/potato-os/projects/1` for all active work.
 - Board flow: Todo → In Progress → In Review → QA → Done.
 - Squash merge preferred. Delete branch after merge.
 - See `WORKFLOW.md` for full lifecycle details.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ See [Building Images](docs/building-images.md) for prerequisites, variants, flas
 
 ### Project
 
-- Board: [github.com/orgs/potato-os/projects/1](https://github.com/orgs/potato-os/projects/1)
+- Active board: [github.com/orgs/potato-os/projects/1](https://github.com/orgs/potato-os/projects/1)
 - Defaults: hostname `potato`, SSH `pi`/`raspberry`
 
 ## License

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -4,7 +4,8 @@ This is the single source of truth for how we plan, execute, and close work.
 
 ## Project Board
 
-- Board: <https://github.com/orgs/potato-os/projects/1>
+- Canonical active board: <https://github.com/orgs/potato-os/projects/1>
+- All active work, automation, and `gh project` commands must use the org-owned `potato-os` board.
 - Default status flow:
   - `Todo`
   - `In Progress`
@@ -302,6 +303,8 @@ After building a runtime on Pi, publish it so fresh installs can auto-download:
 - **Local build always wins** when `runtimes/<family>/` exists locally.
 
 ## Helpful CLI snippets
+
+These commands target the canonical org-owned `Potato OS` board.
 
 ```bash
 # Create issue


### PR DESCRIPTION
## Summary
Clarifies the repo workflow and agent guidance so the org-owned Potato OS project board is the only board used for active work.

## Why
After the repo and board move, some agents were still inferring that the old personal board was active. This change removes that ambiguity in the tracked docs.

## Verification
- `rg -n "slomin|users/slomin/projects/8|project view 8|--owner slomin|PVT_kwHOABrb5c4BP912" WORKFLOW.md README.md AGENTS.md .github docs core apps bin tests`

## Risk / rollback
- Docs-only change
- Roll back by reverting this PR if needed

Closes #285
