### PR TITLE
feat(runtime): enable LiteRT Gemma 4 vision support

### DIFF
--- a/core/litert_adapter.py
+++ b/core/litert_adapter.py
@@ -32,10 +32,32 @@ except ImportError:
 
 _engine: Any = None
 _conversation: Any = None
+_vision_enabled: bool = False
 # Tracks the messages we've already sent to the persistent conversation
 # so we can detect continuations vs new sessions.
-_conversation_history: list[dict[str, str]] = []
+_conversation_history: list[dict[str, Any]] = []
 _lock = asyncio.Lock()
+
+
+def _probe_vision_support(model_path: str) -> tuple[Any, bool]:
+    """Try to create an Engine with vision support.
+
+    Returns (engine, vision_enabled).  Falls back to text-only if the
+    current litert-lm build does not support the vision_backend kwarg
+    or if the runtime vision calculator is missing.
+    """
+    try:
+        engine = litert_lm.Engine(
+            model_path,
+            backend=litert_lm.Backend.CPU,
+            vision_backend=litert_lm.Backend.CPU,
+        )
+        logger.info("LiteRT vision probe succeeded — multimodal enabled")
+        return engine, True
+    except (TypeError, RuntimeError, Exception) as exc:
+        logger.info("LiteRT vision probe failed (%s) — text-only mode", exc)
+        engine = litert_lm.Engine(model_path, backend=litert_lm.Backend.CPU)
+        return engine, False
 
 
 def _reset_conversation() -> None:
@@ -54,7 +76,7 @@ def _reset_conversation() -> None:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    global _engine
+    global _engine, _vision_enabled
     model_path = os.environ.get("POTATO_MODEL_PATH", "")
     if not model_path:
         logger.error("POTATO_MODEL_PATH not set")
@@ -63,9 +85,9 @@ async def _lifespan(app: FastAPI):
     else:
         logger.info("Loading LiteRT engine from %s", model_path)
         try:
-            _engine = litert_lm.Engine(model_path, backend=litert_lm.Backend.CPU)
+            _engine, _vision_enabled = _probe_vision_support(model_path)
             _reset_conversation()
-            logger.info("LiteRT engine loaded successfully")
+            logger.info("LiteRT engine loaded successfully (vision=%s)", _vision_enabled)
         except Exception:
             logger.exception("Failed to load LiteRT engine")
             _engine = None
@@ -92,7 +114,7 @@ app = FastAPI(lifespan=_lifespan)
 async def health():
     if _engine is None:
         return JSONResponse(status_code=503, content={"status": "error", "reason": "engine_not_loaded"})
-    return {"status": "ok"}
+    return {"status": "ok", "vision": _vision_enabled}
 
 
 def _build_openai_response(text: str, model: str, prompt_tokens: int = 0) -> dict[str, Any]:
@@ -125,7 +147,63 @@ def _extract_text(response: Any) -> str:
     return ""
 
 
-def _messages_match(incoming: list[dict[str, str]], history: list[dict[str, str]]) -> bool:
+def _convert_openai_to_litert_content(content: str | list[dict[str, Any]]) -> str | list[dict[str, Any]]:
+    """Convert OpenAI-format multimodal content to litert-lm format.
+
+    OpenAI: [{"type": "text", ...}, {"type": "image_url", "image_url": {"url": "data:...;base64,AAAA"}}]
+    LiteRT: [{"type": "text", ...}, {"type": "image", "blob": "AAAA"}]
+
+    Only base64 data URLs are supported.  Remote URLs (https://...) are
+    rejected — LiteRT expects raw image bytes, not a URL fetch.
+    """
+    if isinstance(content, str):
+        return content
+    parts: list[dict[str, Any]] = []
+    for part in content:
+        if part.get("type") == "image_url":
+            data_url = part.get("image_url", {}).get("url", "")
+            if not data_url.startswith("data:"):
+                raise ValueError(f"Only base64 data URLs are supported for LiteRT vision, got: {data_url[:60]}")
+            blob = data_url.split(",", 1)[1] if "," in data_url else ""
+            parts.append({"type": "image", "blob": blob})
+        else:
+            parts.append(part)
+    return parts
+
+
+def _content_equal(a: str | list | None, b: str | list | None) -> bool:
+    """Compare message content that may be a string or a list of parts."""
+    return a == b
+
+
+def _has_image_content(messages: list[dict[str, Any]]) -> bool:
+    """Return True if any message contains an image_url content part."""
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if part.get("type") == "image_url":
+                    return True
+    return False
+
+
+def _estimate_prompt_chars(messages: list[dict[str, Any]]) -> int:
+    """Estimate total character count across all messages, handling multimodal."""
+    total = 0
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            total += len(content)
+        elif isinstance(content, list):
+            for part in content:
+                if part.get("type") == "text":
+                    total += len(part.get("text", ""))
+                else:
+                    total += 256  # approximate image token cost in chars
+    return total
+
+
+def _messages_match(incoming: list[dict[str, Any]], history: list[dict[str, Any]]) -> bool:
     """Check if incoming message history is a continuation of our tracked history.
 
     Returns True only when history is non-empty AND every tracked message
@@ -137,7 +215,7 @@ def _messages_match(incoming: list[dict[str, str]], history: list[dict[str, str]
     if len(history) > len(incoming):
         return False
     for prev, inc in zip(history, incoming):
-        if prev.get("role") != inc.get("role") or prev.get("content") != inc.get("content"):
+        if prev.get("role") != inc.get("role") or not _content_equal(prev.get("content"), inc.get("content")):
             return False
     return True
 
@@ -171,25 +249,34 @@ def _prepare_conversation_sync(messages: list[dict[str, str]]) -> None:
             # the preceding user turn via send_message above.
             continue
         if role == "system":
-            _conversation.send_message(f"[System instruction] {content}")
+            _conversation.send_message(f"[System instruction] {content}" if isinstance(content, str) else content)
+        elif isinstance(content, list):
+            # Multimodal: send_message expects a dict with role/content
+            converted = _convert_openai_to_litert_content(content)
+            _conversation.send_message({"role": "user", "content": converted})
         else:
             _conversation.send_message(content)
 
     _conversation_history = list(history_messages)
 
 
-def _run_inference_sync(messages: list[dict[str, str]], stream: bool) -> Any:
+def _run_inference_sync(messages: list[dict[str, Any]], stream: bool) -> Any:
     """Run inference synchronously — must be called via asyncio.to_thread."""
     _prepare_conversation_sync(messages)
 
-    final_content = messages[-1].get("content", "") if messages else ""
+    raw_content = messages[-1].get("content", "") if messages else ""
+    if isinstance(raw_content, list):
+        # Multimodal: send_message expects {"role": "user", "content": [...]}
+        final_content = {"role": "user", "content": _convert_openai_to_litert_content(raw_content)}
+    else:
+        final_content = raw_content
 
     if stream:
         return _conversation.send_message_async(final_content)
     else:
         response = _conversation.send_message(final_content)
         text = _extract_text(response)
-        # Track the full exchange in history
+        # Track the full exchange in history (store original content for matching)
         _conversation_history.append(messages[-1])
         _conversation_history.append({"role": "assistant", "content": text})
         return text
@@ -216,6 +303,13 @@ async def chat_completions(request: Request):
         return JSONResponse(
             status_code=400,
             content={"error": {"message": "messages required", "type": "invalid_request_error"}},
+        )
+
+    # Reject multimodal input when vision is not available
+    if not _vision_enabled and _has_image_content(messages):
+        return JSONResponse(
+            status_code=400,
+            content={"error": {"message": "Vision input is not supported by this model/runtime configuration", "type": "invalid_request_error"}},
         )
 
     stream = payload.get("stream", False)
@@ -289,7 +383,7 @@ async def chat_completions(request: Request):
                         predicted_ms = (now - decode_start) * 1000
                         per_token_ms = (predicted_ms / predicted_n) if predicted_n > 0 else 0
                         per_second = (predicted_n / (predicted_ms / 1000)) if predicted_ms > 0 else 0
-                        prompt_n = sum(len(m.get("content", "")) // 4 for m in messages)
+                        prompt_n = _estimate_prompt_chars(messages) // 4
 
                         stop_chunk = {
                             "id": response_id,
@@ -329,8 +423,13 @@ async def chat_completions(request: Request):
                 )
             else:
                 text = await asyncio.to_thread(_run_inference_sync, messages, False)
-                prompt_tokens = sum(len(m.get("content", "")) // 4 for m in messages)
+                prompt_tokens = _estimate_prompt_chars(messages) // 4
                 return JSONResponse(content=_build_openai_response(str(text), model_name, prompt_tokens))
+        except ValueError as ve:
+            return JSONResponse(
+                status_code=400,
+                content={"error": {"message": str(ve), "type": "invalid_request_error"}},
+            )
         except Exception:
             logger.exception("Inference error")
             return JSONResponse(

--- a/core/main.py
+++ b/core/main.py
@@ -808,6 +808,31 @@ def _build_status_fs(
     }
 
 
+async def _probe_litert_adapter_vision(runtime: RuntimeConfig) -> bool | None:
+    """Check if the running LiteRT adapter reports vision support.
+
+    Returns True/False if adapter is reachable, None if unreachable.
+    """
+    timeout = httpx.Timeout(2.0, connect=1.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(f"{runtime.llama_base_url}/health")
+        if response.status_code == 200:
+            return bool(response.json().get("vision", False))
+    except httpx.HTTPError:
+        pass
+    return None
+
+
+_LITERT_BUNDLED_PROJECTOR: dict[str, Any] = {
+    "configured_filename": None,
+    "filename": None,
+    "present": False,
+    "path": None,
+    "default_candidates": [],
+}
+
+
 async def build_status(
     runtime: RuntimeConfig,
     *,
@@ -840,6 +865,25 @@ async def build_status(
             result["backend"]["active"] = active_backend
             result["backend"]["fallback_active"] = fallback_active
             result["model_loading"] = dict(_MODEL_LOADING_INACTIVE)
+
+    # LiteRT: gate vision capabilities on adapter-reported support.
+    # When the probe returns None (adapter unreachable / restarting), preserve
+    # the existing filename-derived capabilities instead of forcing false.
+    installed_family = _detect_installed_runtime_family(runtime)
+    if installed_family == "litert":
+        litert_vision = await _probe_litert_adapter_vision(runtime)
+        if isinstance(litert_vision, bool):
+            for entry in result.get("models", []):
+                if is_gemma4_filename(str(entry.get("filename") or "")):
+                    entry["capabilities"] = dict(entry["capabilities"], vision=litert_vision)
+                    if str(entry.get("filename") or "").endswith(".litertlm"):
+                        entry["projector"] = dict(_LITERT_BUNDLED_PROJECTOR, present=litert_vision)
+            model = result.get("model")
+            if model and is_gemma4_filename(str(model.get("filename") or "")):
+                model["capabilities"] = dict(model["capabilities"], vision=litert_vision)
+                if str(model.get("filename") or "").endswith(".litertlm"):
+                    model["projector"] = dict(_LITERT_BUNDLED_PROJECTOR, present=litert_vision)
+
     return result
 
 

--- a/tests/api/test_runtime_env.py
+++ b/tests/api/test_runtime_env.py
@@ -5,7 +5,7 @@ import json
 
 from fastapi.testclient import TestClient
 
-from core.main import _runtime_env, create_app, ensure_models_state, get_runtime, save_models_state
+from core.main import _runtime_env, build_status, create_app, ensure_models_state, get_runtime, save_models_state
 from core.model_state import build_model_projector_status
 
 
@@ -570,5 +570,122 @@ def test_runtime_env_disables_gemma4_flag_when_vision_off(runtime):
     assert env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] == "0"
     assert env["POTATO_AUTO_DOWNLOAD_MMPROJ"] == "0"
     assert "POTATO_MMPROJ_PATH" not in env
+
+
+# -- LiteRT Gemma 4 vision gating in /status ------------------------------------
+
+
+def _make_litert_gemma4_runtime(runtime, model_filename="gemma-4-E2B-it.litertlm"):
+    """Set up a runtime with a LiteRT Gemma 4 model and litert installed."""
+    runtime.enable_orchestrator = True
+    model_path = runtime.base_dir / "models" / model_filename
+    model_path.write_bytes(b"litert-model")
+    runtime.model_path = model_path
+    # Install litert runtime marker
+    llama_dir = runtime.base_dir / "llama"
+    llama_dir.mkdir(parents=True, exist_ok=True)
+    (llama_dir / "runtime.json").write_text(
+        '{"family": "litert", "commit": "abc123"}',
+        encoding="utf-8",
+    )
+    runtime.models_state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "countdown_enabled": True,
+                "default_model_downloaded_once": True,
+                "active_model_id": "gemma4-litert",
+                "default_model_id": "gemma4-litert",
+                "current_download_model_id": None,
+                "models": [
+                    {
+                        "id": "gemma4-litert",
+                        "filename": model_filename,
+                        "source_url": "https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm",
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                        "settings": {
+                            "vision": {
+                                "enabled": True,
+                                "projector_mode": "default",
+                                "projector_filename": None,
+                            }
+                        },
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return runtime
+
+
+def test_status_litert_gemma4_vision_true_when_adapter_confirms(runtime, monkeypatch):
+    """When LiteRT adapter reports vision=true, /status capabilities.vision=True."""
+    _make_litert_gemma4_runtime(runtime)
+    app = create_app(runtime=runtime, enable_orchestrator=True)
+    app.dependency_overrides[get_runtime] = lambda: runtime
+
+    async def _adapter_health_vision_true(_runtime):
+        return True
+
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    monkeypatch.setattr("core.main._probe_litert_adapter_vision", _adapter_health_vision_true)
+
+    with TestClient(app) as client:
+        response = client.get("/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["model"]["capabilities"]["vision"] is True
+    gemma4_entry = next(m for m in body["models"] if m["id"] == "gemma4-litert")
+    assert gemma4_entry["capabilities"]["vision"] is True
+    # LiteRT bundles vision — projector.present should be True, no download needed
+    assert body["model"]["projector"]["present"] is True
+    assert body["model"]["projector"]["default_candidates"] == []
+
+
+def test_status_litert_gemma4_vision_false_when_adapter_denies(runtime, monkeypatch):
+    """When LiteRT adapter reports vision=false, /status capabilities.vision=False."""
+    _make_litert_gemma4_runtime(runtime)
+    app = create_app(runtime=runtime, enable_orchestrator=True)
+    app.dependency_overrides[get_runtime] = lambda: runtime
+
+    async def _adapter_health_vision_false(_runtime):
+        return False
+
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    monkeypatch.setattr("core.main._probe_litert_adapter_vision", _adapter_health_vision_false)
+
+    with TestClient(app) as client:
+        response = client.get("/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["model"]["capabilities"]["vision"] is False
+    gemma4_entry = next(m for m in body["models"] if m["id"] == "gemma4-litert")
+    assert gemma4_entry["capabilities"]["vision"] is False
+
+
+def test_status_litert_preserves_vision_when_adapter_unreachable(runtime, monkeypatch):
+    """When adapter is unreachable (probe returns None), preserve filename-derived capabilities."""
+    _make_litert_gemma4_runtime(runtime)
+    app = create_app(runtime=runtime, enable_orchestrator=True)
+    app.dependency_overrides[get_runtime] = lambda: runtime
+
+    async def _adapter_unreachable(_runtime):
+        return None
+
+    monkeypatch.setattr("core.main.check_llama_health", _healthy_true)
+    monkeypatch.setattr("core.main._probe_litert_adapter_vision", _adapter_unreachable)
+
+    with TestClient(app) as client:
+        response = client.get("/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    # Gemma 4 is vision-capable by filename — should NOT be downgraded to false
+    assert body["model"]["capabilities"]["vision"] is True
 
 

--- a/tests/ui/settings.spec.js
+++ b/tests/ui/settings.spec.js
@@ -1007,3 +1007,133 @@ test("add model by URL shows inline validation feedback", async ({ page }) => {
   await expect(page.locator("#modelUrlInput")).toHaveValue("http://example.com/bad-model.gguf");
 });
 
+
+test("litert-backed vision model shows Vision chip and enables image upload", async ({ page }) => {
+  await page.route("**/v1/chat/completions", (route) => fulfillStreamingChat(route));
+  await page.route("**/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(makeStatusPayload({
+        model: {
+          filename: "gemma-4-E2B-it.litertlm",
+          active_model_id: "gemma4-litert",
+          settings: {
+            chat: {
+              system_prompt: "", stream: true, generation_mode: "random", seed: 42,
+              temperature: 0.7, top_p: 0.8, top_k: 20, repetition_penalty: 1.0,
+              presence_penalty: 1.5, max_tokens: 16384, cache_prompt: true,
+            },
+            vision: { enabled: true, projector_mode: "default", projector_filename: "" },
+          },
+          capabilities: { vision: true },
+          projector: { present: true, filename: null, default_candidates: [] },
+        },
+        models: [
+          {
+            id: "gemma4-litert",
+            filename: "gemma-4-E2B-it.litertlm",
+            source_url: null, source_type: "local_file",
+            status: "ready", is_active: true,
+            settings: {
+              chat: {
+                system_prompt: "", stream: true, generation_mode: "random", seed: 42,
+                temperature: 0.7, top_p: 0.8, top_k: 20, repetition_penalty: 1.0,
+                presence_penalty: 1.5, max_tokens: 16384, cache_prompt: true,
+              },
+              vision: { enabled: true, projector_mode: "default", projector_filename: "" },
+            },
+            capabilities: { vision: true },
+            projector: { present: true, filename: null, default_candidates: [] },
+            bytes_total: 0, bytes_downloaded: 0, percent: 0, error: null,
+          },
+        ],
+        llama_runtime: {
+          current: { family: "litert", runtime_type: "litert_adapter", has_server_binary: false },
+          available_runtimes: [
+            { family: "litert", runtime_type: "litert_adapter", is_active: true, compatible: true },
+          ],
+          switch: { active: false, target_family: null, error: null },
+          memory_loading: { mode: "auto", label: "Automatic", no_mmap_env: "0" },
+          large_model_override: { enabled: false },
+        },
+      })),
+    });
+  });
+
+  await waitUntilReady(page);
+  await openSettingsModal(page);
+
+  await page.locator('#modelsList .model-row[data-model-id="gemma4-litert"]').click();
+  await expect(page.locator("#modelCapabilitiesChips")).toContainText("Vision");
+  await expect(page.locator("#modelCapabilitiesChips")).not.toContainText("Text only");
+
+  await closeSettingsModal(page);
+  await expect(page.locator("#attachImageBtn")).toBeEnabled();
+});
+
+
+test("litert-backed text-only model shows Text only chip and disables image upload", async ({ page }) => {
+  await page.route("**/v1/chat/completions", (route) => fulfillStreamingChat(route));
+  await page.route("**/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(makeStatusPayload({
+        model: {
+          filename: "gemma-4-E2B-it.litertlm",
+          active_model_id: "gemma4-litert",
+          settings: {
+            chat: {
+              system_prompt: "", stream: true, generation_mode: "random", seed: 42,
+              temperature: 0.7, top_p: 0.8, top_k: 20, repetition_penalty: 1.0,
+              presence_penalty: 1.5, max_tokens: 16384, cache_prompt: true,
+            },
+            vision: { enabled: true, projector_mode: "default", projector_filename: "" },
+          },
+          capabilities: { vision: false },
+          projector: { present: false, filename: null, default_candidates: [] },
+        },
+        models: [
+          {
+            id: "gemma4-litert",
+            filename: "gemma-4-E2B-it.litertlm",
+            source_url: null, source_type: "local_file",
+            status: "ready", is_active: true,
+            settings: {
+              chat: {
+                system_prompt: "", stream: true, generation_mode: "random", seed: 42,
+                temperature: 0.7, top_p: 0.8, top_k: 20, repetition_penalty: 1.0,
+                presence_penalty: 1.5, max_tokens: 16384, cache_prompt: true,
+              },
+              vision: { enabled: true, projector_mode: "default", projector_filename: "" },
+            },
+            capabilities: { vision: false },
+            projector: { present: false, filename: null, default_candidates: [] },
+            bytes_total: 0, bytes_downloaded: 0, percent: 0, error: null,
+          },
+        ],
+        llama_runtime: {
+          current: { family: "litert", runtime_type: "litert_adapter", has_server_binary: false },
+          available_runtimes: [
+            { family: "litert", runtime_type: "litert_adapter", is_active: true, compatible: true },
+          ],
+          switch: { active: false, target_family: null, error: null },
+          memory_loading: { mode: "auto", label: "Automatic", no_mmap_env: "0" },
+          large_model_override: { enabled: false },
+        },
+      })),
+    });
+  });
+
+  await waitUntilReady(page);
+  await openSettingsModal(page);
+
+  await page.locator('#modelsList .model-row[data-model-id="gemma4-litert"]').click();
+  await expect(page.locator("#modelCapabilitiesChips")).toContainText("Text only");
+  await expect(page.locator("#modelCapabilitiesChips")).not.toContainText("Vision");
+
+  await closeSettingsModal(page);
+  await expect(page.locator("#attachImageBtn")).toBeDisabled();
+});
+

--- a/tests/unit/test_litert_adapter.py
+++ b/tests/unit/test_litert_adapter.py
@@ -13,7 +13,7 @@ class _FakeConversation:
     """Mock LiteRT-LM Conversation with send_message / send_message_async."""
 
     def __init__(self):
-        self._history: list[str] = []
+        self._history: list = []
 
     def __enter__(self):
         return self
@@ -21,13 +21,15 @@ class _FakeConversation:
     def __exit__(self, *_args):
         pass
 
-    def send_message(self, msg: str) -> dict:
+    def send_message(self, msg) -> dict:
         self._history.append(msg)
-        return {"content": [{"type": "text", "text": f"Reply to: {msg[:20]}"}]}
+        label = str(msg)[:20] if isinstance(msg, str) else "multimodal"
+        return {"content": [{"type": "text", "text": f"Reply to: {label}"}]}
 
-    def send_message_async(self, msg: str):
+    def send_message_async(self, msg):
         self._history.append(msg)
-        for word in f"Reply to {msg[:10]}".split():
+        label = str(msg)[:10] if isinstance(msg, str) else "image"
+        for word in f"Reply to {label}".split():
             yield {"content": [{"type": "text", "text": word + " "}]}
 
 
@@ -252,3 +254,262 @@ def test_chat_completion_rejects_empty_messages(client):
         json={"messages": []},
     )
     assert response.status_code == 400
+
+
+# -- LiteRT vision support tests ------------------------------------------------
+
+
+def test_health_reports_vision_false_by_default(client):
+    """When engine loaded without vision, /health reports vision=false."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["vision"] is False
+
+
+def test_health_reports_vision_true_when_probe_succeeds(_mock_litert_lm, client):
+    """When vision probe succeeded, /health reports vision=true."""
+    _mock_litert_lm._vision_enabled = True
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["vision"] is True
+
+
+def test_vision_probe_falls_back_to_text_only_engine(_mock_litert_lm):
+    """_probe_vision_support catches failures and returns (engine, False)."""
+    # Make Engine raise TypeError when vision_backend is passed (simulates
+    # litert_lm version that doesn't support the kwarg).
+    original_engine_cls = _mock_litert_lm.litert_lm.Engine
+
+    class _VisionUnsupportedEngine:
+        def __init__(self, model_path="", backend=None, **kwargs):
+            if "vision_backend" in kwargs:
+                raise TypeError("unexpected keyword argument 'vision_backend'")
+            self.model_path = model_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def create_conversation(self, **kwargs):
+            return _FakeConversation()
+
+    _mock_litert_lm.litert_lm.Engine = _VisionUnsupportedEngine
+    try:
+        engine, vision = _mock_litert_lm._probe_vision_support("test.litertlm")
+        assert engine is not None
+        assert vision is False
+    finally:
+        _mock_litert_lm.litert_lm.Engine = original_engine_cls
+
+
+def test_vision_probe_succeeds_when_engine_accepts_vision_backend(_mock_litert_lm):
+    """_probe_vision_support returns (engine, True) when Engine accepts vision_backend."""
+
+    class _VisionEngine:
+        def __init__(self, model_path="", backend=None, vision_backend=None):
+            self.model_path = model_path
+            self.vision_backend = vision_backend
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def create_conversation(self, **kwargs):
+            return _FakeConversation()
+
+    _mock_litert_lm.litert_lm.Engine = _VisionEngine
+    try:
+        engine, vision = _mock_litert_lm._probe_vision_support("test.litertlm")
+        assert engine is not None
+        assert vision is True
+    finally:
+        _mock_litert_lm.litert_lm.Engine = _FakeEngine
+
+
+def test_multimodal_message_converted_to_litert_format(_mock_litert_lm):
+    """OpenAI image_url content parts are converted to litert-lm blob format."""
+    openai_content = [
+        {"type": "text", "text": "Describe this image:"},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+    ]
+    result = _mock_litert_lm._convert_openai_to_litert_content(openai_content)
+    assert isinstance(result, list)
+    assert result[0] == {"type": "text", "text": "Describe this image:"}
+    assert result[1] == {"type": "image", "blob": "AAAA"}
+
+
+def test_multimodal_inference_sends_dict_message_to_engine(_mock_litert_lm, client):
+    """Multimodal content is wrapped as {role, content} dict for send_message."""
+    _mock_litert_lm._vision_enabled = True
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is this?"},
+                        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+                    ],
+                }
+            ],
+            "stream": False,
+        },
+    )
+    # The last send_message call should receive a dict with role/content
+    last_sent = _mock_litert_lm._conversation._history[-1]
+    assert isinstance(last_sent, dict)
+    assert last_sent["role"] == "user"
+    assert isinstance(last_sent["content"], list)
+    assert last_sent["content"][1] == {"type": "image", "blob": "AAAA"}
+
+
+def test_base64_extracted_from_data_url(_mock_litert_lm):
+    """data:image/png;base64,<data> is correctly split to extract the blob."""
+    content = [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="}},
+    ]
+    result = _mock_litert_lm._convert_openai_to_litert_content(content)
+    assert result[0]["blob"] == "iVBORw0KGgo="
+
+
+def test_remote_image_url_rejected(_mock_litert_lm):
+    """Remote https:// image URLs are rejected with ValueError."""
+    content = [
+        {"type": "image_url", "image_url": {"url": "https://example.com/photo.jpg"}},
+    ]
+    with pytest.raises(ValueError, match="Only base64 data URLs"):
+        _mock_litert_lm._convert_openai_to_litert_content(content)
+
+
+def test_structured_text_only_content_accepted_without_vision(_mock_litert_lm, client):
+    """Text-only structured content [{"type":"text","text":"hi"}] must not be rejected."""
+    _mock_litert_lm._vision_enabled = False
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello"}],
+                }
+            ],
+            "stream": False,
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_text_only_content_passes_through_unchanged(_mock_litert_lm):
+    """Plain string content is returned as-is."""
+    result = _mock_litert_lm._convert_openai_to_litert_content("Hello, world!")
+    assert result == "Hello, world!"
+
+
+def test_multimodal_message_rejected_when_vision_disabled(_mock_litert_lm, client):
+    """When vision is not available, multimodal messages return 400."""
+    _mock_litert_lm._vision_enabled = False
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is this?"},
+                        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+                    ],
+                }
+            ],
+            "stream": False,
+        },
+    )
+    assert response.status_code == 400
+    assert "vision" in response.json()["error"]["message"].lower()
+
+
+def test_multimodal_message_accepted_when_vision_enabled(_mock_litert_lm, client):
+    """When vision is enabled, multimodal messages are accepted."""
+    _mock_litert_lm._vision_enabled = True
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is this?"},
+                        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+                    ],
+                }
+            ],
+            "stream": False,
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_messages_match_handles_multimodal_content(_mock_litert_lm):
+    """_messages_match works correctly with content-as-list."""
+    multimodal_msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What is this?"},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+        ],
+    }
+    history = [multimodal_msg, {"role": "assistant", "content": "It's a photo."}]
+    incoming = [
+        multimodal_msg,
+        {"role": "assistant", "content": "It's a photo."},
+        {"role": "user", "content": "Tell me more."},
+    ]
+    assert _mock_litert_lm._messages_match(incoming, history) is True
+
+
+def test_conversation_history_tracks_multimodal_messages(_mock_litert_lm, client):
+    """After a multimodal turn, history stores content list correctly."""
+    _mock_litert_lm._vision_enabled = True
+    multimodal_msg = [
+        {"type": "text", "text": "What is this?"},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+    ]
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "messages": [{"role": "user", "content": multimodal_msg}],
+            "stream": False,
+        },
+    )
+    assert len(_mock_litert_lm._conversation_history) == 2
+    assert isinstance(_mock_litert_lm._conversation_history[0]["content"], list)
+
+
+def test_prompt_token_estimate_handles_multimodal_content(_mock_litert_lm, client):
+    """Token estimation doesn't crash when content is a list of parts."""
+    _mock_litert_lm._vision_enabled = True
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this."},
+                        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,AAAA"}},
+                    ],
+                }
+            ],
+            "stream": False,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["usage"]["prompt_tokens"] >= 0


### PR DESCRIPTION
## Summary
Enables Gemma 4 E2B/E4B vision on the LiteRT path by probing adapter vision support, surfacing the correct capability state in /status, and converting OpenAI-compatible multimodal requests into LiteRT message content.

## Why
Potato already supports LiteRT text models. This completes the smaller Gemma 4 multimodal path so supported LiteRT models can accept image input without breaking text-only configurations or clearing pending attachments during transient adapter outages.

## Test plan
- uv run python -m pytest tests/unit/test_litert_adapter.py tests/api/test_runtime_env.py tests/api/test_chat_proxy.py -q
- npx playwright test tests/ui/settings.spec.js --reporter=dot --timeout=15000

## Results
- 59 passed in 1.80s
- 16 passed (20.7s)

## QA
- LiteRT adapter deployed and validated for Gemma 4 E2B/E4B vision
- Adapter-unreachable state preserves existing vision capability instead of downgrading to text-only
- Structured text-part messages remain accepted, and remote image URLs fail with a clear 400

Closes #290
Refs #288