### PR TITLE
feat(inferno): extract model registry and projector management into core/inferno

### DIFF
--- a/core/inferno/__init__.py
+++ b/core/inferno/__init__.py
@@ -1,7 +1,8 @@
 """Inferno -- Potato OS inference layer.
 
 Inferno owns the runtime-facing side of inference: backend proxying,
-model family classification, and adapter processes.  Everything between
+model family classification, model registry, settings normalization,
+projector management, and adapter processes.  Everything between
 "Potato says run this model" and "here is the OpenAI-compatible response"
 lives here.
 
@@ -13,6 +14,7 @@ Potato (caller) provides:
     - Model filename and optional source URL (for projector resolution)
     - POTATO_MODEL_PATH env var (for LiteRT adapter startup)
     - Hardware/device/OS inputs (memory, device class, runtime binaries)
+    - ModelStoreConfig with filesystem paths and product-level defaults
 
 Inferno (this package) provides:
     - BackendProxyError            exception for proxy failures
@@ -25,6 +27,12 @@ Inferno (this package) provides:
     - is_gemma4_filename           detect Gemma 4 model files
     - projector_repo_for_model     resolve HuggingFace projector repo
     - recommended_runtime_for_model  preferred runtime family for a model
+    - build_llama_server_args      pure function to build CLI args
+    - ModelStoreConfig             filesystem/policy config for registry ops
+    - Model registry functions     ensure/save/register/delete/update state
+    - Format handling              model_format_for_filename, validate_model_url
+    - Settings normalization       normalize_model_settings, build_model_capabilities
+    - Projector management         build_model_projector_status, download, candidates
     - litert_adapter               standalone FastAPI app (core.inferno.litert_adapter:app)
 
 Inferno does NOT import from core.model_state, core.runtime_state,
@@ -42,10 +50,40 @@ from .backend import (
 )
 from .launch_config import build_llama_server_args
 from .model_families import (
+    build_model_projector_status,
+    default_projector_candidates_for_model,
     is_gemma4_filename,
     is_qwen35_filename,
     projector_repo_for_model,
     recommended_runtime_for_model,
+)
+from .model_registry import (
+    DEFAULT_MODEL_CHAT_SETTINGS,
+    DEFAULT_MODEL_VISION_SETTINGS,
+    MODELS_STATE_VERSION,
+    VALID_MODEL_EXTENSIONS,
+    ModelSettingsValidationError,
+    ModelStoreConfig,
+    any_model_ready,
+    apply_model_chat_defaults,
+    build_model_capabilities,
+    delete_model,
+    describe_model_storage,
+    discover_local_model_filenames,
+    download_default_projector_for_model,
+    ensure_models_state,
+    get_model_by_id,
+    is_qwen35_a3b_filename,
+    model_file_path,
+    model_file_present,
+    model_format_for_filename,
+    model_supports_vision_filename,
+    normalize_model_settings,
+    register_model_url,
+    resolve_model_runtime_path,
+    save_models_state,
+    update_model_settings,
+    validate_model_url,
 )
 
 __all__ = [
@@ -53,11 +91,39 @@ __all__ = [
     "BackendResponse",
     "ChatCompletionRepository",
     "ChatRepositoryManager",
+    "DEFAULT_MODEL_CHAT_SETTINGS",
+    "DEFAULT_MODEL_VISION_SETTINGS",
     "FakeLlamaRepository",
     "LlamaCppRepository",
+    "MODELS_STATE_VERSION",
+    "ModelSettingsValidationError",
+    "ModelStoreConfig",
+    "VALID_MODEL_EXTENSIONS",
+    "any_model_ready",
+    "apply_model_chat_defaults",
     "build_llama_server_args",
+    "build_model_capabilities",
+    "build_model_projector_status",
+    "default_projector_candidates_for_model",
+    "delete_model",
+    "describe_model_storage",
+    "discover_local_model_filenames",
+    "download_default_projector_for_model",
+    "ensure_models_state",
+    "get_model_by_id",
     "is_gemma4_filename",
+    "is_qwen35_a3b_filename",
     "is_qwen35_filename",
+    "model_file_path",
+    "model_file_present",
+    "model_format_for_filename",
+    "model_supports_vision_filename",
+    "normalize_model_settings",
     "projector_repo_for_model",
     "recommended_runtime_for_model",
+    "register_model_url",
+    "resolve_model_runtime_path",
+    "save_models_state",
+    "update_model_settings",
+    "validate_model_url",
 ]

--- a/core/inferno/model_families.py
+++ b/core/inferno/model_families.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import re
-from typing import Final
+from pathlib import Path
+from typing import Any, Final
 
 QWEN35_PROJECTOR_REPO_RULES: Final[tuple[tuple[tuple[str, ...], str], ...]] = (
     (("35b", "a3b", "hauhaucs"), "HauhauCS/Qwen3.5-35B-A3B-Uncensored-HauhauCS-Aggressive"),
@@ -96,3 +97,93 @@ def projector_repo_for_model(filename: str | None, source_url: str | None = None
         _qwen35_projector_repo(filename, source_url=source_url)
         or _gemma4_projector_repo(filename, source_url=source_url)
     )
+
+
+# ---------------------------------------------------------------------------
+# Vision family detection & projector candidates
+# ---------------------------------------------------------------------------
+
+
+def _is_vision_family(filename: str) -> bool:
+    """Return True if the filename belongs to a curated vision model family."""
+    model_name = filename.strip().lower()
+    if "qwen" in model_name and "3.5" in model_name:
+        return True
+    return is_gemma4_filename(model_name)
+
+
+def default_projector_candidates_for_model(filename: str | None) -> list[str]:
+    """Return ordered list of mmproj filename candidates for a given model."""
+    model_name = str(filename or "").strip()
+    if not model_name or not _is_vision_family(model_name):
+        return []
+
+    stem = Path(model_name).stem
+    stem_candidates = [stem]
+    trimmed_stem = stem
+    while True:
+        next_stem = re.sub(
+            r"-(?:UD-)?(?:\d+(?:\.\d+)?bpw|I?Q\d+(?:_[A-Za-z0-9]+)*|MXFP\d+_MOE)$",
+            "",
+            trimmed_stem,
+            flags=re.IGNORECASE,
+        )
+        if next_stem == trimmed_stem or not next_stem:
+            break
+        trimmed_stem = next_stem
+        if trimmed_stem not in stem_candidates:
+            stem_candidates.append(trimmed_stem)
+
+    candidates: list[str] = []
+    # Model-specific candidates first (f16 preferred, bf16 fallback),
+    # then generic F16 last. This ensures a downloaded model-specific
+    # bf16 projector is found before a stale generic F16.
+    for precision in ("f16", "bf16"):
+        for candidate_stem in stem_candidates:
+            candidate_name = f"mmproj-{candidate_stem}-{precision}.gguf"
+            if candidate_name not in candidates:
+                candidates.append(candidate_name)
+    if "mmproj-F16.gguf" not in candidates:
+        candidates.append("mmproj-F16.gguf")
+    return candidates
+
+
+def build_model_projector_status(models_dir: Path, model: dict[str, Any]) -> dict[str, Any]:
+    """Build projector status for a model (presence, path, candidates)."""
+    from .model_registry import normalize_model_settings
+
+    filename = str(model.get("filename") or "")
+    settings = normalize_model_settings(model.get("settings"), filename=filename)
+    vision = settings.get("vision", {})
+    projector_mode = str(vision.get("projector_mode") or "default").strip().lower()
+    configured_filename = str(vision.get("projector_filename") or "").strip() or None
+    default_candidates = default_projector_candidates_for_model(filename)
+    search_names: list[str] = []
+    if projector_mode == "custom":
+        if configured_filename:
+            search_names.append(configured_filename)
+    else:
+        for candidate in default_candidates:
+            if candidate not in search_names:
+                search_names.append(candidate)
+        if configured_filename and configured_filename not in search_names:
+            search_names.append(configured_filename)
+
+    resolved_name = configured_filename
+    present = False
+    resolved_path = None
+    for candidate in search_names:
+        candidate_path = models_dir / candidate
+        if candidate_path.exists():
+            present = True
+            resolved_name = candidate
+            resolved_path = candidate_path
+            break
+
+    return {
+        "configured_filename": configured_filename,
+        "filename": resolved_name,
+        "present": present,
+        "path": str(resolved_path) if resolved_path is not None else None,
+        "default_candidates": default_candidates,
+    }

--- a/core/inferno/model_registry.py
+++ b/core/inferno/model_registry.py
@@ -1,0 +1,807 @@
+"""Model registry, format handling, and settings normalization for Inferno.
+
+This module owns the model lifecycle logic that is inference-owned:
+format detection, URL validation, filename sanitization, settings
+normalization, registry CRUD, file operations, and projector download.
+
+Product-specific defaults (device class, default model selection) are
+injected via ModelStoreConfig — this module never imports from
+core.model_state, core.runtime_state, or any Potato-specific code.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+logger = __import__("logging").getLogger("potato")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_MODEL_EXTENSIONS = (".gguf", ".litertlm")
+
+MODELS_STATE_VERSION = 1
+
+DEFAULT_MODEL_CHAT_SETTINGS = {
+    "temperature": 0.7,
+    "top_p": 0.8,
+    "top_k": 20,
+    "repetition_penalty": 1.0,
+    "presence_penalty": 1.5,
+    "max_tokens": 16384,
+    "stream": True,
+    "generation_mode": "random",
+    "seed": 42,
+    "system_prompt": "",
+    "cache_prompt": True,
+}
+
+DEFAULT_MODEL_VISION_SETTINGS = {
+    "enabled": False,
+    "projector_mode": "default",
+    "projector_filename": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Store configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ModelStoreConfig:
+    """Filesystem and product-policy context for model registry operations.
+
+    This bundles the paths and defaults that the Potato layer injects so
+    that Inferno never needs to import RuntimeConfig.
+    """
+
+    models_dir: Path
+    state_path: Path
+    default_filename: str
+    default_url: str
+    known_default_filenames: tuple[str, ...]
+    current_model_filename: str
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ModelSettingsValidationError(ValueError):
+    def __init__(self, field: str) -> None:
+        super().__init__(field)
+        self.field = field
+
+
+# ---------------------------------------------------------------------------
+# Format detection & URL validation
+# ---------------------------------------------------------------------------
+
+
+def model_format_for_filename(filename: str) -> str:
+    if filename.lower().endswith(".litertlm"):
+        return "litertlm"
+    return "gguf"
+
+
+def _has_valid_model_extension(filename: str) -> bool:
+    lower = filename.lower()
+    return any(lower.endswith(ext) for ext in VALID_MODEL_EXTENSIONS)
+
+
+def validate_model_url(source_url: str) -> tuple[bool, str, str]:
+    from urllib.parse import unquote, urlparse
+
+    parsed = urlparse(source_url.strip())
+    if parsed.scheme != "https":
+        return False, "https_required", ""
+    basename = unquote(Path(parsed.path).name)
+    if not basename:
+        return False, "filename_missing", ""
+    if not _has_valid_model_extension(basename):
+        return False, "unsupported_model_format", ""
+    safe_name = _sanitize_filename(basename)
+    if not _has_valid_model_extension(safe_name):
+        safe_name = f"{Path(safe_name).stem}.gguf"
+    return True, "", safe_name
+
+
+# ---------------------------------------------------------------------------
+# Filename / ID utilities
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_filename(filename: str) -> str:
+    candidate = Path(filename).name.strip()
+    candidate = re.sub(r"[^A-Za-z0-9._-]+", "-", candidate)
+    candidate = candidate.lstrip(".")
+    return candidate or "model.gguf"
+
+
+def _slugify_id(raw: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    return slug or "model"
+
+
+def _unique_model_id(base_id: str, existing_ids: set[str]) -> str:
+    candidate = base_id
+    idx = 2
+    while candidate in existing_ids:
+        candidate = f"{base_id}-{idx}"
+        idx += 1
+    return candidate
+
+
+def _unique_filename(base_name: str, existing_names: set[str]) -> str:
+    stem = Path(base_name).stem
+    suffix = Path(base_name).suffix or ".gguf"
+    candidate = f"{stem}{suffix}"
+    idx = 2
+    while candidate in existing_names:
+        candidate = f"{stem}-{idx}{suffix}"
+        idx += 1
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Model detection
+# ---------------------------------------------------------------------------
+
+
+def is_qwen35_a3b_filename(filename: str | None) -> bool:
+    value = str(filename or "").strip().lower()
+    return bool(value) and "qwen" in value and "3.5" in value and "35b" in value and "a3b" in value
+
+
+def model_supports_vision_filename(filename: str | None) -> bool:
+    value = str(filename or "").strip().lower()
+    if not value:
+        return False
+    if "qwen3" in value and "vl" in value:
+        return True
+    if "qwen" in value and "3.5" in value:
+        return True
+    from .model_families import is_gemma4_filename
+
+    if is_gemma4_filename(value):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Settings normalization
+# ---------------------------------------------------------------------------
+
+
+def _coerce_float_setting(raw_value: Any, *, field: str, default: float) -> float:
+    value = default if raw_value is None else raw_value
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ModelSettingsValidationError(field) from exc
+
+
+def _coerce_int_setting(raw_value: Any, *, field: str, default: int) -> int:
+    value = default if raw_value is None else raw_value
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ModelSettingsValidationError(field) from exc
+
+
+def _normalize_chat_settings(raw_value: Any) -> dict[str, Any]:
+    raw = raw_value if isinstance(raw_value, dict) else {}
+    return {
+        "temperature": _coerce_float_setting(
+            raw.get("temperature"),
+            field="chat.temperature",
+            default=DEFAULT_MODEL_CHAT_SETTINGS["temperature"],
+        ),
+        "top_p": _coerce_float_setting(
+            raw.get("top_p"),
+            field="chat.top_p",
+            default=DEFAULT_MODEL_CHAT_SETTINGS["top_p"],
+        ),
+        "top_k": _coerce_int_setting(
+            raw.get("top_k"),
+            field="chat.top_k",
+            default=DEFAULT_MODEL_CHAT_SETTINGS["top_k"],
+        ),
+        "repetition_penalty": _coerce_float_setting(
+            raw.get("repetition_penalty"),
+            field="chat.repetition_penalty",
+            default=DEFAULT_MODEL_CHAT_SETTINGS["repetition_penalty"],
+        ),
+        "presence_penalty": _coerce_float_setting(
+            raw.get("presence_penalty"),
+            field="chat.presence_penalty",
+            default=DEFAULT_MODEL_CHAT_SETTINGS["presence_penalty"],
+        ),
+        "max_tokens": _coerce_int_setting(
+            raw.get("max_tokens"),
+            field="chat.max_tokens",
+            default=DEFAULT_MODEL_CHAT_SETTINGS["max_tokens"],
+        ),
+        "stream": bool(raw.get("stream", DEFAULT_MODEL_CHAT_SETTINGS["stream"])),
+        "generation_mode": (
+            "deterministic"
+            if str(raw.get("generation_mode", DEFAULT_MODEL_CHAT_SETTINGS["generation_mode"])).strip().lower() == "deterministic"
+            else "random"
+        ),
+        "seed": _coerce_int_setting(
+            raw.get("seed"),
+            field="chat.seed",
+            default=DEFAULT_MODEL_CHAT_SETTINGS["seed"],
+        ),
+        "system_prompt": str(raw.get("system_prompt", DEFAULT_MODEL_CHAT_SETTINGS["system_prompt"]) or ""),
+        "cache_prompt": bool(raw.get("cache_prompt", DEFAULT_MODEL_CHAT_SETTINGS["cache_prompt"])),
+    }
+
+
+def _normalize_vision_settings(raw_value: Any, *, filename: str) -> dict[str, Any]:
+    raw = raw_value if isinstance(raw_value, dict) else {}
+    default_enabled = model_supports_vision_filename(filename)
+    projector_filename_raw = raw.get("projector_filename")
+    projector_filename = None
+    if projector_filename_raw is not None:
+        value = str(projector_filename_raw).strip()
+        projector_filename = value or None
+    projector_mode = str(raw.get("projector_mode", DEFAULT_MODEL_VISION_SETTINGS["projector_mode"]) or "default").strip().lower()
+    if projector_mode not in {"default", "custom"}:
+        projector_mode = "default"
+    return {
+        "enabled": bool(raw.get("enabled", default_enabled)),
+        "projector_mode": projector_mode,
+        "projector_filename": projector_filename,
+    }
+
+
+def normalize_model_settings(raw_value: Any, *, filename: str) -> dict[str, Any]:
+    raw = raw_value if isinstance(raw_value, dict) else {}
+    return {
+        "chat": _normalize_chat_settings(raw.get("chat")),
+        "vision": _normalize_vision_settings(raw.get("vision"), filename=filename),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Capabilities
+# ---------------------------------------------------------------------------
+
+
+def build_model_capabilities(filename: str | None) -> dict[str, Any]:
+    return {
+        "vision": model_supports_vision_filename(filename),
+    }
+
+
+def apply_model_chat_defaults(payload: dict[str, Any], *, active_model_filename: str | None) -> dict[str, Any]:
+    if not is_qwen35_a3b_filename(active_model_filename):
+        return payload
+
+    chat_template_kwargs = payload.get("chat_template_kwargs")
+    if isinstance(chat_template_kwargs, dict) and "enable_thinking" in chat_template_kwargs:
+        return payload
+
+    updated = dict(payload)
+    if isinstance(chat_template_kwargs, dict):
+        merged = dict(chat_template_kwargs)
+    else:
+        merged = {}
+    merged["enable_thinking"] = False
+    updated["chat_template_kwargs"] = merged
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Registry queries (pure)
+# ---------------------------------------------------------------------------
+
+
+def get_model_by_id(state: dict[str, Any], model_id: str) -> dict[str, Any] | None:
+    for item in state.get("models", []):
+        if isinstance(item, dict) and item.get("id") == model_id:
+            return item
+    return None
+
+
+def _is_discoverable_local_model_filename(filename: str) -> bool:
+    name = _sanitize_filename(filename)
+    if not _has_valid_model_extension(name):
+        return False
+    stem = Path(name).stem.lower()
+    if stem.startswith("mmproj") or "mmproj" in stem:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Atomic write utility
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        import tempfile
+
+        fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(payload))
+        os.replace(tmp_name, path)
+    except OSError:
+        logger.warning("Could not persist JSON state to %s", path, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# File / path operations
+# ---------------------------------------------------------------------------
+
+
+def model_file_path(models_dir: Path, filename: str) -> Path:
+    return models_dir / filename
+
+
+def model_file_present(models_dir: Path, filename: str) -> bool:
+    path = model_file_path(models_dir, filename)
+    try:
+        return path.exists() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
+def describe_model_storage(models_dir: Path, filename: str) -> dict[str, Any]:
+    path = model_file_path(models_dir, filename)
+    size_bytes = 0
+    exists = False
+
+    try:
+        exists = path.exists()
+    except OSError:
+        exists = False
+
+    if exists:
+        try:
+            size_bytes = max(0, int(path.stat().st_size))
+        except OSError:
+            size_bytes = 0
+
+    return {
+        "location": "local",
+        "size_bytes": size_bytes,
+        "exists": exists,
+    }
+
+
+def resolve_model_runtime_path(models_dir: Path, filename: str) -> Path:
+    """Return the real filesystem path for a model, resolving symlinks."""
+    path = model_file_path(models_dir, filename)
+    try:
+        if path.is_symlink():
+            return path.resolve(strict=False)
+    except OSError:
+        return path
+    return path
+
+
+def discover_local_model_filenames(models_dir: Path) -> list[str]:
+    try:
+        children = list(models_dir.iterdir())
+    except OSError:
+        return []
+    names: list[str] = []
+    for child in children:
+        if not child.is_file():
+            continue
+        filename = _sanitize_filename(child.name)
+        if not _is_discoverable_local_model_filename(filename):
+            continue
+        names.append(filename)
+    return sorted(set(names))
+
+
+# ---------------------------------------------------------------------------
+# Default model record (built from ModelStoreConfig)
+# ---------------------------------------------------------------------------
+
+
+def _default_model_record(store: ModelStoreConfig) -> dict[str, Any]:
+    return {
+        "id": "default",
+        "filename": store.default_filename,
+        "source_url": store.default_url,
+        "source_type": "url",
+        "status": "not_downloaded",
+        "error": None,
+        "settings": normalize_model_settings(None, filename=store.default_filename),
+    }
+
+
+# ---------------------------------------------------------------------------
+# State normalization and persistence
+# ---------------------------------------------------------------------------
+
+
+def _normalize_models_state(store: ModelStoreConfig, raw: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload = raw or {}
+    models_raw = payload.get("models")
+    models: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    seen_filenames: set[str] = set()
+
+    if isinstance(models_raw, list):
+        for item in models_raw:
+            if not isinstance(item, dict):
+                continue
+            source_url = str(item.get("source_url") or "")
+            filename = _sanitize_filename(str(item.get("filename") or ""))
+            if not _has_valid_model_extension(filename):
+                filename = f"{Path(filename).stem}.gguf"
+            item_id_raw = str(item.get("id") or _slugify_id(Path(filename).stem))
+            item_id = _unique_model_id(_slugify_id(item_id_raw), seen_ids)
+            filename = _unique_filename(filename, seen_filenames)
+            seen_ids.add(item_id)
+            seen_filenames.add(filename)
+            source_type_raw = str(item.get("source_type") or "").strip().lower()
+            if source_url:
+                source_type = source_type_raw or "url"
+            elif source_type_raw in {"upload", "local_file"}:
+                source_type = source_type_raw
+            else:
+                source_type = "upload"
+            models.append(
+                {
+                    "id": item_id,
+                    "filename": filename,
+                    "source_url": source_url or None,
+                    "source_type": source_type,
+                    "status": str(item.get("status") or "not_downloaded"),
+                    "error": item.get("error"),
+                    "settings": normalize_model_settings(item.get("settings"), filename=filename),
+                }
+            )
+
+    if not models:
+        default_model = _default_model_record(store)
+        models.append(default_model)
+        seen_ids.add(default_model["id"])
+        seen_filenames.add(default_model["filename"])
+    elif "default" not in seen_ids:
+        default_model = _default_model_record(store)
+        default_model["id"] = _unique_model_id("default", seen_ids)
+        default_model["filename"] = _unique_filename(default_model["filename"], seen_filenames)
+        models.insert(0, default_model)
+        seen_ids.add(default_model["id"])
+        seen_filenames.add(default_model["filename"])
+
+    for local_filename in discover_local_model_filenames(store.models_dir):
+        if local_filename in seen_filenames:
+            continue
+        local_id = _unique_model_id(_slugify_id(Path(local_filename).stem), seen_ids)
+        models.append(
+            {
+                "id": local_id,
+                "filename": local_filename,
+                "source_url": None,
+                "source_type": "local_file",
+                "status": "ready",
+                "error": None,
+                "settings": normalize_model_settings(None, filename=local_filename),
+            }
+        )
+        seen_ids.add(local_id)
+        seen_filenames.add(local_filename)
+
+    runtime_model_name = _sanitize_filename(store.current_model_filename) if store.current_model_filename else ""
+    active_model_id = str(payload.get("active_model_id") or "").strip()
+    if active_model_id not in seen_ids:
+        runtime_match = next(
+            (
+                str(item.get("id") or "")
+                for item in models
+                if isinstance(item, dict) and _sanitize_filename(str(item.get("filename") or "")) == runtime_model_name
+            ),
+            "",
+        )
+        active_model_id = runtime_match or models[0]["id"]
+
+    default_model_id = str(payload.get("default_model_id") or "default")
+    if default_model_id not in seen_ids:
+        default_model_id = "default" if "default" in seen_ids else models[0]["id"]
+
+    current_download_model_id = payload.get("current_download_model_id")
+    if current_download_model_id not in seen_ids:
+        current_download_model_id = None
+
+    return {
+        "version": MODELS_STATE_VERSION,
+        "countdown_enabled": bool(payload.get("countdown_enabled", True)),
+        "default_model_downloaded_once": bool(payload.get("default_model_downloaded_once", False)),
+        "active_model_id": active_model_id,
+        "default_model_id": default_model_id,
+        "current_download_model_id": current_download_model_id,
+        "models": models,
+    }
+
+
+def ensure_models_state(store: ModelStoreConfig) -> dict[str, Any]:
+    raw: dict[str, Any] | None = None
+    if store.state_path.exists():
+        try:
+            loaded = json.loads(store.state_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                raw = loaded
+        except (OSError, json.JSONDecodeError):
+            raw = None
+
+    normalized = _normalize_models_state(store, raw)
+    default_model_id = str(normalized.get("default_model_id") or "default")
+    default_model = get_model_by_id(normalized, default_model_id)
+    if isinstance(default_model, dict):
+        default_filename = str(default_model.get("filename") or "")
+        if default_filename in store.known_default_filenames and model_file_present(store.models_dir, default_filename):
+            normalized["default_model_downloaded_once"] = True
+    _atomic_write_json(store.state_path, normalized)
+    return normalized
+
+
+def save_models_state(store: ModelStoreConfig, state: dict[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_models_state(store, state)
+    _atomic_write_json(store.state_path, normalized)
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Registry mutations
+# ---------------------------------------------------------------------------
+
+
+def update_model_settings(
+    store: ModelStoreConfig,
+    *,
+    model_id: str,
+    settings: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any] | None]:
+    state = ensure_models_state(store)
+    model = get_model_by_id(state, model_id)
+    if model is None:
+        return False, "model_not_found", None
+    filename = str(model.get("filename") or "")
+    try:
+        model["settings"] = normalize_model_settings(settings, filename=filename)
+    except ModelSettingsValidationError:
+        return False, "invalid_settings", None
+    saved = save_models_state(store, state)
+    updated = get_model_by_id(saved, model_id)
+    return True, "updated", updated
+
+
+def register_model_url(store: ModelStoreConfig, source_url: str, alias: str | None = None) -> tuple[bool, str, dict[str, Any] | None]:
+    ok, reason, filename = validate_model_url(source_url)
+    if not ok:
+        return False, reason, None
+
+    state = ensure_models_state(store)
+    models = state.get("models", [])
+    assert isinstance(models, list)
+    existing_ids = {str(item.get("id")) for item in models if isinstance(item, dict)}
+    existing_names = {str(item.get("filename")) for item in models if isinstance(item, dict)}
+
+    for item in models:
+        if isinstance(item, dict) and str(item.get("source_url") or "") == source_url:
+            saved = save_models_state(store, state)
+            model = get_model_by_id(saved, str(item.get("id") or ""))
+            return True, "already_exists", model
+
+    preferred_name = filename
+    if alias:
+        alias_safe = _sanitize_filename(alias)
+        if not alias_safe.lower().endswith(".gguf"):
+            alias_safe = f"{Path(alias_safe).stem}.gguf"
+        if alias_safe:
+            preferred_name = alias_safe
+
+    final_name = _unique_filename(preferred_name, existing_names)
+    model_id = _unique_model_id(_slugify_id(Path(final_name).stem), existing_ids)
+    model_record = {
+        "id": model_id,
+        "filename": final_name,
+        "source_url": source_url,
+        "source_type": "url",
+        "status": "ready" if model_file_present(store.models_dir, final_name) else "not_downloaded",
+        "error": None,
+    }
+    models.append(model_record)
+    saved = save_models_state(store, state)
+    created = get_model_by_id(saved, model_id)
+    return True, "registered", created
+
+
+def delete_model(store: ModelStoreConfig, *, model_id: str) -> tuple[bool, str, bool, int, bool]:
+    state = ensure_models_state(store)
+    active_model_id = str(state.get("active_model_id") or "")
+    target = get_model_by_id(state, model_id)
+    if target is None:
+        return False, "model_not_found", False, 0, False
+    was_active = model_id == active_model_id
+
+    filename = str(target.get("filename") or "")
+    models = state.get("models", [])
+    assert isinstance(models, list)
+
+    same_filename_elsewhere = any(
+        isinstance(item, dict)
+        and str(item.get("id") or "") != model_id
+        and str(item.get("filename") or "") == filename
+        for item in models
+    )
+
+    deleted_file = False
+    freed_bytes = 0
+    if filename and not same_filename_elsewhere:
+        candidate_paths = (
+            model_file_path(store.models_dir, filename),
+            model_file_path(store.models_dir, filename + ".part"),
+        )
+        for candidate_path in candidate_paths:
+            candidate_is_symlink = False
+            try:
+                candidate_is_symlink = candidate_path.is_symlink()
+            except OSError:
+                candidate_is_symlink = False
+            if not candidate_path.exists() and not candidate_is_symlink:
+                continue
+
+            target_path: Path | None = None
+            file_size = 0
+            if candidate_is_symlink:
+                try:
+                    target_path = candidate_path.resolve(strict=False)
+                    if target_path.exists():
+                        file_size = max(0, target_path.stat().st_size)
+                except OSError:
+                    target_path = None
+                    file_size = 0
+            else:
+                try:
+                    file_size = max(0, candidate_path.stat().st_size)
+                except OSError:
+                    file_size = 0
+            try:
+                candidate_path.unlink(missing_ok=True)
+                if target_path is not None and target_path.exists():
+                    target_path.unlink(missing_ok=True)
+                deleted_file = True
+                freed_bytes += file_size
+            except OSError:
+                logger.warning("Could not delete model file: %s", candidate_path, exc_info=True)
+                return False, "delete_failed", False, 0, was_active
+
+    remaining_models = [
+        item
+        for item in models
+        if not (isinstance(item, dict) and str(item.get("id") or "") == model_id)
+    ]
+    state["models"] = remaining_models
+    if str(state.get("current_download_model_id") or "") == model_id:
+        state["current_download_model_id"] = None
+    if was_active:
+        next_active_id: str | None = None
+        for item in remaining_models:
+            if not isinstance(item, dict):
+                continue
+            candidate_id = str(item.get("id") or "")
+            candidate_name = str(item.get("filename") or "")
+            if candidate_id and model_file_present(store.models_dir, candidate_name):
+                next_active_id = candidate_id
+                break
+        if next_active_id is None:
+            for item in remaining_models:
+                if isinstance(item, dict) and item.get("id"):
+                    next_active_id = str(item["id"])
+                    break
+        if next_active_id is None:
+            next_active_id = str(state.get("default_model_id") or "default")
+        state["active_model_id"] = next_active_id
+    save_models_state(store, state)
+    return True, "deleted", deleted_file, freed_bytes, was_active
+
+
+def any_model_ready(store: ModelStoreConfig) -> bool:
+    """Return True if any model in the models state has a file on disk."""
+    state = ensure_models_state(store)
+    models = state.get("models") or []
+    for model in models:
+        filename = str(model.get("filename") or "").strip()
+        if filename and model_file_present(store.models_dir, filename):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Projector download
+# ---------------------------------------------------------------------------
+
+
+def download_default_projector_for_model(store: ModelStoreConfig, model_id: str) -> tuple[bool, str, str | None]:
+    """Download the default vision projector for a model from HuggingFace."""
+    import httpx
+
+    from .model_families import default_projector_candidates_for_model, projector_repo_for_model
+
+    state = ensure_models_state(store)
+    model = get_model_by_id(state, model_id)
+    if model is None:
+        return False, "model_not_found", None
+    filename = str(model.get("filename") or "")
+    if not model_supports_vision_filename(filename):
+        return False, "vision_not_supported", None
+    repo = projector_repo_for_model(filename, source_url=model.get("source_url"))
+    candidates = default_projector_candidates_for_model(filename)
+    if not repo or not candidates:
+        return False, "projector_repo_unknown", None
+
+    models_dir = store.models_dir
+    models_dir.mkdir(parents=True, exist_ok=True)
+
+    _generics = {"mmproj-F16.gguf", "mmproj-bf16.gguf"}
+    preferred_local: str | None = None
+    for c in candidates:
+        if c == "mmproj-F16.gguf":
+            break
+        preferred_local = c
+    preferred_local_bf16: str | None = None
+    if preferred_local:
+        preferred_local_bf16 = preferred_local.replace("-f16.gguf", "-bf16.gguf")
+
+    for candidate in candidates:
+        if candidate in _generics and preferred_local:
+            continue
+        target_path = models_dir / candidate
+        if target_path.exists():
+            return True, "downloaded", candidate
+
+    download_targets = list(candidates)
+    if "mmproj-bf16.gguf" not in download_targets:
+        download_targets.append("mmproj-bf16.gguf")
+
+    client = httpx.Client(follow_redirects=True, timeout=120.0)
+    try:
+        for candidate in download_targets:
+            url = f"https://huggingface.co/{repo}/resolve/main/{candidate}"
+            if candidate == "mmproj-F16.gguf" and preferred_local:
+                local_name = preferred_local
+            elif candidate == "mmproj-bf16.gguf" and preferred_local_bf16:
+                local_name = preferred_local_bf16
+            else:
+                local_name = candidate
+            target_path = models_dir / local_name
+            if target_path.exists():
+                return True, "downloaded", local_name
+            part_path = target_path.with_suffix(target_path.suffix + ".part")
+            try:
+                with client.stream("GET", url) as response:
+                    response.raise_for_status()
+                    with part_path.open("wb") as handle:
+                        for chunk in response.iter_bytes():
+                            if chunk:
+                                handle.write(chunk)
+                part_path.replace(target_path)
+                if local_name not in _generics:
+                    for g in _generics:
+                        (models_dir / g).unlink(missing_ok=True)
+                return True, "downloaded", local_name
+            except Exception:
+                part_path.unlink(missing_ok=True)
+                continue
+    finally:
+        client.close()
+    return False, "download_failed", None

--- a/core/model_state.py
+++ b/core/model_state.py
@@ -1,26 +1,129 @@
+"""Model state -- Potato-specific adapter over core.inferno.model_registry.
+
+This module provides the RuntimeConfig-aware interface that the rest of
+Potato uses.  All registry, format, settings, and projector logic lives
+in core.inferno.model_registry and core.inferno.model_families; this
+file supplies product-level defaults (device detection, default model
+selection) and translates RuntimeConfig into ModelStoreConfig for inferno.
+
+Activation flow (resolve_active_model, model_present) remains here
+because it mutates RuntimeConfig.model_path -- extraction is planned
+for a follow-up ticket.
+"""
+
 from __future__ import annotations
 
-import json
-import logging
-import re
 from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urlparse
 
 try:
-    from core.runtime_state import RuntimeConfig, _atomic_write_json, _read_pi_device_model_name, classify_runtime_device
+    from core.runtime_state import RuntimeConfig, _read_pi_device_model_name, classify_runtime_device
 except ModuleNotFoundError:
-    from runtime_state import RuntimeConfig, _atomic_write_json, _read_pi_device_model_name, classify_runtime_device  # type: ignore[no-redef]
+    from runtime_state import RuntimeConfig, _read_pi_device_model_name, classify_runtime_device  # type: ignore[no-redef]
 
-logger = logging.getLogger("potato")
+# ---------------------------------------------------------------------------
+# Re-exports from inferno (pure functions, no RuntimeConfig dependency)
+# ---------------------------------------------------------------------------
+
+try:
+    from core.inferno.model_registry import (  # noqa: F401 — re-exports
+        DEFAULT_MODEL_CHAT_SETTINGS,
+        DEFAULT_MODEL_VISION_SETTINGS,
+        MODELS_STATE_VERSION,
+        VALID_MODEL_EXTENSIONS,
+        ModelSettingsValidationError,
+        ModelStoreConfig,
+        _has_valid_model_extension,
+        _is_discoverable_local_model_filename,
+        _sanitize_filename,
+        _slugify_id,
+        _unique_filename,
+        _unique_model_id,
+        apply_model_chat_defaults,
+        build_model_capabilities,
+        get_model_by_id,
+        is_qwen35_a3b_filename,
+        model_format_for_filename,
+        model_supports_vision_filename,
+        normalize_model_settings,
+        validate_model_url,
+    )
+    from core.inferno.model_families import (  # noqa: F401 — re-exports
+        _is_vision_family,
+        default_projector_candidates_for_model,
+    )
+    from core.inferno.model_registry import (
+        model_file_path as _inferno_model_file_path,
+        model_file_present as _inferno_model_file_present,
+        describe_model_storage as _inferno_describe_model_storage,
+        resolve_model_runtime_path as _inferno_resolve_model_runtime_path,
+        discover_local_model_filenames as _inferno_discover_local_model_filenames,
+        ensure_models_state as _inferno_ensure_models_state,
+        save_models_state as _inferno_save_models_state,
+        register_model_url as _inferno_register_model_url,
+        delete_model as _inferno_delete_model,
+        update_model_settings as _inferno_update_model_settings,
+        any_model_ready as _inferno_any_model_ready,
+        download_default_projector_for_model as _inferno_download_default_projector,
+    )
+    from core.inferno.model_families import (
+        build_model_projector_status as _inferno_build_model_projector_status,
+    )
+except ModuleNotFoundError:
+    from inferno.model_registry import (  # type: ignore[no-redef]
+        DEFAULT_MODEL_CHAT_SETTINGS,
+        DEFAULT_MODEL_VISION_SETTINGS,
+        MODELS_STATE_VERSION,
+        VALID_MODEL_EXTENSIONS,
+        ModelSettingsValidationError,
+        ModelStoreConfig,
+        _has_valid_model_extension,
+        _is_discoverable_local_model_filename,
+        _sanitize_filename,
+        _slugify_id,
+        _unique_filename,
+        _unique_model_id,
+        apply_model_chat_defaults,
+        build_model_capabilities,
+        get_model_by_id,
+        is_qwen35_a3b_filename,
+        model_format_for_filename,
+        model_supports_vision_filename,
+        normalize_model_settings,
+        validate_model_url,
+    )
+    from inferno.model_families import (  # type: ignore[no-redef]
+        _is_vision_family,
+        default_projector_candidates_for_model,
+    )
+    from inferno.model_registry import (  # type: ignore[no-redef]
+        model_file_path as _inferno_model_file_path,
+        model_file_present as _inferno_model_file_present,
+        describe_model_storage as _inferno_describe_model_storage,
+        resolve_model_runtime_path as _inferno_resolve_model_runtime_path,
+        discover_local_model_filenames as _inferno_discover_local_model_filenames,
+        ensure_models_state as _inferno_ensure_models_state,
+        save_models_state as _inferno_save_models_state,
+        register_model_url as _inferno_register_model_url,
+        delete_model as _inferno_delete_model,
+        update_model_settings as _inferno_update_model_settings,
+        any_model_ready as _inferno_any_model_ready,
+        download_default_projector_for_model as _inferno_download_default_projector,
+    )
+    from inferno.model_families import (  # type: ignore[no-redef]
+        build_model_projector_status as _inferno_build_model_projector_status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Product-level constants (Potato-specific defaults)
+# ---------------------------------------------------------------------------
 
 MODEL_FILENAME = "Qwen3.5-2B-Q4_K_M.gguf"
 MODEL_URL = (
     "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/"
     "Qwen3.5-2B-Q4_K_M.gguf"
 )
-
-VALID_MODEL_EXTENSIONS = (".gguf", ".litertlm")
 
 MODEL_FILENAME_PI4 = "Qwen3.5-0.8B-IQ4_NL.gguf"
 MODEL_URL_PI4 = (
@@ -35,236 +138,103 @@ def default_model_for_device(device_class: str) -> tuple[str, str]:
     return MODEL_FILENAME, MODEL_URL
 
 
-MODELS_STATE_VERSION = 1
-
-DEFAULT_MODEL_CHAT_SETTINGS = {
-    "temperature": 0.7,
-    "top_p": 0.8,
-    "top_k": 20,
-    "repetition_penalty": 1.0,
-    "presence_penalty": 1.5,
-    "max_tokens": 16384,
-    "stream": True,
-    "generation_mode": "random",
-    "seed": 42,
-    "system_prompt": "",
-    "cache_prompt": True,
-}
-
-DEFAULT_MODEL_VISION_SETTINGS = {
-    "enabled": False,
-    "projector_mode": "default",
-    "projector_filename": None,
-}
-
-
-class ModelSettingsValidationError(ValueError):
-    def __init__(self, field: str) -> None:
-        super().__init__(field)
-        self.field = field
-
-
-def _model_file_path(runtime: RuntimeConfig, filename: str) -> Path:
-    return runtime.base_dir / "models" / filename
-
-
-def _sanitize_filename(filename: str) -> str:
-    candidate = Path(filename).name.strip()
-    candidate = re.sub(r"[^A-Za-z0-9._-]+", "-", candidate)
-    candidate = candidate.lstrip(".")
-    return candidate or "model.gguf"
-
-
-def _slugify_id(raw: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
-    return slug or "model"
-
-
-def is_qwen35_a3b_filename(filename: str | None) -> bool:
-    value = str(filename or "").strip().lower()
-    return bool(value) and "qwen" in value and "3.5" in value and "35b" in value and "a3b" in value
-
-
-def model_supports_vision_filename(filename: str | None) -> bool:
-    value = str(filename or "").strip().lower()
-    if not value:
-        return False
-    if "qwen3" in value and "vl" in value:
-        return True
-    if "qwen" in value and "3.5" in value:
-        return True
-    try:
-        from core.inferno import is_gemma4_filename
-    except ModuleNotFoundError:
-        from inferno import is_gemma4_filename  # type: ignore[no-redef]
-    if is_gemma4_filename(value):
-        return True
-    return False
-
-
-def _coerce_float_setting(raw_value: Any, *, field: str, default: float) -> float:
-    value = default if raw_value is None else raw_value
-    try:
-        return float(value)
-    except (TypeError, ValueError) as exc:
-        raise ModelSettingsValidationError(field) from exc
-
-
-def _coerce_int_setting(raw_value: Any, *, field: str, default: int) -> int:
-    value = default if raw_value is None else raw_value
-    try:
-        return int(value)
-    except (TypeError, ValueError) as exc:
-        raise ModelSettingsValidationError(field) from exc
-
-
-def _normalize_chat_settings(raw_value: Any) -> dict[str, Any]:
-    raw = raw_value if isinstance(raw_value, dict) else {}
-    return {
-        "temperature": _coerce_float_setting(
-            raw.get("temperature"),
-            field="chat.temperature",
-            default=DEFAULT_MODEL_CHAT_SETTINGS["temperature"],
-        ),
-        "top_p": _coerce_float_setting(
-            raw.get("top_p"),
-            field="chat.top_p",
-            default=DEFAULT_MODEL_CHAT_SETTINGS["top_p"],
-        ),
-        "top_k": _coerce_int_setting(
-            raw.get("top_k"),
-            field="chat.top_k",
-            default=DEFAULT_MODEL_CHAT_SETTINGS["top_k"],
-        ),
-        "repetition_penalty": _coerce_float_setting(
-            raw.get("repetition_penalty"),
-            field="chat.repetition_penalty",
-            default=DEFAULT_MODEL_CHAT_SETTINGS["repetition_penalty"],
-        ),
-        "presence_penalty": _coerce_float_setting(
-            raw.get("presence_penalty"),
-            field="chat.presence_penalty",
-            default=DEFAULT_MODEL_CHAT_SETTINGS["presence_penalty"],
-        ),
-        "max_tokens": _coerce_int_setting(
-            raw.get("max_tokens"),
-            field="chat.max_tokens",
-            default=DEFAULT_MODEL_CHAT_SETTINGS["max_tokens"],
-        ),
-        "stream": bool(raw.get("stream", DEFAULT_MODEL_CHAT_SETTINGS["stream"])),
-        "generation_mode": (
-            "deterministic"
-            if str(raw.get("generation_mode", DEFAULT_MODEL_CHAT_SETTINGS["generation_mode"])).strip().lower() == "deterministic"
-            else "random"
-        ),
-        "seed": _coerce_int_setting(
-            raw.get("seed"),
-            field="chat.seed",
-            default=DEFAULT_MODEL_CHAT_SETTINGS["seed"],
-        ),
-        "system_prompt": str(raw.get("system_prompt", DEFAULT_MODEL_CHAT_SETTINGS["system_prompt"]) or ""),
-        "cache_prompt": bool(raw.get("cache_prompt", DEFAULT_MODEL_CHAT_SETTINGS["cache_prompt"])),
-    }
-
-
-def _normalize_vision_settings(raw_value: Any, *, filename: str) -> dict[str, Any]:
-    raw = raw_value if isinstance(raw_value, dict) else {}
-    default_enabled = model_supports_vision_filename(filename)
-    projector_filename_raw = raw.get("projector_filename")
-    projector_filename = None
-    if projector_filename_raw is not None:
-        value = str(projector_filename_raw).strip()
-        projector_filename = value or None
-    projector_mode = str(raw.get("projector_mode", DEFAULT_MODEL_VISION_SETTINGS["projector_mode"]) or "default").strip().lower()
-    if projector_mode not in {"default", "custom"}:
-        projector_mode = "default"
-    return {
-        "enabled": bool(raw.get("enabled", default_enabled)),
-        "projector_mode": projector_mode,
-        "projector_filename": projector_filename,
-    }
-
-
-def normalize_model_settings(raw_value: Any, *, filename: str) -> dict[str, Any]:
-    raw = raw_value if isinstance(raw_value, dict) else {}
-    return {
-        "chat": _normalize_chat_settings(raw.get("chat")),
-        "vision": _normalize_vision_settings(raw.get("vision"), filename=filename),
-    }
-
-
-def build_model_capabilities(filename: str | None) -> dict[str, Any]:
-    return {
-        "vision": model_supports_vision_filename(filename),
-    }
-
-
-def apply_model_chat_defaults(payload: dict[str, Any], *, active_model_filename: str | None) -> dict[str, Any]:
-    if not is_qwen35_a3b_filename(active_model_filename):
-        return payload
-
-    chat_template_kwargs = payload.get("chat_template_kwargs")
-    if isinstance(chat_template_kwargs, dict) and "enable_thinking" in chat_template_kwargs:
-        return payload
-
-    updated = dict(payload)
-    if isinstance(chat_template_kwargs, dict):
-        merged = dict(chat_template_kwargs)
-    else:
-        merged = {}
-    merged["enable_thinking"] = False
-    updated["chat_template_kwargs"] = merged
-    return updated
-
-
-def _unique_model_id(base_id: str, existing_ids: set[str]) -> str:
-    candidate = base_id
-    idx = 2
-    while candidate in existing_ids:
-        candidate = f"{base_id}-{idx}"
-        idx += 1
-    return candidate
-
-
-def _unique_filename(base_name: str, existing_names: set[str]) -> str:
-    stem = Path(base_name).stem
-    suffix = Path(base_name).suffix or ".gguf"
-    candidate = f"{stem}{suffix}"
-    idx = 2
-    while candidate in existing_names:
-        candidate = f"{stem}-{idx}{suffix}"
-        idx += 1
-    return candidate
-
-
-def _has_valid_model_extension(filename: str) -> bool:
-    lower = filename.lower()
-    return any(lower.endswith(ext) for ext in VALID_MODEL_EXTENSIONS)
-
-
-def model_format_for_filename(filename: str) -> str:
-    if filename.lower().endswith(".litertlm"):
-        return "litertlm"
-    return "gguf"
-
-
-def validate_model_url(source_url: str) -> tuple[bool, str, str]:
-    parsed = urlparse(source_url.strip())
-    if parsed.scheme != "https":
-        return False, "https_required", ""
-    basename = unquote(Path(parsed.path).name)
-    if not basename:
-        return False, "filename_missing", ""
-    if not _has_valid_model_extension(basename):
-        return False, "unsupported_model_format", ""
-    safe_name = _sanitize_filename(basename)
-    if not _has_valid_model_extension(safe_name):
-        safe_name = f"{Path(safe_name).stem}.gguf"
-    return True, "", safe_name
+# ---------------------------------------------------------------------------
+# RuntimeConfig → ModelStoreConfig translation
+# ---------------------------------------------------------------------------
 
 
 def _detect_device_class() -> str:
     return classify_runtime_device(pi_model_name=_read_pi_device_model_name())
+
+
+def _store_config(runtime: RuntimeConfig) -> ModelStoreConfig:
+    device_class = _detect_device_class()
+    filename, url = default_model_for_device(device_class)
+    return ModelStoreConfig(
+        models_dir=runtime.base_dir / "models",
+        state_path=runtime.models_state_path,
+        default_filename=filename,
+        default_url=url,
+        known_default_filenames=(MODEL_FILENAME, MODEL_FILENAME_PI4),
+        current_model_filename=getattr(runtime.model_path, "name", ""),
+    )
+
+
+def _models_dir(runtime: RuntimeConfig) -> Path:
+    return runtime.base_dir / "models"
+
+
+# ---------------------------------------------------------------------------
+# Thin wrappers (RuntimeConfig → inferno delegation)
+# ---------------------------------------------------------------------------
+
+
+def _model_file_path(runtime: RuntimeConfig, filename: str) -> Path:
+    return _inferno_model_file_path(_models_dir(runtime), filename)
+
+
+def model_file_present(runtime: RuntimeConfig, filename: str) -> bool:
+    return _inferno_model_file_present(_models_dir(runtime), filename)
+
+
+def describe_model_storage(runtime: RuntimeConfig, filename: str) -> dict[str, Any]:
+    return _inferno_describe_model_storage(_models_dir(runtime), filename)
+
+
+def resolve_model_runtime_path(runtime: RuntimeConfig, filename: str) -> Path:
+    return _inferno_resolve_model_runtime_path(_models_dir(runtime), filename)
+
+
+def _discover_local_model_filenames(runtime: RuntimeConfig) -> list[str]:
+    return _inferno_discover_local_model_filenames(_models_dir(runtime))
+
+
+def ensure_models_state(runtime: RuntimeConfig) -> dict[str, Any]:
+    return _inferno_ensure_models_state(_store_config(runtime))
+
+
+def save_models_state(runtime: RuntimeConfig, state: dict[str, Any]) -> dict[str, Any]:
+    return _inferno_save_models_state(_store_config(runtime), state)
+
+
+def register_model_url(runtime: RuntimeConfig, source_url: str, alias: str | None = None) -> tuple[bool, str, dict[str, Any] | None]:
+    return _inferno_register_model_url(_store_config(runtime), source_url, alias)
+
+
+def delete_model(runtime: RuntimeConfig, *, model_id: str) -> tuple[bool, str, bool, int, bool]:
+    return _inferno_delete_model(_store_config(runtime), model_id=model_id)
+
+
+def update_model_settings(
+    runtime: RuntimeConfig,
+    *,
+    model_id: str,
+    settings: dict[str, Any],
+) -> tuple[bool, str, dict[str, Any] | None]:
+    return _inferno_update_model_settings(_store_config(runtime), model_id=model_id, settings=settings)
+
+
+def any_model_ready(runtime: RuntimeConfig) -> bool:
+    return _inferno_any_model_ready(_store_config(runtime))
+
+
+def download_default_projector_for_model(*, runtime: RuntimeConfig, model_id: str) -> tuple[bool, str, str | None]:
+    return _inferno_download_default_projector(_store_config(runtime), model_id)
+
+
+def build_model_projector_status(runtime: RuntimeConfig, model: dict[str, Any]) -> dict[str, Any]:
+    return _inferno_build_model_projector_status(_models_dir(runtime), model)
+
+
+# ---------------------------------------------------------------------------
+# Product policy state
+# ---------------------------------------------------------------------------
+
+
+def set_download_countdown_enabled(runtime: RuntimeConfig, enabled: bool) -> dict[str, Any]:
+    state = ensure_models_state(runtime)
+    state["countdown_enabled"] = bool(enabled)
+    return save_models_state(runtime, state)
 
 
 def _default_model_record(_runtime: RuntimeConfig, *, device_class: str = "") -> dict[str, Any]:
@@ -281,240 +251,9 @@ def _default_model_record(_runtime: RuntimeConfig, *, device_class: str = "") ->
     }
 
 
-def _is_discoverable_local_model_filename(filename: str) -> bool:
-    name = _sanitize_filename(filename)
-    if not _has_valid_model_extension(name):
-        return False
-    stem = Path(name).stem.lower()
-    if stem.startswith("mmproj") or "mmproj" in stem:
-        return False
-    return True
-
-
-def _discover_local_model_filenames(runtime: RuntimeConfig) -> list[str]:
-    model_dir = runtime.base_dir / "models"
-    try:
-        children = list(model_dir.iterdir())
-    except OSError:
-        return []
-    names: list[str] = []
-    for child in children:
-        if not child.is_file():
-            continue
-        filename = _sanitize_filename(child.name)
-        if not _is_discoverable_local_model_filename(filename):
-            continue
-        names.append(filename)
-    return sorted(set(names))
-
-
-def model_file_present(runtime: RuntimeConfig, filename: str) -> bool:
-    path = _model_file_path(runtime, filename)
-    try:
-        return path.exists() and path.stat().st_size > 0
-    except OSError:
-        return False
-
-
-def any_model_ready(runtime: RuntimeConfig) -> bool:
-    """Return True if any model in the models state has a file on disk."""
-    state = ensure_models_state(runtime)
-    models = state.get("models") or []
-    for model in models:
-        filename = str(model.get("filename") or "").strip()
-        if filename and model_file_present(runtime, filename):
-            return True
-    return False
-
-
-def resolve_model_runtime_path(runtime: RuntimeConfig, filename: str) -> Path:
-    """Return the real filesystem path for a model, resolving symlinks."""
-    path = _model_file_path(runtime, filename)
-    try:
-        if path.is_symlink():
-            return path.resolve(strict=False)
-    except OSError:
-        return path
-    return path
-
-
-def describe_model_storage(runtime: RuntimeConfig, filename: str) -> dict[str, Any]:
-    path = _model_file_path(runtime, filename)
-    size_bytes = 0
-    exists = False
-
-    try:
-        exists = path.exists()
-    except OSError:
-        exists = False
-
-    if exists:
-        try:
-            size_bytes = max(0, int(path.stat().st_size))
-        except OSError:
-            size_bytes = 0
-
-    return {
-        "location": "local",
-        "size_bytes": size_bytes,
-        "exists": exists,
-    }
-
-
-def _normalize_models_state(runtime: RuntimeConfig, raw: dict[str, Any] | None = None) -> dict[str, Any]:
-    payload = raw or {}
-    models_raw = payload.get("models")
-    models: list[dict[str, Any]] = []
-    seen_ids: set[str] = set()
-    seen_filenames: set[str] = set()
-
-    if isinstance(models_raw, list):
-        for item in models_raw:
-            if not isinstance(item, dict):
-                continue
-            source_url = str(item.get("source_url") or "")
-            filename = _sanitize_filename(str(item.get("filename") or ""))
-            if not _has_valid_model_extension(filename):
-                filename = f"{Path(filename).stem}.gguf"
-            item_id_raw = str(item.get("id") or _slugify_id(Path(filename).stem))
-            item_id = _unique_model_id(_slugify_id(item_id_raw), seen_ids)
-            filename = _unique_filename(filename, seen_filenames)
-            seen_ids.add(item_id)
-            seen_filenames.add(filename)
-            source_type_raw = str(item.get("source_type") or "").strip().lower()
-            if source_url:
-                source_type = source_type_raw or "url"
-            elif source_type_raw in {"upload", "local_file"}:
-                source_type = source_type_raw
-            else:
-                source_type = "upload"
-            models.append(
-                {
-                    "id": item_id,
-                    "filename": filename,
-                    "source_url": source_url or None,
-                    "source_type": source_type,
-                    "status": str(item.get("status") or "not_downloaded"),
-                    "error": item.get("error"),
-                    "settings": normalize_model_settings(item.get("settings"), filename=filename),
-                }
-            )
-
-    if not models:
-        default_model = _default_model_record(runtime)
-        models.append(default_model)
-        seen_ids.add(default_model["id"])
-        seen_filenames.add(default_model["filename"])
-    elif "default" not in seen_ids:
-        default_model = _default_model_record(runtime)
-        default_model["id"] = _unique_model_id("default", seen_ids)
-        default_model["filename"] = _unique_filename(default_model["filename"], seen_filenames)
-        models.insert(0, default_model)
-        seen_ids.add(default_model["id"])
-        seen_filenames.add(default_model["filename"])
-
-    for local_filename in _discover_local_model_filenames(runtime):
-        if local_filename in seen_filenames:
-            continue
-        local_id = _unique_model_id(_slugify_id(Path(local_filename).stem), seen_ids)
-        models.append(
-            {
-                "id": local_id,
-                "filename": local_filename,
-                "source_url": None,
-                "source_type": "local_file",
-                "status": "ready",
-                "error": None,
-                "settings": normalize_model_settings(None, filename=local_filename),
-            }
-        )
-        seen_ids.add(local_id)
-        seen_filenames.add(local_filename)
-
-    runtime_model_name = _sanitize_filename(getattr(runtime.model_path, "name", ""))
-    active_model_id = str(payload.get("active_model_id") or "").strip()
-    if active_model_id not in seen_ids:
-        runtime_match = next(
-            (
-                str(item.get("id") or "")
-                for item in models
-                if isinstance(item, dict) and _sanitize_filename(str(item.get("filename") or "")) == runtime_model_name
-            ),
-            "",
-        )
-        active_model_id = runtime_match or models[0]["id"]
-
-    default_model_id = str(payload.get("default_model_id") or "default")
-    if default_model_id not in seen_ids:
-        default_model_id = "default" if "default" in seen_ids else models[0]["id"]
-
-    current_download_model_id = payload.get("current_download_model_id")
-    if current_download_model_id not in seen_ids:
-        current_download_model_id = None
-
-    return {
-        "version": MODELS_STATE_VERSION,
-        "countdown_enabled": bool(payload.get("countdown_enabled", True)),
-        "default_model_downloaded_once": bool(payload.get("default_model_downloaded_once", False)),
-        "active_model_id": active_model_id,
-        "default_model_id": default_model_id,
-        "current_download_model_id": current_download_model_id,
-        "models": models,
-    }
-
-
-def ensure_models_state(runtime: RuntimeConfig) -> dict[str, Any]:
-    raw: dict[str, Any] | None = None
-    if runtime.models_state_path.exists():
-        try:
-            loaded = json.loads(runtime.models_state_path.read_text(encoding="utf-8"))
-            if isinstance(loaded, dict):
-                raw = loaded
-        except (OSError, json.JSONDecodeError):
-            raw = None
-
-    normalized = _normalize_models_state(runtime, raw)
-    default_model_id = str(normalized.get("default_model_id") or "default")
-    default_model = get_model_by_id(normalized, default_model_id)
-    if isinstance(default_model, dict):
-        default_filename = str(default_model.get("filename") or "")
-        if default_filename in (MODEL_FILENAME, MODEL_FILENAME_PI4) and model_file_present(runtime, default_filename):
-            normalized["default_model_downloaded_once"] = True
-    _atomic_write_json(runtime.models_state_path, normalized)
-    return normalized
-
-
-def save_models_state(runtime: RuntimeConfig, state: dict[str, Any]) -> dict[str, Any]:
-    normalized = _normalize_models_state(runtime, state)
-    _atomic_write_json(runtime.models_state_path, normalized)
-    return normalized
-
-
-def get_model_by_id(state: dict[str, Any], model_id: str) -> dict[str, Any] | None:
-    for item in state.get("models", []):
-        if isinstance(item, dict) and item.get("id") == model_id:
-            return item
-    return None
-
-
-def update_model_settings(
-    runtime: RuntimeConfig,
-    *,
-    model_id: str,
-    settings: dict[str, Any],
-) -> tuple[bool, str, dict[str, Any] | None]:
-    state = ensure_models_state(runtime)
-    model = get_model_by_id(state, model_id)
-    if model is None:
-        return False, "model_not_found", None
-    filename = str(model.get("filename") or "")
-    try:
-        model["settings"] = normalize_model_settings(settings, filename=filename)
-    except ModelSettingsValidationError:
-        return False, "invalid_settings", None
-    saved = save_models_state(runtime, state)
-    updated = get_model_by_id(saved, model_id)
-    return True, "updated", updated
+# ---------------------------------------------------------------------------
+# Activation flow (excluded from #295 extraction scope)
+# ---------------------------------------------------------------------------
 
 
 def resolve_active_model(state: dict[str, Any], runtime: RuntimeConfig) -> tuple[dict[str, Any], Path]:
@@ -535,314 +274,3 @@ def model_present(runtime: RuntimeConfig) -> bool:
         return active_model_path.exists() and active_model_path.stat().st_size > 0
     except OSError:
         return False
-
-
-def set_download_countdown_enabled(runtime: RuntimeConfig, enabled: bool) -> dict[str, Any]:
-    state = ensure_models_state(runtime)
-    state["countdown_enabled"] = bool(enabled)
-    return save_models_state(runtime, state)
-
-
-def register_model_url(runtime: RuntimeConfig, source_url: str, alias: str | None = None) -> tuple[bool, str, dict[str, Any] | None]:
-    ok, reason, filename = validate_model_url(source_url)
-    if not ok:
-        return False, reason, None
-
-    state = ensure_models_state(runtime)
-    models = state.get("models", [])
-    assert isinstance(models, list)
-    existing_ids = {str(item.get("id")) for item in models if isinstance(item, dict)}
-    existing_names = {str(item.get("filename")) for item in models if isinstance(item, dict)}
-
-    for item in models:
-        if isinstance(item, dict) and str(item.get("source_url") or "") == source_url:
-            saved = save_models_state(runtime, state)
-            model = get_model_by_id(saved, str(item.get("id") or ""))
-            return True, "already_exists", model
-
-    preferred_name = filename
-    if alias:
-        alias_safe = _sanitize_filename(alias)
-        if not alias_safe.lower().endswith(".gguf"):
-            alias_safe = f"{Path(alias_safe).stem}.gguf"
-        if alias_safe:
-            preferred_name = alias_safe
-
-    final_name = _unique_filename(preferred_name, existing_names)
-    model_id = _unique_model_id(_slugify_id(Path(final_name).stem), existing_ids)
-    model_record = {
-        "id": model_id,
-        "filename": final_name,
-        "source_url": source_url,
-        "source_type": "url",
-        "status": "ready" if model_file_present(runtime, final_name) else "not_downloaded",
-        "error": None,
-    }
-    models.append(model_record)
-    saved = save_models_state(runtime, state)
-    created = get_model_by_id(saved, model_id)
-    return True, "registered", created
-
-
-def delete_model(runtime: RuntimeConfig, *, model_id: str) -> tuple[bool, str, bool, int, bool]:
-    state = ensure_models_state(runtime)
-    active_model_id = str(state.get("active_model_id") or "")
-    target = get_model_by_id(state, model_id)
-    if target is None:
-        return False, "model_not_found", False, 0, False
-    was_active = model_id == active_model_id
-
-    filename = str(target.get("filename") or "")
-    models = state.get("models", [])
-    assert isinstance(models, list)
-
-    same_filename_elsewhere = any(
-        isinstance(item, dict)
-        and str(item.get("id") or "") != model_id
-        and str(item.get("filename") or "") == filename
-        for item in models
-    )
-
-    deleted_file = False
-    freed_bytes = 0
-    if filename and not same_filename_elsewhere:
-        candidate_paths = (
-            _model_file_path(runtime, filename),
-            _model_file_path(runtime, filename + ".part"),
-        )
-        for candidate_path in candidate_paths:
-            candidate_is_symlink = False
-            try:
-                candidate_is_symlink = candidate_path.is_symlink()
-            except OSError:
-                candidate_is_symlink = False
-            if not candidate_path.exists() and not candidate_is_symlink:
-                continue
-
-            target_path: Path | None = None
-            file_size = 0
-            if candidate_is_symlink:
-                try:
-                    target_path = candidate_path.resolve(strict=False)
-                    if target_path.exists():
-                        file_size = max(0, target_path.stat().st_size)
-                except OSError:
-                    target_path = None
-                    file_size = 0
-            else:
-                try:
-                    file_size = max(0, candidate_path.stat().st_size)
-                except OSError:
-                    file_size = 0
-            try:
-                candidate_path.unlink(missing_ok=True)
-                if target_path is not None and target_path.exists():
-                    target_path.unlink(missing_ok=True)
-                deleted_file = True
-                freed_bytes += file_size
-            except OSError:
-                logger.warning("Could not delete model file: %s", candidate_path, exc_info=True)
-                return False, "delete_failed", False, 0, was_active
-
-    remaining_models = [
-        item
-        for item in models
-        if not (isinstance(item, dict) and str(item.get("id") or "") == model_id)
-    ]
-    state["models"] = remaining_models
-    if str(state.get("current_download_model_id") or "") == model_id:
-        state["current_download_model_id"] = None
-    if was_active:
-        next_active_id: str | None = None
-        for item in remaining_models:
-            if not isinstance(item, dict):
-                continue
-            candidate_id = str(item.get("id") or "")
-            candidate_name = str(item.get("filename") or "")
-            if candidate_id and model_file_present(runtime, candidate_name):
-                next_active_id = candidate_id
-                break
-        if next_active_id is None:
-            for item in remaining_models:
-                if isinstance(item, dict) and item.get("id"):
-                    next_active_id = str(item["id"])
-                    break
-        if next_active_id is None:
-            next_active_id = str(state.get("default_model_id") or "default")
-        state["active_model_id"] = next_active_id
-    save_models_state(runtime, state)
-    return True, "deleted", deleted_file, freed_bytes, was_active
-
-
-def _is_vision_family(filename: str) -> bool:
-    """Return True if the filename belongs to a curated vision model family."""
-    model_name = filename.strip().lower()
-    if "qwen" in model_name and "3.5" in model_name:
-        return True
-    try:
-        from core.inferno import is_gemma4_filename
-    except ModuleNotFoundError:
-        from inferno import is_gemma4_filename  # type: ignore[no-redef]
-    return is_gemma4_filename(model_name)
-
-
-def default_projector_candidates_for_model(filename: str | None) -> list[str]:
-    """Return ordered list of mmproj filename candidates for a given model."""
-    model_name = str(filename or "").strip()
-    if not model_name or not _is_vision_family(model_name):
-        return []
-
-    stem = Path(model_name).stem
-    stem_candidates = [stem]
-    trimmed_stem = stem
-    while True:
-        next_stem = re.sub(
-            r"-(?:UD-)?(?:\d+(?:\.\d+)?bpw|I?Q\d+(?:_[A-Za-z0-9]+)*|MXFP\d+_MOE)$",
-            "",
-            trimmed_stem,
-            flags=re.IGNORECASE,
-        )
-        if next_stem == trimmed_stem or not next_stem:
-            break
-        trimmed_stem = next_stem
-        if trimmed_stem not in stem_candidates:
-            stem_candidates.append(trimmed_stem)
-
-    candidates: list[str] = []
-    # Model-specific candidates first (f16 preferred, bf16 fallback),
-    # then generic F16 last. This ensures a downloaded model-specific
-    # bf16 projector is found before a stale generic F16.
-    for precision in ("f16", "bf16"):
-        for candidate_stem in stem_candidates:
-            candidate_name = f"mmproj-{candidate_stem}-{precision}.gguf"
-            if candidate_name not in candidates:
-                candidates.append(candidate_name)
-    if "mmproj-F16.gguf" not in candidates:
-        candidates.append("mmproj-F16.gguf")
-    return candidates
-
-
-def download_default_projector_for_model(*, runtime: RuntimeConfig, model_id: str) -> tuple[bool, str, str | None]:
-    """Download the default vision projector for a model from HuggingFace."""
-    import httpx
-
-    try:
-        from core.inferno import projector_repo_for_model
-    except ModuleNotFoundError:
-        from inferno import projector_repo_for_model  # type: ignore[no-redef]
-
-    state = ensure_models_state(runtime)
-    model = get_model_by_id(state, model_id)
-    if model is None:
-        return False, "model_not_found", None
-    filename = str(model.get("filename") or "")
-    if not model_supports_vision_filename(filename):
-        return False, "vision_not_supported", None
-    repo = projector_repo_for_model(filename, source_url=model.get("source_url"))
-    candidates = default_projector_candidates_for_model(filename)
-    if not repo or not candidates:
-        return False, "projector_repo_unknown", None
-
-    models_dir = runtime.base_dir / "models"
-    models_dir.mkdir(parents=True, exist_ok=True)
-
-    # Determine preferred model-specific local names (last candidate before each generic).
-    # E.g. for Qwen3.5-2B-Q4_K_M.gguf → "mmproj-Qwen3.5-2B-f16.gguf"
-    _generics = {"mmproj-F16.gguf", "mmproj-bf16.gguf"}
-    preferred_local: str | None = None
-    for c in candidates:
-        if c == "mmproj-F16.gguf":
-            break
-        preferred_local = c
-    preferred_local_bf16: str | None = None
-    if preferred_local:
-        preferred_local_bf16 = preferred_local.replace("-f16.gguf", "-bf16.gguf")
-
-    # Check for existing model-specific files first (skip stale generics).
-    for candidate in candidates:
-        if candidate in _generics and preferred_local:
-            continue
-        target_path = models_dir / candidate
-        if target_path.exists():
-            return True, "downloaded", candidate
-
-    # Download targets include generic bf16 for repos that only ship it
-    # (e.g. ByteShape), even though it's excluded from local discovery.
-    download_targets = list(candidates)
-    if "mmproj-bf16.gguf" not in download_targets:
-        download_targets.append("mmproj-bf16.gguf")
-
-    client = httpx.Client(follow_redirects=True, timeout=120.0)
-    try:
-        for candidate in download_targets:
-            url = f"https://huggingface.co/{repo}/resolve/main/{candidate}"
-            # When downloading a generic file, save with model-specific name
-            # to prevent stale reuse across model switches (#136).
-            if candidate == "mmproj-F16.gguf" and preferred_local:
-                local_name = preferred_local
-            elif candidate == "mmproj-bf16.gguf" and preferred_local_bf16:
-                local_name = preferred_local_bf16
-            else:
-                local_name = candidate
-            target_path = models_dir / local_name
-            if target_path.exists():
-                return True, "downloaded", local_name
-            part_path = target_path.with_suffix(target_path.suffix + ".part")
-            try:
-                with client.stream("GET", url) as response:
-                    response.raise_for_status()
-                    with part_path.open("wb") as handle:
-                        for chunk in response.iter_bytes():
-                            if chunk:
-                                handle.write(chunk)
-                part_path.replace(target_path)
-                # Clean up stale generics after saving model-specific file.
-                if local_name not in _generics:
-                    for g in _generics:
-                        (models_dir / g).unlink(missing_ok=True)
-                return True, "downloaded", local_name
-            except Exception:
-                part_path.unlink(missing_ok=True)
-                continue
-    finally:
-        client.close()
-    return False, "download_failed", None
-
-
-def build_model_projector_status(runtime: RuntimeConfig, model: dict[str, Any]) -> dict[str, Any]:
-    """Build projector status for a model (presence, path, candidates)."""
-    filename = str(model.get("filename") or "")
-    settings = normalize_model_settings(model.get("settings"), filename=filename)
-    vision = settings.get("vision", {})
-    projector_mode = str(vision.get("projector_mode") or "default").strip().lower()
-    configured_filename = str(vision.get("projector_filename") or "").strip() or None
-    default_candidates = default_projector_candidates_for_model(filename)
-    search_names: list[str] = []
-    if projector_mode == "custom":
-        if configured_filename:
-            search_names.append(configured_filename)
-    else:
-        for candidate in default_candidates:
-            if candidate not in search_names:
-                search_names.append(candidate)
-        if configured_filename and configured_filename not in search_names:
-            search_names.append(configured_filename)
-
-    resolved_name = configured_filename
-    present = False
-    resolved_path = None
-    for candidate in search_names:
-        candidate_path = runtime.base_dir / "models" / candidate
-        if candidate_path.exists():
-            present = True
-            resolved_name = candidate
-            resolved_path = candidate_path
-            break
-
-    return {
-        "configured_filename": configured_filename,
-        "filename": resolved_name,
-        "present": present,
-        "path": str(resolved_path) if resolved_path is not None else None,
-        "default_candidates": default_candidates,
-    }

--- a/tests/unit/test_inferno_model_registry.py
+++ b/tests/unit/test_inferno_model_registry.py
@@ -1,0 +1,559 @@
+"""Tests for core.inferno.model_registry — format, settings, file ops, and state management."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+try:
+    from core.inferno.model_registry import (
+        VALID_MODEL_EXTENSIONS,
+        DEFAULT_MODEL_CHAT_SETTINGS,
+        DEFAULT_MODEL_VISION_SETTINGS,
+        MODELS_STATE_VERSION,
+        ModelSettingsValidationError,
+        ModelStoreConfig,
+        model_format_for_filename,
+        validate_model_url,
+        _has_valid_model_extension,
+        _sanitize_filename,
+        _slugify_id,
+        _unique_model_id,
+        _unique_filename,
+        is_qwen35_a3b_filename,
+        model_supports_vision_filename,
+        normalize_model_settings,
+        build_model_capabilities,
+        apply_model_chat_defaults,
+        get_model_by_id,
+        _is_discoverable_local_model_filename,
+        model_file_path,
+        model_file_present,
+        describe_model_storage,
+        resolve_model_runtime_path,
+        discover_local_model_filenames,
+        ensure_models_state,
+        save_models_state,
+        register_model_url,
+        delete_model,
+        update_model_settings,
+        any_model_ready,
+    )
+except ModuleNotFoundError:
+    from inferno.model_registry import (  # type: ignore[no-redef]
+        VALID_MODEL_EXTENSIONS,
+        DEFAULT_MODEL_CHAT_SETTINGS,
+        DEFAULT_MODEL_VISION_SETTINGS,
+        MODELS_STATE_VERSION,
+        ModelSettingsValidationError,
+        ModelStoreConfig,
+        model_format_for_filename,
+        validate_model_url,
+        _has_valid_model_extension,
+        _sanitize_filename,
+        _slugify_id,
+        _unique_model_id,
+        _unique_filename,
+        is_qwen35_a3b_filename,
+        model_supports_vision_filename,
+        normalize_model_settings,
+        build_model_capabilities,
+        apply_model_chat_defaults,
+        get_model_by_id,
+        _is_discoverable_local_model_filename,
+        model_file_path,
+        model_file_present,
+        describe_model_storage,
+        resolve_model_runtime_path,
+        discover_local_model_filenames,
+        ensure_models_state,
+        save_models_state,
+        register_model_url,
+        delete_model,
+        update_model_settings,
+        any_model_ready,
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> ModelStoreConfig:
+    """Create a ModelStoreConfig backed by a temp directory."""
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    state_path = tmp_path / "state" / "models.json"
+    state_path.parent.mkdir()
+    return ModelStoreConfig(
+        models_dir=models_dir,
+        state_path=state_path,
+        default_filename="default-model.gguf",
+        default_url="https://example.com/default-model.gguf",
+        known_default_filenames=("default-model.gguf",),
+        current_model_filename="",
+    )
+
+
+# -- Constants --
+
+
+def test_valid_model_extensions():
+    assert ".gguf" in VALID_MODEL_EXTENSIONS
+    assert ".litertlm" in VALID_MODEL_EXTENSIONS
+
+
+def test_state_version_is_int():
+    assert isinstance(MODELS_STATE_VERSION, int)
+
+
+def test_default_chat_settings_has_required_keys():
+    for key in ("temperature", "top_p", "top_k", "max_tokens", "stream"):
+        assert key in DEFAULT_MODEL_CHAT_SETTINGS
+
+
+def test_default_vision_settings_has_required_keys():
+    for key in ("enabled", "projector_mode", "projector_filename"):
+        assert key in DEFAULT_MODEL_VISION_SETTINGS
+
+
+# -- Format detection --
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("model.gguf", "gguf"),
+        ("MODEL.GGUF", "gguf"),
+        ("model.litertlm", "litertlm"),
+        ("Model.LiteRTLM", "litertlm"),
+        ("anything-else.bin", "gguf"),
+    ],
+)
+def test_model_format_for_filename(filename, expected):
+    assert model_format_for_filename(filename) == expected
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("model.gguf", True),
+        ("model.GGUF", True),
+        ("model.litertlm", True),
+        ("model.bin", False),
+        ("model.safetensors", False),
+    ],
+)
+def test_has_valid_model_extension(filename, expected):
+    assert _has_valid_model_extension(filename) == expected
+
+
+# -- URL validation --
+
+
+def test_validate_model_url_valid():
+    ok, reason, name = validate_model_url("https://example.com/model.gguf")
+    assert ok is True
+    assert reason == ""
+    assert name == "model.gguf"
+
+
+def test_validate_model_url_http_rejected():
+    ok, reason, _ = validate_model_url("http://example.com/model.gguf")
+    assert ok is False
+    assert reason == "https_required"
+
+
+def test_validate_model_url_no_filename():
+    ok, reason, _ = validate_model_url("https://example.com/")
+    assert ok is False
+    assert reason == "filename_missing"
+
+
+def test_validate_model_url_bad_extension():
+    ok, reason, _ = validate_model_url("https://example.com/model.bin")
+    assert ok is False
+    assert reason == "unsupported_model_format"
+
+
+def test_validate_model_url_litertlm():
+    ok, reason, name = validate_model_url("https://example.com/model.litertlm")
+    assert ok is True
+    assert name == "model.litertlm"
+
+
+# -- Filename / ID utilities --
+
+
+def test_sanitize_filename_basic():
+    assert _sanitize_filename("model.gguf") == "model.gguf"
+
+
+def test_sanitize_filename_special_chars():
+    result = _sanitize_filename("my model (v2).gguf")
+    assert result.endswith(".gguf")
+    assert " " not in result
+    assert "(" not in result
+
+
+def test_sanitize_filename_empty():
+    assert _sanitize_filename("") == "model.gguf"
+
+
+def test_slugify_id():
+    assert _slugify_id("My Model-V2") == "my-model-v2"
+
+
+def test_slugify_id_empty():
+    assert _slugify_id("") == "model"
+
+
+def test_unique_model_id_no_conflict():
+    assert _unique_model_id("base", set()) == "base"
+
+
+def test_unique_model_id_with_conflict():
+    assert _unique_model_id("base", {"base"}) == "base-2"
+    assert _unique_model_id("base", {"base", "base-2"}) == "base-3"
+
+
+def test_unique_filename_no_conflict():
+    assert _unique_filename("model.gguf", set()) == "model.gguf"
+
+
+def test_unique_filename_with_conflict():
+    assert _unique_filename("model.gguf", {"model.gguf"}) == "model-2.gguf"
+
+
+# -- Model detection --
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("Qwen3.5-35B-A3B-Q4_K_M.gguf", True),
+        ("qwen-3.5-35b-a3b-q4.gguf", True),
+        ("Qwen3.5-2B-Q4_K_M.gguf", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_qwen35_a3b_filename(filename, expected):
+    assert is_qwen35_a3b_filename(filename) == expected
+
+
+@pytest.mark.parametrize(
+    "filename, expected",
+    [
+        ("Qwen3.5-2B-Q4_K_M.gguf", True),
+        ("Qwen3-VL-2B-Q4.gguf", True),
+        ("gemma-4-E2B-it-Q4_K_M.gguf", True),
+        ("llama-3.2-1B.gguf", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_model_supports_vision_filename(filename, expected):
+    assert model_supports_vision_filename(filename) == expected
+
+
+# -- Settings normalization --
+
+
+def test_normalize_model_settings_defaults():
+    result = normalize_model_settings(None, filename="model.gguf")
+    assert "chat" in result
+    assert "vision" in result
+    assert result["chat"]["temperature"] == DEFAULT_MODEL_CHAT_SETTINGS["temperature"]
+
+
+def test_normalize_model_settings_preserves_values():
+    raw = {"chat": {"temperature": 0.5}}
+    result = normalize_model_settings(raw, filename="model.gguf")
+    assert result["chat"]["temperature"] == 0.5
+
+
+def test_normalize_model_settings_invalid_float_raises():
+    raw = {"chat": {"temperature": "not_a_number"}}
+    with pytest.raises(ModelSettingsValidationError):
+        normalize_model_settings(raw, filename="model.gguf")
+
+
+def test_normalize_model_settings_vision_enabled_for_vision_model():
+    result = normalize_model_settings(None, filename="Qwen3.5-2B-Q4_K_M.gguf")
+    assert result["vision"]["enabled"] is True
+
+
+def test_normalize_model_settings_vision_disabled_for_non_vision():
+    result = normalize_model_settings(None, filename="llama-3.2.gguf")
+    assert result["vision"]["enabled"] is False
+
+
+def test_normalize_vision_projector_mode_validates():
+    raw = {"vision": {"projector_mode": "bogus"}}
+    result = normalize_model_settings(raw, filename="model.gguf")
+    assert result["vision"]["projector_mode"] == "default"
+
+
+# -- Capabilities --
+
+
+def test_build_model_capabilities_vision():
+    caps = build_model_capabilities("Qwen3.5-2B-Q4_K_M.gguf")
+    assert caps["vision"] is True
+
+
+def test_build_model_capabilities_no_vision():
+    caps = build_model_capabilities("llama-3.2-1B.gguf")
+    assert caps["vision"] is False
+
+
+# -- Chat defaults --
+
+
+def test_apply_model_chat_defaults_a3b_adds_thinking():
+    payload = {"messages": []}
+    result = apply_model_chat_defaults(payload, active_model_filename="Qwen3.5-35B-A3B-Q4.gguf")
+    assert result["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_apply_model_chat_defaults_non_a3b_unchanged():
+    payload = {"messages": []}
+    result = apply_model_chat_defaults(payload, active_model_filename="Qwen3.5-2B-Q4.gguf")
+    assert result is payload
+
+
+def test_apply_model_chat_defaults_preserves_explicit_thinking():
+    payload = {"messages": [], "chat_template_kwargs": {"enable_thinking": True}}
+    result = apply_model_chat_defaults(payload, active_model_filename="Qwen3.5-35B-A3B-Q4.gguf")
+    assert result["chat_template_kwargs"]["enable_thinking"] is True
+
+
+# -- get_model_by_id --
+
+
+def test_get_model_by_id_found():
+    state = {"models": [{"id": "a"}, {"id": "b"}]}
+    assert get_model_by_id(state, "b") == {"id": "b"}
+
+
+def test_get_model_by_id_missing():
+    state = {"models": [{"id": "a"}]}
+    assert get_model_by_id(state, "missing") is None
+
+
+def test_get_model_by_id_empty():
+    assert get_model_by_id({"models": []}, "x") is None
+
+
+# -- Discoverable filenames --
+
+
+def test_discoverable_gguf():
+    assert _is_discoverable_local_model_filename("model.gguf") is True
+
+
+def test_discoverable_litertlm():
+    assert _is_discoverable_local_model_filename("model.litertlm") is True
+
+
+def test_discoverable_rejects_mmproj():
+    assert _is_discoverable_local_model_filename("mmproj-F16.gguf") is False
+    assert _is_discoverable_local_model_filename("mmproj-model-f16.gguf") is False
+
+
+def test_discoverable_rejects_bad_extension():
+    assert _is_discoverable_local_model_filename("model.bin") is False
+
+
+# -- File / path operations --
+
+
+def test_model_file_path(tmp_path):
+    result = model_file_path(tmp_path / "models", "test.gguf")
+    assert result == tmp_path / "models" / "test.gguf"
+
+
+def test_model_file_present_true(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "model.gguf").write_bytes(b"data")
+    assert model_file_present(models_dir, "model.gguf") is True
+
+
+def test_model_file_present_false(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    assert model_file_present(models_dir, "model.gguf") is False
+
+
+def test_model_file_present_empty_file(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "model.gguf").write_bytes(b"")
+    assert model_file_present(models_dir, "model.gguf") is False
+
+
+def test_describe_model_storage_exists(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "model.gguf").write_bytes(b"x" * 100)
+    result = describe_model_storage(models_dir, "model.gguf")
+    assert result["exists"] is True
+    assert result["size_bytes"] == 100
+    assert result["location"] == "local"
+
+
+def test_describe_model_storage_missing(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    result = describe_model_storage(models_dir, "model.gguf")
+    assert result["exists"] is False
+    assert result["size_bytes"] == 0
+
+
+def test_resolve_model_runtime_path_regular(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "model.gguf").write_bytes(b"data")
+    result = resolve_model_runtime_path(models_dir, "model.gguf")
+    assert result == models_dir / "model.gguf"
+
+
+def test_resolve_model_runtime_path_symlink(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    real = tmp_path / "real.gguf"
+    real.write_bytes(b"data")
+    (models_dir / "model.gguf").symlink_to(real)
+    result = resolve_model_runtime_path(models_dir, "model.gguf")
+    assert result == real.resolve()
+
+
+def test_discover_local_model_filenames(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "alpha.gguf").write_bytes(b"a")
+    (models_dir / "beta.litertlm").write_bytes(b"b")
+    (models_dir / "mmproj-F16.gguf").write_bytes(b"p")
+    (models_dir / "readme.txt").write_bytes(b"r")
+    result = discover_local_model_filenames(models_dir)
+    assert "alpha.gguf" in result
+    assert "beta.litertlm" in result
+    assert "mmproj-F16.gguf" not in result
+    assert "readme.txt" not in result
+
+
+def test_discover_local_model_filenames_empty(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    assert discover_local_model_filenames(models_dir) == []
+
+
+# -- State management (ModelStoreConfig) --
+
+
+def test_ensure_models_state_creates_default(store):
+    state = ensure_models_state(store)
+    assert state["version"] == MODELS_STATE_VERSION
+    assert len(state["models"]) >= 1
+    default = state["models"][0]
+    assert default["id"] == "default"
+    assert default["filename"] == "default-model.gguf"
+    assert store.state_path.exists()
+
+
+def test_ensure_models_state_reads_existing(store):
+    raw = {
+        "version": 1,
+        "models": [{"id": "custom", "filename": "custom.gguf", "source_url": None, "source_type": "upload", "status": "ready"}],
+        "active_model_id": "custom",
+    }
+    store.state_path.write_text(json.dumps(raw), encoding="utf-8")
+    state = ensure_models_state(store)
+    ids = [m["id"] for m in state["models"]]
+    assert "custom" in ids
+
+
+def test_ensure_models_state_marks_default_downloaded_once(store):
+    (store.models_dir / "default-model.gguf").write_bytes(b"model-data")
+    state = ensure_models_state(store)
+    assert state["default_model_downloaded_once"] is True
+
+
+def test_save_models_state_normalizes_and_persists(store):
+    ensure_models_state(store)
+    state = {"models": [{"id": "x", "filename": "x.gguf"}], "active_model_id": "x"}
+    saved = save_models_state(store, state)
+    assert saved["version"] == MODELS_STATE_VERSION
+    reloaded = json.loads(store.state_path.read_text(encoding="utf-8"))
+    assert reloaded["version"] == MODELS_STATE_VERSION
+
+
+def test_register_model_url_adds_model(store):
+    ensure_models_state(store)
+    ok, reason, model = register_model_url(store, "https://example.com/new-model.gguf")
+    assert ok is True
+    assert reason == "registered"
+    assert model["filename"] == "new-model.gguf"
+
+
+def test_register_model_url_detects_duplicate(store):
+    ensure_models_state(store)
+    register_model_url(store, "https://example.com/dup.gguf")
+    ok, reason, _ = register_model_url(store, "https://example.com/dup.gguf")
+    assert ok is True
+    assert reason == "already_exists"
+
+
+def test_register_model_url_rejects_http(store):
+    ensure_models_state(store)
+    ok, reason, _ = register_model_url(store, "http://example.com/model.gguf")
+    assert ok is False
+    assert reason == "https_required"
+
+
+def test_delete_model_removes_file(store):
+    ensure_models_state(store)
+    register_model_url(store, "https://example.com/to-delete.gguf")
+    (store.models_dir / "to-delete.gguf").write_bytes(b"data")
+    ok, reason, deleted_file, freed, was_active = delete_model(store, model_id="to-delete")
+    assert ok is True
+    assert reason == "deleted"
+    assert deleted_file is True
+    assert freed > 0
+    assert not (store.models_dir / "to-delete.gguf").exists()
+
+
+def test_delete_model_not_found(store):
+    ensure_models_state(store)
+    ok, reason, _, _, _ = delete_model(store, model_id="nonexistent")
+    assert ok is False
+    assert reason == "model_not_found"
+
+
+def test_update_model_settings_persists(store):
+    ensure_models_state(store)
+    ok, reason, updated = update_model_settings(
+        store, model_id="default", settings={"chat": {"temperature": 0.3}}
+    )
+    assert ok is True
+    assert reason == "updated"
+    assert updated["settings"]["chat"]["temperature"] == 0.3
+
+
+def test_update_model_settings_not_found(store):
+    ensure_models_state(store)
+    ok, reason, _ = update_model_settings(store, model_id="nope", settings={})
+    assert ok is False
+    assert reason == "model_not_found"
+
+
+def test_any_model_ready_false(store):
+    ensure_models_state(store)
+    assert any_model_ready(store) is False
+
+
+def test_any_model_ready_true(store):
+    ensure_models_state(store)
+    (store.models_dir / "default-model.gguf").write_bytes(b"data")
+    assert any_model_ready(store) is True

--- a/tests/unit/test_model_families.py
+++ b/tests/unit/test_model_families.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from core.inferno.model_families import is_gemma4_filename, projector_repo_for_model, recommended_runtime_for_model
+from core.inferno.model_families import (
+    build_model_projector_status,
+    default_projector_candidates_for_model,
+    is_gemma4_filename,
+    projector_repo_for_model,
+    recommended_runtime_for_model,
+)
 
 
 def test_projector_repo_for_qwen35_9b():
@@ -59,8 +65,6 @@ def test_projector_repo_dot_delimited_4b():
 def test_default_candidates_include_model_specific_bf16_but_not_generic():
     """default_projector_candidates_for_model must include model-specific bf16
     names but NOT generic mmproj-bf16.gguf (unsafe cross-model reuse)."""
-    from core.model_state import default_projector_candidates_for_model
-
     candidates = default_projector_candidates_for_model("Qwen3.5-9B-Q4_K_S.gguf")
     assert "mmproj-F16.gguf" in candidates
     assert "mmproj-Qwen3.5-9B-f16.gguf" in candidates
@@ -71,8 +75,6 @@ def test_default_candidates_include_model_specific_bf16_but_not_generic():
 
 def test_projector_status_finds_model_specific_bf16_on_disk(runtime):
     """build_model_projector_status must detect a model-specific bf16 projector."""
-    from core.model_state import build_model_projector_status
-
     models_dir = runtime.base_dir / "models"
     (models_dir / "mmproj-Qwen3.5-9B-bf16.gguf").write_bytes(b"bf16-projector")
 
@@ -82,7 +84,7 @@ def test_projector_status_finds_model_specific_bf16_on_disk(runtime):
             "vision": {"enabled": True, "projector_mode": "default", "projector_filename": None},
         },
     }
-    status = build_model_projector_status(runtime, model)
+    status = build_model_projector_status(models_dir, model)
     assert status["present"] is True
     assert "bf16" in status["filename"]
 
@@ -90,8 +92,6 @@ def test_projector_status_finds_model_specific_bf16_on_disk(runtime):
 def test_projector_status_ignores_stale_generic_bf16_for_wrong_model(runtime):
     """A generic mmproj-bf16.gguf left over from a 9B download must NOT be
     reported as present for a 4B model — wrong dimensions would crash. #136."""
-    from core.model_state import build_model_projector_status
-
     models_dir = runtime.base_dir / "models"
     (models_dir / "mmproj-bf16.gguf").write_bytes(b"stale-9b-bf16")
 
@@ -101,7 +101,7 @@ def test_projector_status_ignores_stale_generic_bf16_for_wrong_model(runtime):
             "vision": {"enabled": True, "projector_mode": "default", "projector_filename": None},
         },
     }
-    status = build_model_projector_status(runtime, model)
+    status = build_model_projector_status(models_dir, model)
     assert status["present"] is False, (
         "Generic mmproj-bf16.gguf must not be accepted for a different model size"
     )
@@ -197,8 +197,6 @@ def test_projector_repo_gemma4_does_not_break_qwen35():
 
 def test_default_candidates_gemma4_e2b():
     """Gemma 4 E2B produces model-specific f16/bf16 then generic F16."""
-    from core.model_state import default_projector_candidates_for_model
-
     candidates = default_projector_candidates_for_model("gemma-4-E2B-it-Q4_K_M.gguf")
     assert len(candidates) > 0
     assert "mmproj-gemma-4-E2B-it-f16.gguf" in candidates
@@ -212,8 +210,6 @@ def test_default_candidates_gemma4_e2b():
 
 def test_default_candidates_gemma4_26b_a4b():
     """Gemma 4 26B-A4B stem-trimming strips the UD-IQ2_M quant suffix."""
-    from core.model_state import default_projector_candidates_for_model
-
     candidates = default_projector_candidates_for_model("gemma-4-26B-A4B-it-UD-IQ2_M.gguf")
     assert "mmproj-gemma-4-26B-A4B-it-f16.gguf" in candidates
     assert "mmproj-F16.gguf" in candidates
@@ -221,8 +217,6 @@ def test_default_candidates_gemma4_26b_a4b():
 
 def test_projector_status_gemma4_finds_model_specific_on_disk(runtime):
     """build_model_projector_status detects a Gemma 4 model-specific projector."""
-    from core.model_state import build_model_projector_status
-
     models_dir = runtime.base_dir / "models"
     (models_dir / "mmproj-gemma-4-E2B-it-f16.gguf").write_bytes(b"g4-projector")
 
@@ -232,7 +226,7 @@ def test_projector_status_gemma4_finds_model_specific_on_disk(runtime):
             "vision": {"enabled": True, "projector_mode": "default", "projector_filename": None},
         },
     }
-    status = build_model_projector_status(runtime, model)
+    status = build_model_projector_status(models_dir, model)
     assert status["present"] is True
     assert "gemma-4-E2B-it" in status["filename"]
 


### PR DESCRIPTION
## Summary
- move Inferno-owned model registry, model-format handling, and projector logic into `core/inferno/model_registry.py`
- delegate `core/model_state.py` to the extracted module while leaving activation sequencing in place
- keep product-visible behavior stable and add focused coverage for the extracted flows

Closes #295
Refs #264

## Testing
- `uv run python -m pytest tests/unit/test_inferno_model_registry.py tests/unit/test_model_families.py tests/api/test_model_crud.py tests/api/test_runtime_env.py -q`

## QA
- Not required; behavior-preserving refactor with focused test coverage