### PR TITLE
fix(runtime): use generic projector repo for non-ByteShape Qwen3.5-9B

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ uvicorn[standard]>=0.30.0,<1.0.0
 httpx>=0.27.0,<1.0.0
 psutil>=6.0.0,<7.0.0
 PyYAML>=6.0.2,<7.0.0
-potato-inferno @ git+https://github.com/potato-os/inferno.git@5f0b6a0
+potato-inferno @ git+https://github.com/potato-os/inferno.git@2785766

--- a/tests/api/test_model_settings.py
+++ b/tests/api/test_model_settings.py
@@ -20,7 +20,7 @@ def test_update_model_settings_persists_per_model_chat_and_vision(runtime):
     with TestClient(app) as client:
         upload = client.post(
             "/internal/models/upload",
-            headers={"x-potato-filename": "Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf"},
+            headers={"x-potato-filename": "Qwen3.5-4B-Q4_K_M.gguf"},
             content=b"gguf",
         )
         assert upload.status_code == 200
@@ -74,7 +74,7 @@ def test_settings_document_yaml_round_trip_updates_active_model_and_model_settin
     with TestClient(app) as client:
         upload = client.post(
             "/internal/models/upload",
-            headers={"x-potato-filename": "Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf"},
+            headers={"x-potato-filename": "Qwen3.5-4B-Q4_K_M.gguf"},
             content=b"gguf",
         )
         assert upload.status_code == 200
@@ -155,7 +155,7 @@ def test_update_model_settings_rejects_invalid_numeric_value(runtime):
     with TestClient(app) as client:
         upload = client.post(
             "/internal/models/upload",
-            headers={"x-potato-filename": "Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf"},
+            headers={"x-potato-filename": "Qwen3.5-4B-Q4_K_M.gguf"},
             content=b"gguf",
         )
         assert upload.status_code == 200

--- a/tests/api/test_projector_download.py
+++ b/tests/api/test_projector_download.py
@@ -28,7 +28,7 @@ def test_download_default_projector_for_model_uses_curated_helper(runtime, monke
     with TestClient(app) as client:
         upload = client.post(
             "/internal/models/upload",
-            headers={"x-potato-filename": "Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf"},
+            headers={"x-potato-filename": "Qwen3.5-4B-Q4_K_M.gguf"},
             content=b"gguf",
         )
         assert upload.status_code == 200

--- a/tests/api/test_runtime_env.py
+++ b/tests/api/test_runtime_env.py
@@ -263,6 +263,50 @@ def test_runtime_env_enables_mmproj_auto_download_when_vision_on_and_no_mmproj(r
     assert "unsloth" in env["POTATO_HF_MMPROJ_REPO"] or "huggingface" in env["POTATO_HF_MMPROJ_REPO"].lower()
 
 
+def test_runtime_env_resolves_9b_non_byteshape_to_unsloth_repo(runtime):
+    """Non-ByteShape Qwen3.5-9B must resolve to unsloth/Qwen3.5-9B-GGUF."""
+    model_filename = "Qwen3.5-9B-Q4_K_M.gguf"
+    model_path = runtime.base_dir / "models" / model_filename
+    model_path.write_bytes(b"gguf")
+    runtime.model_path = model_path
+    runtime.models_state_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "countdown_enabled": True,
+                "default_model_downloaded_once": True,
+                "active_model_id": "default",
+                "default_model_id": "default",
+                "current_download_model_id": None,
+                "models": [
+                    {
+                        "id": "default",
+                        "filename": model_filename,
+                        "source_url": "https://example.com/qwen35-9b.gguf",
+                        "source_type": "url",
+                        "status": "ready",
+                        "error": None,
+                        "settings": {
+                            "vision": {
+                                "enabled": True,
+                                "projector_mode": "default",
+                                "projector_filename": None,
+                            }
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = _runtime_env(runtime)
+
+    assert env["POTATO_VISION_MODEL_NAME_PATTERN_QWEN35"] == "1"
+    assert env["POTATO_AUTO_DOWNLOAD_MMPROJ"] == "1"
+    assert env["POTATO_HF_MMPROJ_REPO"] == "unsloth/Qwen3.5-9B-GGUF"
+
+
 def test_projector_status_reports_generic_truthfully_for_offline_compat(runtime):
     """build_model_projector_status must report mmproj-F16.gguf as present even
     when model-specific candidates exist — preserves offline upgrades where the


### PR DESCRIPTION
## Summary

- bump `potato-inferno` to the revision that applies the generic non-ByteShape Qwen3.5-9B projector mapping
- add API regression coverage proving supported non-ByteShape Qwen3.5-9B models resolve to `unsloth/Qwen3.5-9B-GGUF`
- align test fixtures with the generic 9B projector path instead of publisher-specific names

Closes #263

## Test evidence

**Python (589 passed):**
```
uv run python -m pytest tests/unit tests/api -q -n auto
589 passed in 10.25s
```

**Playwright (173 passed):**
```
npx playwright test tests/ui/ --reporter=dot --timeout=15000 --workers=75%
173 passed (41.6s)
```

**Reference sweep:**
```
grep -ri "hauhaucs" tests/ core/ --exclude-dir='__pycache__'
# zero matches
```

## QA

- [ ] Pi QA pending review for this runtime/projector behavior change
