### PR TITLE
fix(runtime): refresh runtime packaging dependencies

### DIFF
--- a/bin/build_and_publish_remote.sh
+++ b/bin/build_and_publish_remote.sh
@@ -130,6 +130,8 @@ _rsync --delete \
   --include 'systemd/***' \
   --include 'nginx/***' \
   --include 'tests/***' \
+  --include 'requirements.txt' \
+  --include 'requirements-dev.txt' \
   --include 'pyproject.toml' \
   --include 'playwright.config.js' \
   --include 'package.json' \

--- a/bin/build_llama_runtime.sh
+++ b/bin/build_llama_runtime.sh
@@ -277,14 +277,20 @@ for so in "${build_dir}/lib/"*.so* "${build_dir}/bin/"*.so*; do
 done
 shopt -u nullglob
 
-# Universal profile: cmake MODULE libraries (ggml-cpu-armv8*.so) may land in
-# subdirectories of the build tree instead of bin/ or lib/. Copy any we missed.
-if [ "${BUILD_PROFILE}" = "universal" ]; then
-  while IFS= read -r so; do
-    base="$(basename "${so}")"
-    [ ! -e "${slot_dir}/lib/${base}" ] && cp -P "${so}" "${slot_dir}/lib/"
-  done < <(find "${build_dir}" -name 'libggml*.so*' -type f 2>/dev/null)
-fi
+# Upstream layout shifts over time. Required shared libs can land outside the
+# top-level build lib/bin dirs (for example examples/mtmd/libmtmd.so). Include
+# both real files and SONAME symlinks, and dereference symlinks so every loader
+# name (for example libmtmd.so.0) exists in the packaged lib/ directory.
+while IFS= read -r so; do
+  base="$(basename "${so}")"
+  [ ! -e "${slot_dir}/lib/${base}" ] && cp -L "${so}" "${slot_dir}/lib/${base}"
+done < <(
+  find "${build_dir}" \( -type f -o -type l \) \( \
+    -name 'libmtmd*.so*' -o \
+    -name 'libllama*.so*' -o \
+    -name 'libggml*.so*' \
+  \) 2>/dev/null
+)
 
 copy_runtime_deps "${slot_dir}/lib" "${slot_dir}/bin/llama-server" "${slot_dir}/bin/llama-bench" "${slot_dir}/lib/"*.so*
 

--- a/bin/install_dev.sh
+++ b/bin/install_dev.sh
@@ -116,7 +116,8 @@ run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
   wget \
   curl \
   jq \
-  rsync
+  rsync \
+  libvulkan1
 
 if [ "${POTATO_ENFORCE_HOSTNAME}" = "1" ]; then
   current_hostname="$(hostnamectl --static 2>/dev/null || hostname)"

--- a/tests/unit/test_shell_scripts.py
+++ b/tests/unit/test_shell_scripts.py
@@ -81,6 +81,32 @@ def test_ensure_model_script_keeps_shell_functions_outside_python_heredoc():
     assert "free_space_bytes()" not in python_block
 
 
+def test_build_llama_runtime_collects_nested_shared_libraries():
+    """Upstream may place required .so files outside top-level build lib/bin dirs."""
+    script = (REPO_ROOT / "bin" / "build_llama_runtime.sh").read_text(encoding="utf-8")
+
+    assert "find \"${build_dir}\"" in script
+    assert "\\( -type f -o -type l \\)" in script
+    assert "cp -L \"${so}\" \"${slot_dir}/lib/${base}\"" in script
+    assert "libmtmd*.so*" in script
+    assert "libllama*.so*" in script
+    assert "libggml*.so*" in script
+
+
+def test_remote_runtime_build_syncs_install_requirements():
+    """The remote build checkout must be complete enough to run install_dev.sh."""
+    script = (REPO_ROOT / "bin" / "build_and_publish_remote.sh").read_text(encoding="utf-8")
+
+    assert "--include 'requirements.txt'" in script
+
+
+def test_install_dev_installs_litert_native_runtime_dependencies():
+    """LiteRT-LM 0.12 needs libvulkan.so.1 available even for CPU startup."""
+    script = (REPO_ROOT / "bin" / "install_dev.sh").read_text(encoding="utf-8")
+
+    assert "libvulkan1" in script
+
+
 def test_uninstall_script_executes_pi_cleanup_without_package_removal(tmp_path: Path):
     fakebin = tmp_path / "fakebin"
     fakebin.mkdir()
@@ -393,4 +419,3 @@ def test_prepare_imager_aborts_on_missing_app():
     script = (REPO_ROOT / "bin" / "prepare_imager_bundle.sh").read_text(encoding="utf-8")
     assert "ERROR: selected app missing from payload" in script
     assert "exit 1" in script
-


### PR DESCRIPTION
## Summary
- refresh runtime packaging so nested upstream shared libraries are bundled for current ik_llama builds
- include requirements files in the remote Pi build checkout so install_dev.sh can run from /tmp/potato-os
- install libvulkan1 as a LiteRT native runtime dependency required by litert-lm-api 0.12.0

Closes #315

## Runtime releases
- ik_llama 40aae0b, pi5-opt: https://github.com/potato-os/core/releases/tag/runtime/ik_llama-40aae0b
- llama_cpp 45b455e, universal: https://github.com/potato-os/core/releases/tag/runtime/llama_cpp-45b455e

## Test evidence
- uv run python -m pytest tests/unit tests/api -q -n auto: 582 passed
- npx playwright test tests/ui/runtime.spec.js tests/ui/settings.spec.js --reporter=dot --timeout=15000: 35 passed
- bin/publish_runtime.sh --family ik_llama --dry-run: produced ik_llama-40aae0b-pi5-opt.tar.gz
- bin/publish_runtime.sh --family llama_cpp --dry-run: produced llama_cpp-45b455e-universal.tar.gz

## Pi QA
- Device: potato.local, Raspberry Pi 5 Model B Rev 1.0, aarch64
- Built latest ik_llama from https://github.com/ikawrakow/ik_llama.cpp commit 40aae0b
- Built latest llama.cpp from https://github.com/ggerganov/llama.cpp commit 45b455e
- Installed refreshed ik_llama slot; /status READY on family ik_llama commit 40aae0b
- Chat smoke on ik_llama returned: Potato Runtime OK.
- Installed refreshed llama_cpp slot; /status READY on family llama_cpp commit 45b455e
- Chat smoke on llama_cpp returned: Llama C++ Runtime is available now.
- Runtime switch API llama_cpp -> ik_llama succeeded and returned READY
- Installed litert-lm-api 0.12.0 and libvulkan1; LiteRT /health returned {"status":"ok","vision":true}
- Downloaded and activated gemma-4-E2B-it.litertlm; LiteRT chat smoke returned: LiteRT runtime ok.

## Notes
- Current ik_llama upstream places required shared libraries such as libmtmd.so outside top-level build lib/bin directories, so runtime packaging now recursively collects required runtime .so files.
- LiteRT-LM 0.12.0 requires libvulkan.so.1 to load its native library even for CPU engine startup.