### PR TITLE
hotfix(ota): provision LiteRT runtime on update

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -80,6 +80,7 @@ try:
         apply_staged_update,
         is_update_safe,
         mark_first_boot_update_done,
+        provision_litert_runtime,
         read_first_boot_update_done,
         signal_service_restart,
         staging_dir,
@@ -204,6 +205,7 @@ except ModuleNotFoundError:
         apply_staged_update,
         is_update_safe,
         mark_first_boot_update_done,
+        provision_litert_runtime,
         read_first_boot_update_done,
         signal_service_restart,
         staging_dir,
@@ -1804,7 +1806,8 @@ def create_app(runtime: RuntimeConfig | None = None, enable_orchestrator: bool |
         switched, reason = await ensure_compatible_runtime(app.state.runtime)
         if switched:
             logger.info("Runtime auto-switched at startup: %s", reason)
-        detect_post_update_state(app.state.runtime)
+        if detect_post_update_state(app.state.runtime):
+            await provision_litert_runtime(app.state.runtime)
         ensure_models_state(app.state.runtime)
         prime_system_metrics_counters()
         app.state.system_metrics_snapshot = collect_system_metrics_snapshot()

--- a/core/update_state.py
+++ b/core/update_state.py
@@ -10,6 +10,7 @@ import stat
 import subprocess
 import tarfile
 import time
+from ctypes.util import find_library
 from pathlib import Path
 from typing import Any, Callable
 
@@ -265,6 +266,7 @@ async def check_for_update(runtime: RuntimeConfig) -> dict[str, Any]:
 UPDATE_DOWNLOAD_TIMEOUT_SECONDS = 600
 UPDATE_STAGING_DIR_NAME = ".update_staging"
 UPDATE_APPLY_DIRS = ("core", "bin", "apps")
+LITERT_PIP_PACKAGE = "litert-lm-api"
 
 EXECUTION_ACTIVE_STATES = frozenset({"downloading", "staging", "applying", "restart_pending"})
 
@@ -505,6 +507,7 @@ async def apply_staged_update(runtime: RuntimeConfig, staged_dir: Path) -> None:
     try:
         await asyncio.to_thread(_apply)
         await install_requirements(runtime)
+        await provision_litert_runtime(runtime)
     except Exception:
         logger.warning("Apply failed, restoring backup", exc_info=True)
         try:
@@ -532,6 +535,105 @@ async def install_requirements(runtime: RuntimeConfig) -> None:
         raise RuntimeError(
             f"pip install failed (exit {proc.returncode}): {stderr.decode(errors='replace').strip()}"
         )
+
+
+async def _run_update_command(*args: str) -> tuple[int, str, str]:
+    import asyncio
+
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    return proc.returncode, stdout.decode(errors="replace"), stderr.decode(errors="replace")
+
+
+def _litert_runtime_json_path(runtime: RuntimeConfig) -> Path:
+    return runtime.base_dir / "runtimes" / "litert" / "runtime.json"
+
+
+def _has_litert_native_dependency() -> bool:
+    return bool(find_library("vulkan"))
+
+
+async def provision_litert_runtime(runtime: RuntimeConfig) -> dict[str, Any]:
+    """Best-effort provisioning for LiteRT on devices upgraded via OTA.
+
+    Full installs run install_dev.sh, but OTA applies only core/bin/apps plus
+    Python requirements. Keep this non-fatal so missing apt privileges or
+    unavailable wheels never roll back an otherwise valid update.
+    """
+    machine = os.uname().machine.lower() if hasattr(os, "uname") else ""
+    if machine not in {"aarch64", "arm64"}:
+        return {"provisioned": False, "reason": "unsupported_arch", "arch": machine}
+
+    venv_pip = runtime.base_dir / "venv" / "bin" / "pip"
+    if not venv_pip.exists():
+        return {"provisioned": False, "reason": "missing_pip"}
+
+    result: dict[str, Any] = {
+        "provisioned": False,
+        "reason": None,
+        "apt": "skipped",
+        "native_dependency": "missing",
+        "pip": "skipped",
+        "version": None,
+    }
+
+    # libvulkan1 is required by litert-lm-api's native library. OTA may not have
+    # permission to install apt packages, so treat this as a best-effort repair.
+    native_ready = _has_litert_native_dependency()
+    result["native_dependency"] = "present" if native_ready else "missing"
+    if not native_ready and shutil.which("sudo") and shutil.which("apt-get"):
+        code, _stdout, stderr = await _run_update_command(
+            "sudo", "-n", "apt-get", "install", "-y", "libvulkan1"
+        )
+        result["apt"] = "installed" if code == 0 else "failed"
+        if code != 0:
+            logger.warning("LiteRT apt dependency provisioning failed: %s", stderr.strip())
+        native_ready = code == 0 and _has_litert_native_dependency()
+        result["native_dependency"] = "present" if native_ready else "missing"
+
+    if not native_ready:
+        result["reason"] = "native_dependency_missing"
+        logger.warning("LiteRT runtime slot not provisioned because libvulkan is unavailable")
+        return result
+
+    code, _stdout, stderr = await _run_update_command(str(venv_pip), "install", LITERT_PIP_PACKAGE)
+    result["pip"] = "installed" if code == 0 else "failed"
+    if code != 0:
+        result["reason"] = "pip_install_failed"
+        logger.warning("LiteRT Python dependency provisioning failed: %s", stderr.strip())
+        return result
+
+    code, stdout, stderr = await _run_update_command(str(venv_pip), "show", LITERT_PIP_PACKAGE)
+    if code != 0:
+        result["reason"] = "package_not_found_after_install"
+        logger.warning("LiteRT package not found after install: %s", stderr.strip())
+        return result
+
+    version = ""
+    for line in stdout.splitlines():
+        if line.startswith("Version:"):
+            version = line.split(":", 1)[1].strip()
+            break
+    if not version:
+        result["reason"] = "missing_package_version"
+        return result
+
+    runtime_json = _litert_runtime_json_path(runtime)
+    runtime_json.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_json(
+        runtime_json,
+        {
+            "family": "litert",
+            "runtime_type": "litert_adapter",
+            "version": version,
+        },
+    )
+    result.update({"provisioned": True, "reason": "provisioned", "version": version})
+    return result
 
 
 async def signal_service_restart(runtime: RuntimeConfig) -> None:

--- a/tests/unit/test_app_lifecycle.py
+++ b/tests/unit/test_app_lifecycle.py
@@ -89,6 +89,14 @@ def test_app_lifespan_runs_startup_and_shutdown_hooks(
         startup_events.append("ensure_models_state")
         return {}
 
+    def _detect_post_update_state(_runtime: main.RuntimeConfig) -> bool:
+        startup_events.append("detect_post_update_state")
+        return False
+
+    async def _provision_litert_runtime(_runtime: main.RuntimeConfig) -> dict[str, Any]:
+        startup_events.append("provision_litert_runtime")
+        return {"provisioned": True}
+
     def _prime_system_metrics_counters() -> None:
         startup_events.append("prime_system_metrics_counters")
 
@@ -103,6 +111,8 @@ def test_app_lifespan_runs_startup_and_shutdown_hooks(
         return task
 
     monkeypatch.setattr(main, "ensure_models_state", _ensure_models_state)
+    monkeypatch.setattr(main, "detect_post_update_state", _detect_post_update_state)
+    monkeypatch.setattr(main, "provision_litert_runtime", _provision_litert_runtime)
     monkeypatch.setattr(main, "prime_system_metrics_counters", _prime_system_metrics_counters)
     monkeypatch.setattr(main, "collect_system_metrics_snapshot", _collect_system_metrics_snapshot)
     monkeypatch.setattr(main, "get_monotonic_time", lambda: 123.0)
@@ -117,6 +127,7 @@ def test_app_lifespan_runs_startup_and_shutdown_hooks(
         assert app.state.startup_monotonic == 123.0
         assert app.state.system_metrics_snapshot == {"cpu_percent": 12.5}
         assert startup_events == [
+            "detect_post_update_state",
             "ensure_models_state",
             "prime_system_metrics_counters",
             "collect_system_metrics_snapshot",
@@ -132,6 +143,40 @@ def test_app_lifespan_runs_startup_and_shutdown_hooks(
     assert download_task.awaited is True
     assert llama_process.terminated is True
     assert llama_process.waited is True
+
+
+def test_app_lifespan_runs_litert_provisioning_after_post_update(
+    runtime: main.RuntimeConfig,
+    monkeypatch,
+) -> None:
+    startup_events: list[str] = []
+    created_tasks: list[_FakeTask] = []
+
+    def _create_task(coro: Any, *, name: str | None = None) -> _FakeTask:
+        coro.close()
+        task = _FakeTask(name or "unnamed")
+        created_tasks.append(task)
+        return task
+
+    async def _provision_litert_runtime(_runtime: main.RuntimeConfig) -> dict[str, Any]:
+        startup_events.append("provision_litert_runtime")
+        return {"provisioned": True}
+
+    async def _ensure_compatible_runtime(_runtime: main.RuntimeConfig) -> tuple[bool, str]:
+        return False, "ok"
+
+    monkeypatch.setattr(main, "ensure_compatible_runtime", _ensure_compatible_runtime)
+    monkeypatch.setattr(main, "detect_post_update_state", lambda _runtime: True)
+    monkeypatch.setattr(main, "provision_litert_runtime", _provision_litert_runtime)
+    monkeypatch.setattr(main, "ensure_models_state", lambda _runtime: {})
+    monkeypatch.setattr(main, "prime_system_metrics_counters", lambda: None)
+    monkeypatch.setattr(main, "collect_system_metrics_snapshot", lambda: {})
+    monkeypatch.setattr(main.asyncio, "create_task", _create_task)
+
+    app = main.create_app(runtime=runtime, enable_orchestrator=False)
+
+    with TestClient(app):
+        assert startup_events == ["provision_litert_runtime"]
 
 
 def test_lifespan_shutdown_escalates_to_kill_on_timeout(monkeypatch) -> None:

--- a/tests/unit/test_update_state.py
+++ b/tests/unit/test_update_state.py
@@ -31,6 +31,7 @@ from core.update_state import (
     is_newer,
     is_update_safe,
     parse_version,
+    provision_litert_runtime,
     read_execution_state,
     read_update_state,
     signal_service_restart,
@@ -1046,6 +1047,25 @@ async def test_apply_staged_update_copies_requirements_txt(runtime):
 
 
 @pytest.mark.anyio
+async def test_apply_staged_update_runs_litert_provisioning(runtime, monkeypatch):
+    staged = staging_dir(runtime) / "extracted" / "potato-os-0.5.0"
+    (staged / "core").mkdir(parents=True)
+    (staged / "core" / "main.py").write_text("# new")
+    calls = 0
+
+    async def _mock_provision(_runtime):
+        nonlocal calls
+        calls += 1
+        return {"provisioned": True}
+
+    monkeypatch.setattr("core.update_state.provision_litert_runtime", _mock_provision)
+
+    await apply_staged_update(runtime, staged)
+
+    assert calls == 1
+
+
+@pytest.mark.anyio
 async def test_apply_staged_update_restores_on_pip_failure(runtime, monkeypatch):
     """If pip install fails after file copy, the old tree is restored."""
     # Set up old content
@@ -1104,6 +1124,117 @@ async def test_apply_staged_update_restores_on_copy_failure(runtime, monkeypatch
         await apply_staged_update(runtime, staged)
 
     assert (runtime.base_dir / "core" / "main.py").read_text() == "# old version"
+
+
+@pytest.mark.anyio
+async def test_provision_litert_runtime_creates_runtime_slot(runtime, monkeypatch):
+    (runtime.base_dir / "venv" / "bin").mkdir(parents=True)
+    (runtime.base_dir / "venv" / "bin" / "pip").write_text("#!/bin/sh\n")
+    calls: list[tuple[str, ...]] = []
+    native_checks = 0
+
+    class _Uname:
+        machine = "aarch64"
+
+    async def _mock_subprocess_exec(*args, **kwargs):
+        calls.append(tuple(str(a) for a in args))
+
+        class _MockProc:
+            returncode = 0
+
+            async def communicate(self):
+                if "show" in args:
+                    return b"Name: litert-lm-api\nVersion: 0.12.0\n", b""
+                return b"", b""
+
+        return _MockProc()
+
+    monkeypatch.setattr("core.update_state.os.uname", lambda: _Uname())
+    monkeypatch.setattr("core.update_state.shutil.which", lambda name: f"/usr/bin/{name}")
+
+    def _mock_native_dependency():
+        nonlocal native_checks
+        native_checks += 1
+        return native_checks > 1
+
+    monkeypatch.setattr("core.update_state._has_litert_native_dependency", _mock_native_dependency)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", _mock_subprocess_exec)
+
+    result = await provision_litert_runtime(runtime)
+
+    runtime_json = runtime.base_dir / "runtimes" / "litert" / "runtime.json"
+    assert result["provisioned"] is True
+    assert json.loads(runtime_json.read_text()) == {
+        "family": "litert",
+        "runtime_type": "litert_adapter",
+        "version": "0.12.0",
+    }
+    assert any(call[:5] == ("sudo", "-n", "apt-get", "install", "-y") for call in calls)
+    assert any(call[-2:] == ("install", "litert-lm-api") for call in calls)
+
+
+@pytest.mark.anyio
+async def test_provision_litert_runtime_skips_slot_when_native_dependency_missing(runtime, monkeypatch):
+    (runtime.base_dir / "venv" / "bin").mkdir(parents=True)
+    (runtime.base_dir / "venv" / "bin" / "pip").write_text("#!/bin/sh\n")
+    calls: list[tuple[str, ...]] = []
+
+    class _Uname:
+        machine = "aarch64"
+
+    async def _mock_subprocess_exec(*args, **kwargs):
+        calls.append(tuple(str(a) for a in args))
+
+        class _MockProc:
+            returncode = 1
+
+            async def communicate(self):
+                return b"", b"sudo password required"
+
+        return _MockProc()
+
+    monkeypatch.setattr("core.update_state.os.uname", lambda: _Uname())
+    monkeypatch.setattr("core.update_state.shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("core.update_state._has_litert_native_dependency", lambda: False)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", _mock_subprocess_exec)
+
+    result = await provision_litert_runtime(runtime)
+
+    assert result["provisioned"] is False
+    assert result["reason"] == "native_dependency_missing"
+    assert result["apt"] == "failed"
+    assert result["pip"] == "skipped"
+    assert not (runtime.base_dir / "runtimes" / "litert" / "runtime.json").exists()
+    assert any(call[:5] == ("sudo", "-n", "apt-get", "install", "-y") for call in calls)
+
+
+@pytest.mark.anyio
+async def test_provision_litert_runtime_is_nonfatal_when_pip_install_fails(runtime, monkeypatch):
+    (runtime.base_dir / "venv" / "bin").mkdir(parents=True)
+    (runtime.base_dir / "venv" / "bin" / "pip").write_text("#!/bin/sh\n")
+
+    class _Uname:
+        machine = "aarch64"
+
+    async def _mock_subprocess_exec(*args, **kwargs):
+        class _MockProc:
+            returncode = 1 if "install" in args else 0
+
+            async def communicate(self):
+                return b"", b"no matching distribution"
+
+        return _MockProc()
+
+    monkeypatch.setattr("core.update_state.os.uname", lambda: _Uname())
+    monkeypatch.setattr("core.update_state.shutil.which", lambda name: None)
+    monkeypatch.setattr("core.update_state._has_litert_native_dependency", lambda: True)
+    monkeypatch.setattr("asyncio.create_subprocess_exec", _mock_subprocess_exec)
+
+    result = await provision_litert_runtime(runtime)
+
+    assert result["provisioned"] is False
+    assert result["reason"] == "pip_install_failed"
+    assert not (runtime.base_dir / "runtimes" / "litert" / "runtime.json").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add best-effort LiteRT provisioning to the OTA apply path for devices upgraded from earlier images
- install litert-lm-api into the Potato venv when possible and create /opt/potato/runtimes/litert/runtime.json from the installed package version
- attempt libvulkan1 installation non-fatally because OTA may not have passwordless apt privileges

Closes #318

## Test evidence
- uv run python -m pytest tests/unit/test_update_state.py -q: 98 passed
- uv run python -m pytest tests/unit tests/api -q -n auto: 585 passed
- npx playwright test --reporter=dot --timeout=15000 --workers=75%: 118 passed

## QA / risk notes
- This is intentionally best-effort: missing apt privileges or unavailable LiteRT wheels are logged and do not roll back the OTA.
- Existing llama runtime slots are not modified.
- Real Pi OTA validation should verify that a 0.7.1-upgraded device receives the litert runtime slot after applying the hotfix.