### PR TITLE
chore(release): bump version to v0.7.2

### DIFF
--- a/core/__version__.py
+++ b/core/__version__.py
@@ -1,3 +1,3 @@
 """Canonical version for Potato OS — the single source of truth."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"


### PR DESCRIPTION
Version bump for v0.7.2 hotfix release.

Test evidence:
- uv run python -m pytest tests/unit tests/api -q -n auto: 587 passed
- npx playwright test --reporter=dot --timeout=15000 --workers=75%: 118 passed
- uv run python -m pytest tests/unit/test_version.py tests/unit/test_ota_release.py tests/api/test_status.py tests/api/test_update.py -q: 63 passed